### PR TITLE
✨(lms_handler) add get_progression method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add `get_progression` to OpenEdX LMS Handler
 - Implement Address model for billing and add routes API to get, create,
   update and delete address.
 - Install security updates in project Docker images


### PR DESCRIPTION
## Purpose

In order to update Enrollment we need to get course_run state from LMS. From OpenEdX, the route `certificate/search` could help us to guess this information for a given user.


## Proposal

- [x] Add a method to OpenEdX LMS Handler to know if an enrollment has been passed, failed or is still in progress to a given user
