### PR TITLE
✨(backend) enable cors headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Enable CORS Headers
 - Add routes API to get all products available for a course
   and get or set orders.
 - Implement first models to manage course products, orders,

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -144,6 +144,7 @@ class Base(Configuration):
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.locale.LocaleMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
+        "corsheaders.middleware.CorsMiddleware",
         "django.middleware.common.CommonMiddleware",
         "django.middleware.csrf.CsrfViewMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -164,6 +165,7 @@ class Base(Configuration):
         "django.contrib.messages",
         "django.contrib.staticfiles",
         # Third party apps
+        "corsheaders",
         "dockerflow.django",
         "rest_framework",
         "parler",
@@ -229,6 +231,11 @@ class Base(Configuration):
 
     AUTH_USER_MODEL = "core.User"
 
+    # CORS headers
+    CORS_ALLOWED_ORIGINS = values.ListValue(
+        [], environ_name="CORS_ALLOWED_ORIGINS", environ_prefix=None
+    )
+
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
@@ -275,8 +282,9 @@ class Development(Base):
     We set DEBUG to True and configure the server to respond from all hosts.
     """
 
-    DEBUG = True
     ALLOWED_HOSTS = ["*"]
+    CORS_ALLOW_ALL_ORIGINS = True
+    DEBUG = True
 
 
 class Test(Base):

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     arrow==1.0.3
     django==3.1.7
     django-configurations==2.2
+    django-cors-headers==3.7.0
     django-parler==2.2
     djangorestframework==3.12.4
     djangorestframework-simplejwt==4.6.0


### PR DESCRIPTION
## Purpose

Install `django-cors-headers` to allow CORS requests from authorized domains (via environment variable) on production and from everywhere on development


## Proposal

- [x] Install `django-cors-headers` and allow configuration from environment variable
