### PR TITLE
🔧(docker) run app service on port 8060

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,4 +91,4 @@ CMD python manage.py runserver 0.0.0.0:8000
 FROM core as production
 
 # The default command runs gunicorn WSGI server in joanie's main module
-CMD gunicorn -c /usr/local/etc/gunicorn/joanie.py wsgi:application
+CMD gunicorn -c /usr/local/etc/gunicorn/joanie.py joanie.wsgi:application

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Now that your Docker services are up, let's running them :
 $ make run
 ```
 
-You should be able to access to the API overview interface at [http://localhost:8060](http://localhost:8060).
+You should be able to access to the API overview interface at [http://localhost:8071](http://localhost:8071).
 
 Finally, you can see all available commands in our `Makefile` with :
 
@@ -51,7 +51,7 @@ $ make help
 
 ### Django admin
 
-You can access the Django admin site at [http://localhost:8060/admin](http://localhost:8060).
+You can access the Django admin site at [http://localhost:8071/admin](http://localhost:8071).
 
 You first need to create a superuser account :
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - env.d/development/common
       - env.d/development/postgresql
     ports:
-      - "8060:8000"
+      - "8071:8000"
     volumes:
       - ./src/backend:/app
       - ./data/static:/data/static
@@ -30,8 +30,10 @@ services:
     depends_on:
       - "postgresql"
     networks:
-      - default
-      - lms_outside
+      default:
+      lms_outside:
+        aliases:
+          - joanie
 
   dockerize:
     image: jwilder/dockerize


### PR DESCRIPTION
## Purpose

~Currently joanie `app` service runs on port `:8000` like richie `app` service.
Furthermore richie `nginx` and joanie `app` services are on the same network.
As richie `nginx` is a reverse proxy to `app:8000,` there is a conflict that may conduct to error if joanie starts before richie.~
➡️ Finally just changing the port does not fix the issue. I propose a solution from Richie (https://github.com/openfun/richie/pull/1351/files)

However I keep this PR opened, to update the port on which Joanie starts as it is currently the same as Marsha.

## Proposal

- [x] ~Run joanie `app` service on another port than 8000~
- [x] Use another port than `:8060` to start Joanie (`:8071`)