### PR TITLE
✨(api) enhance CourseSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to
 
 ### Changed
 
+- Update CourseSerializer to bind order and enrollment related to the user
 - Use a ViewSet to create address api
 - Rename the "name" field to "title" (avoid confusion with new "fullname" field)
 - Rename "main" field to "is_main" as our naming convention for boolean fields

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -44,8 +44,20 @@ class CourseViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 
     lookup_field = "code"
     permission_classes = [permissions.AllowAny]
-    queryset = models.Course.objects.all()
+    queryset = models.Course.objects.select_related("organization").all()
     serializer_class = serializers.CourseSerializer
+
+    def get_serializer_context(self):
+        """
+        Provide username to the authenticated user (if one is authenticated)
+        to the `CourseSerializer`
+        """
+        context = super().get_serializer_context()
+
+        if self.request.user.username:
+            context.update({"username": self.request.user.username})
+
+        return context
 
 
 # pylint: disable=too-many-ancestors

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -3,6 +3,7 @@ Declare and configure the models for the courses part
 """
 from django.db import models
 from django.utils.functional import lazy
+from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 
 from parler import models as parler_models
@@ -75,6 +76,14 @@ class Course(parler_models.TranslatableModel):
 
     def __str__(self):
         return self.safe_translation_getter("title", any_language=True)
+
+    def get_cache_key(self, language=None):
+        """
+        Return a course cache key related to its code and the current language
+        language can be forced by through the language argument.
+        """
+        current_language = language or get_language()
+        return f"course-{self.code}-{current_language}"
 
     def clean(self):
         """

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -13,11 +13,12 @@ class CertificationDefinitionSerializer(serializers.ModelSerializer):
     Serialize information about a certificate definition
     """
 
-    description = serializers.CharField(allow_blank=True, allow_null=True)
+    description = serializers.CharField(read_only=True)
 
     class Meta:
         model = models.CertificateDefinition
         fields = ["description", "name", "title"]
+        read_only_fields = ["description", "name", "title"]
 
 
 class OrganizationSerializer(serializers.ModelSerializer):
@@ -28,6 +29,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Organization
         fields = ["code", "title"]
+        read_only_fields = ["code", "title"]
 
 
 class TargetCourseSerializer(serializers.ModelSerializer):
@@ -42,6 +44,13 @@ class TargetCourseSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Course
         fields = [
+            "code",
+            "course_runs",
+            "organization",
+            "position",
+            "title",
+        ]
+        read_only_fields = [
             "code",
             "course_runs",
             "organization",
@@ -80,22 +89,33 @@ class ProductSerializer(serializers.ModelSerializer):
         - order if user is authenticated
     """
 
-    id = serializers.CharField(source="uid", read_only=True)
+    id = serializers.CharField(read_only=True, source="uid")
     certificate = CertificationDefinitionSerializer(
         read_only=True, source="certificate_definition"
     )
-    currency = serializers.SerializerMethodField()
+    currency = serializers.SerializerMethodField(read_only=True)
     price = serializers.DecimalField(
-        max_digits=9,
-        decimal_places=2,
         coerce_to_string=False,
+        decimal_places=2,
+        max_digits=9,
         min_value=0,
+        read_only=True,
     )
-    target_courses = serializers.SerializerMethodField()
+    target_courses = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = models.Product
         fields = [
+            "call_to_action",
+            "certificate",
+            "currency",
+            "id",
+            "price",
+            "target_courses",
+            "title",
+            "type",
+        ]
+        read_only_fields = [
             "call_to_action",
             "certificate",
             "currency",
@@ -137,16 +157,33 @@ class CourseRunEnrollmentSerializer(serializers.ModelSerializer):
     """
 
     id = serializers.CharField(source="uid", read_only=True, required=False)
-    resource_link = serializers.CharField(source="course_run.resource_link")
-    title = serializers.CharField(source="course_run.title")
-    start = serializers.DateTimeField(source="course_run.start")
-    end = serializers.DateTimeField(source="course_run.end")
-    enrollment_start = serializers.DateTimeField(source="course_run.enrollment_start")
-    enrollment_end = serializers.DateTimeField(source="course_run.enrollment_end")
+    resource_link = serializers.CharField(
+        read_only=True, source="course_run.resource_link"
+    )
+    title = serializers.CharField(read_only=True, source="course_run.title")
+    start = serializers.DateTimeField(read_only=True, source="course_run.start")
+    end = serializers.DateTimeField(read_only=True, source="course_run.end")
+    enrollment_start = serializers.DateTimeField(
+        read_only=True, source="course_run.enrollment_start"
+    )
+    enrollment_end = serializers.DateTimeField(
+        read_only=True, source="course_run.enrollment_end"
+    )
 
     class Meta:
         model = models.Enrollment
         fields = [
+            "id",
+            "is_active",
+            "resource_link",
+            "title",
+            "start",
+            "end",
+            "enrollment_start",
+            "enrollment_end",
+            "state",
+        ]
+        read_only_fields = [
             "id",
             "is_active",
             "resource_link",
@@ -164,11 +201,11 @@ class OrderLiteSerializer(serializers.ModelSerializer):
     Minimal Order model serializer
     """
 
-    id = serializers.CharField(source="uid", read_only=True)
+    id = serializers.CharField(read_only=True, source="uid")
     price = serializers.DecimalField(
-        max_digits=9,
-        decimal_places=2,
         coerce_to_string=False,
+        decimal_places=2,
+        max_digits=9,
         min_value=0,
         read_only=True,
     )
@@ -179,7 +216,22 @@ class OrderLiteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Order
-        fields = ["id", "created_on", "price", "enrollments", "product", "state"]
+        fields = [
+            "id",
+            "created_on",
+            "price",
+            "enrollments",
+            "product",
+            "state",
+        ]
+        read_only_fields = [
+            "id",
+            "created_on",
+            "price",
+            "enrollments",
+            "product",
+            "state",
+        ]
 
 
 class CourseSerializer(serializers.ModelSerializer):
@@ -188,11 +240,17 @@ class CourseSerializer(serializers.ModelSerializer):
     """
 
     organization = OrganizationSerializer(read_only=True)
-    products = ProductSerializer(read_only=True, many=True)
+    products = ProductSerializer(many=True, read_only=True)
 
     class Meta:
         model = models.Course
         fields = [
+            "code",
+            "organization",
+            "title",
+            "products",
+        ]
+        read_only_fields = [
             "code",
             "organization",
             "title",
@@ -262,6 +320,15 @@ class CourseRunSerializer(serializers.ModelSerializer):
             "start",
             "title",
         ]
+        read_only_fields = [
+            "end",
+            "enrollment_end",
+            "enrollment_start",
+            "id",
+            "resource_link",
+            "start",
+            "title",
+        ]
 
 
 class EnrollmentSerializer(serializers.ModelSerializer):
@@ -270,7 +337,7 @@ class EnrollmentSerializer(serializers.ModelSerializer):
     """
 
     id = serializers.CharField(source="uid", read_only=True, required=False)
-    user = serializers.CharField(source="user.username", required=False)
+    user = serializers.CharField(source="user.username", read_only=True, required=False)
     course_run = serializers.SlugRelatedField(
         queryset=models.CourseRun.objects.all(), slug_field="resource_link"
     )
@@ -281,7 +348,7 @@ class EnrollmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Enrollment
         fields = ["id", "user", "course_run", "order", "is_active", "state"]
-        read_only_fields = ["state"]
+        read_only_fields = ["id", "user", "state"]
 
     def update(self, instance, validated_data):
         """
@@ -306,12 +373,12 @@ class OrderSerializer(serializers.ModelSerializer):
         queryset=models.Course.objects.all(), slug_field="code"
     )
     price = serializers.DecimalField(
-        max_digits=9,
-        decimal_places=2,
         coerce_to_string=False,
+        decimal_places=2,
+        max_digits=9,
         min_value=0,
-        required=False,
         read_only=True,
+        required=False,
     )
     product = serializers.SlugRelatedField(
         queryset=models.Product.objects.all(), slug_field="uid"
@@ -336,7 +403,12 @@ class OrderSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "created_on",
+            "enrollments",
+            "id",
+            "owner",
+            "price",
             "state",
+            "target_courses",
         ]
 
     @staticmethod
@@ -360,7 +432,7 @@ class AddressSerializer(serializers.ModelSerializer):
     Address model serializer
     """
 
-    id = serializers.CharField(source="uid", required=False)
+    id = serializers.CharField(source="uid", read_only=True, required=False)
 
     class Meta:
         model = models.Address
@@ -373,4 +445,7 @@ class AddressSerializer(serializers.ModelSerializer):
             "is_main",
             "postcode",
             "title",
+        ]
+        read_only_fields = [
+            "id",
         ]

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -197,6 +197,8 @@ class Base(Configuration):
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     }
 
+    JOANIE_ANONYMOUS_COURSE_SERIALIZER_CACHE_TTL = 3600  # 1 hour
+
     LANGUAGES = (
         ("en-us", _("English")),
         ("fr-fr", _("French")),

--- a/src/backend/joanie/tests/test_api_course.py
+++ b/src/backend/joanie/tests/test_api_course.py
@@ -1,7 +1,11 @@
 """Tests for the Course API."""
 import json
+import random
 
-from joanie.core import factories, models
+from django.conf import settings
+from django.test import override_settings
+
+from joanie.core import enums, factories, models
 
 from .base import BaseAPITestCase
 
@@ -39,47 +43,384 @@ class CourseApiTest(BaseAPITestCase):
             status_code=404,
         )
 
-    def test_api_course_read_detail_anonymous(self):
-        """Anonymous users should be allowed to retrieve a course."""
-        products = factories.ProductFactory.create_batch(2)
-        course = factories.CourseFactory(products=products)
-
-        response = self.client.get("/api/courses/{!s}/".format(course.code))
-        self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-
-        self.assertEqual(
-            content,
+    @override_settings(
+        JOANIE_LMS_BACKENDS=[
             {
-                "code": course.code,
-                "organization": course.organization.code,
-                "title": course.title,
-                "products": [str(p.uid) for p in products],
+                "BACKEND": "joanie.lms_handler.backends.dummy.DummyLMSBackend",
+                "BASE_URL": "http://lms.test",
+                "COURSE_REGEX": r"(?P<course_id>.*)",
+                "SELECTOR_REGEX": r".*",
+            }
+        ]
+    )
+    def test_api_course_read_detail_anonymous(self):
+        """
+        Anonymous users should be allowed to retrieve a course
+        with a minimal db access
+        """
+        target_course_runs = factories.CourseRunFactory.create_batch(2)
+        product = factories.ProductFactory.create(
+            target_courses=[course_run.course for course_run in target_course_runs],
+        )
+        course = factories.CourseFactory(products=[product])
+
+        # - Create a set of random users which possibly purchase the product
+        # then enroll to one of its course run.
+        for _ in range(random.randrange(1, 5)):
+            user = factories.UserFactory()
+            should_purchase = random.choice([True, False])
+            should_enroll = random.choice([True, False])
+
+            if should_purchase:
+                order = factories.OrderFactory(
+                    owner=user,
+                    course=course,
+                    product=product,
+                    state=enums.ORDER_STATE_PAID,
+                )
+
+                if should_enroll:
+                    course_run = random.choice(target_course_runs)
+                    factories.EnrollmentFactory(
+                        user=user, course_run=course_run, order=order, is_active=True
+                    )
+
+        with self.assertNumQueries(11):
+            response = self.client.get("/api/courses/{!s}/".format(course.code))
+
+        content = json.loads(response.content)
+        expected = {
+            "code": course.code,
+            "organization": {
+                "code": course.organization.code,
+                "title": course.organization.title,
             },
+            "title": course.title,
+            "orders": None,
+            "products": [
+                {
+                    "call_to_action": product.call_to_action,
+                    "certificate": None,
+                    "currency": {
+                        "code": settings.JOANIE_CURRENCY[0],
+                        "symbol": settings.JOANIE_CURRENCY[1],
+                    },
+                    "id": str(product.uid),
+                    "price": float(product.price),
+                    "target_courses": [
+                        {
+                            "code": target_course.code,
+                            "organization": {
+                                "code": target_course.organization.code,
+                                "title": target_course.organization.title,
+                            },
+                            "course_runs": [
+                                {
+                                    "id": course_run.id,
+                                    "title": course_run.title,
+                                    "resource_link": course_run.resource_link,
+                                    "start": course_run.start.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "end": course_run.end.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                        "+00:00", "Z"
+                                    ),
+                                }
+                                for course_run in target_course.course_runs.all().order_by(
+                                    "start"
+                                )
+                            ],
+                            "position": target_course.product_relations.get(
+                                product=product
+                            ).position,
+                            "title": target_course.title,
+                        }
+                        for target_course in product.target_courses.all().order_by(
+                            "product_relations__position"
+                        )
+                    ],
+                    "title": product.title,
+                    "type": product.type,
+                }
+                for product in course.products.all()
+            ],
+        }
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, expected)
+
+        # - An other request should get the cached response
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                "/api/courses/{!s}/".format(course.code),
+            )
+
+        # - But cache should rely on the current language
+        with self.assertNumQueries(20):
+            response = self.client.get(
+                "/api/courses/{!s}/".format(course.code),
+                HTTP_ACCEPT_LANGUAGE="fr-fr",
+            )
+
+    @override_settings(
+        JOANIE_LMS_BACKENDS=[
+            {
+                "BACKEND": "joanie.lms_handler.backends.dummy.DummyLMSBackend",
+                "BASE_URL": "http://lms.test",
+                "COURSE_REGEX": r"(?P<course_id>.*)",
+                "SELECTOR_REGEX": r".*",
+            }
+        ]
+    )
+    # pylint: disable=too-many-locals
+    def test_api_course_read_detail_authenticated(self):
+        """
+        Authenticated users should be allowed to retrieve a course
+        with its related order and enrollment bound.
+        """
+        target_course_run11 = factories.CourseRunFactory(
+            resource_link="http://lms.test/courses/course-v1:edx+000011+Demo_Course/course"
+        )
+        target_course_run12 = factories.CourseRunFactory(
+            resource_link="http://lms.test/courses/course-v1:edx+000012+Demo_Course/course"
+        )
+        target_course_run21 = factories.CourseRunFactory(
+            resource_link="http://lms.test/courses/course-v1:edx+000021+Demo_Course/course"
+        )
+        target_course_run22 = factories.CourseRunFactory(
+            resource_link="http://lms.test/courses/course-v1:edx+000022+Demo_Course/course"
         )
 
-    def test_api_course_read_detail_authenticated(self):
-        """Authenticated users should be allowed to retrieve a course."""
-        products = factories.ProductFactory.create_batch(2)
-        course = factories.CourseFactory(products=products)
-        token = self.get_user_token("panoramix")
+        product1 = factories.ProductFactory(
+            target_courses=[target_course_run11.course, target_course_run12.course]
+        )
+        product2 = factories.ProductFactory(
+            target_courses=[target_course_run21.course, target_course_run22.course]
+        )
+        course = factories.CourseFactory(products=[product1, product2])
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        # User has purchased each product and he is enrolled to the related course run
+        # - Product 1
+        order1 = factories.OrderFactory(
+            owner=user, product=product1, state=enums.ORDER_STATE_PAID, course=course
+        )
+        # - Enrollment to course run 11
+        factories.EnrollmentFactory(
+            user=user, course_run=target_course_run11, order=order1, is_active=True
+        )
+        # - Enrollment to course run 12
+        factories.EnrollmentFactory(
+            user=user, course_run=target_course_run12, order=order1, is_active=True
+        )
+        # - Product 2
+        order2 = factories.OrderFactory(
+            owner=user, product=product2, state=enums.ORDER_STATE_PAID, course=course
+        )
+        # - Enrollment to course run 21
+        factories.EnrollmentFactory(
+            user=user, course_run=target_course_run21, order=order2, is_active=True
+        )
+        # - Enrollment to course run 22
+        factories.EnrollmentFactory(
+            user=user, course_run=target_course_run22, order=order2, is_active=True
+        )
+
+        # - Create a set of random users which possibly purchase one of the products
+        # then enroll to one of its course run.
+        for _ in range(random.randrange(1, 5)):
+            user = factories.UserFactory()
+            should_purchase = random.choice([True, False])
+            should_enroll = random.choice([True, False])
+
+            if should_purchase:
+                product = random.choice(course.products.all())
+                order = factories.OrderFactory(
+                    owner=user,
+                    course=course,
+                    product=product,
+                    state=enums.ORDER_STATE_PAID,
+                )
+
+                if should_enroll:
+                    course_run = random.choice(
+                        models.CourseRun.objects.filter(
+                            course__product_relations__product=product
+                        )
+                    )
+                    factories.EnrollmentFactory(
+                        user=user, course_run=course_run, order=order, is_active=True
+                    )
+
+        with self.assertNumQueries(23):
+            response = self.client.get(
+                "/api/courses/{!s}/".format(course.code),
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        content = json.loads(response.content)
+        expected = {
+            "code": course.code,
+            "organization": {
+                "code": course.organization.code,
+                "title": course.organization.title,
+            },
+            "title": course.title,
+            "orders": [
+                {
+                    "id": str(order.uid),
+                    "created_on": order.created_on.isoformat().replace("+00:00", "Z"),
+                    "price": float(order.price),
+                    "state": order.state,
+                    "product": str(order.product.uid),
+                    "enrollments": [
+                        {
+                            "id": str(enrollment.uid),
+                            "is_active": enrollment.is_active,
+                            "state": enrollment.state,
+                            "title": enrollment.course_run.title,
+                            "resource_link": enrollment.course_run.resource_link,
+                            "start": enrollment.course_run.start.isoformat().replace(
+                                "+00:00", "Z"
+                            ),
+                            "end": enrollment.course_run.end.isoformat().replace(
+                                "+00:00", "Z"
+                            ),
+                            "enrollment_start": enrollment.course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "+00:00", "Z"
+                            ),
+                            "enrollment_end": enrollment.course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "+00:00", "Z"
+                            ),
+                        }
+                        for enrollment in order.enrollments.all()
+                    ],
+                }
+                for order in [order1, order2]
+            ],
+            "products": [
+                {
+                    "call_to_action": product.call_to_action,
+                    "certificate": None,
+                    "currency": {
+                        "code": settings.JOANIE_CURRENCY[0],
+                        "symbol": settings.JOANIE_CURRENCY[1],
+                    },
+                    "id": str(product.uid),
+                    "price": float(product.price),
+                    "target_courses": [
+                        {
+                            "code": target_course.code,
+                            "organization": {
+                                "code": target_course.organization.code,
+                                "title": target_course.organization.title,
+                            },
+                            "course_runs": [
+                                {
+                                    "id": course_run.id,
+                                    "title": course_run.title,
+                                    "resource_link": course_run.resource_link,
+                                    "start": course_run.start.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "end": course_run.end.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                        "+00:00", "Z"
+                                    ),
+                                }
+                                for course_run in target_course.course_runs.all().order_by(
+                                    "start"
+                                )
+                            ],
+                            "position": target_course.product_relations.get(
+                                product=product
+                            ).position,
+                            "title": target_course.title,
+                        }
+                        for target_course in product.target_courses.all().order_by(
+                            "product_relations__position"
+                        )
+                    ],
+                    "title": product.title,
+                    "type": product.type,
+                }
+                for product in course.products.all()
+            ],
+        }
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content, expected)
+
+        # - When user is authenticated, response should be partially cached.
+        # Course information should has been cached, but orders not.
+        with self.assertNumQueries(4):
+            response = self.client.get(
+                "/api/courses/{!s}/".format(course.code),
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+    @override_settings(
+        JOANIE_LMS_BACKENDS=[
+            {
+                "BACKEND": "joanie.lms_handler.backends.dummy.DummyLMSBackend",
+                "BASE_URL": "http://lms.test",
+                "COURSE_REGEX": r"(?P<course_id>.*)",
+                "SELECTOR_REGEX": r".*",
+            }
+        ]
+    )
+    # pylint: disable=too-many-locals
+    def test_api_course_read_detail_enrollments(self):
+        """
+        When authenticated user purchased a course's product and then he enrolls
+        to a course run, enrollment information should be embedded
+        in the response
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+        course, tc1, tc2 = factories.CourseFactory.create_batch(3)
+        cr1 = factories.CourseRunFactory.create_batch(5, course=tc1)[1]
+
+        product = factories.ProductFactory(courses=[course], target_courses=[tc1, tc2])
+
+        # - User purchases the product
+        order = factories.OrderFactory(
+            owner=user, product=product, state=enums.ORDER_STATE_PAID
+        )
+        # - Then enrolls to a course run
+        factories.EnrollmentFactory(
+            course_run=cr1,
+            user=user,
+            order=order,
+            is_active=True,
+            state=enums.ENROLLMENT_STATE_SET,
+        )
 
         response = self.client.get(
             "/api/courses/{!s}/".format(course.code),
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
 
         content = json.loads(response.content)
-        self.assertEqual(
-            content,
-            {
-                "code": course.code,
-                "organization": course.organization.code,
-                "title": course.title,
-                "products": [str(p.uid) for p in products],
-            },
-        )
+        enrollments = content["orders"][0]["enrollments"]
+
+        self.assertEqual(len(enrollments), 1)
+
+        self.assertEqual(enrollments[0]["resource_link"], cr1.resource_link)
+        self.assertEqual(enrollments[0]["state"], enums.ENROLLMENT_STATE_SET)
+        self.assertTrue(enrollments[0]["is_active"])
 
     def test_api_course_create_anonymous(self):
         """Anonymous users should not be able to create a course."""

--- a/src/backend/joanie/tests/test_api_order.py
+++ b/src/backend/joanie/tests/test_api_order.py
@@ -58,7 +58,7 @@ class OrderApiTest(BaseAPITestCase):
                         "enrollments": [],
                         "id": str(order.uid),
                         "owner": order.owner.username,
-                        "price": str(product.price),
+                        "price": float(product.price),
                         "product": str(order.product.uid),
                         "state": order.state,
                         "target_courses": [],
@@ -92,7 +92,7 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollments": [],
                         "owner": other_order.owner.username,
-                        "price": str(other_order.price),
+                        "price": float(other_order.price),
                         "product": str(other_order.product.uid),
                         "state": other_order.state,
                         "target_courses": [],
@@ -138,7 +138,7 @@ class OrderApiTest(BaseAPITestCase):
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "state": order.state,
                 "owner": owner.username,
-                "price": str(product.price),
+                "price": float(product.price),
                 "product": str(product.uid),
                 "enrollments": [],
                 "target_courses": [
@@ -216,7 +216,7 @@ class OrderApiTest(BaseAPITestCase):
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "state": "pending",
                 "owner": "panoramix",
-                "price": str(product.price),
+                "price": float(product.price),
                 "product": str(product.uid),
                 "enrollments": [],
                 "target_courses": [
@@ -337,10 +337,10 @@ class OrderApiTest(BaseAPITestCase):
         self.assertEqual(
             list(data.keys()),
             [
-                "id",
                 "course",
                 "created_on",
                 "enrollments",
+                "id",
                 "owner",
                 "price",
                 "product",

--- a/src/backend/joanie/tests/test_models_course.py
+++ b/src/backend/joanie/tests/test_models_course.py
@@ -3,6 +3,7 @@ Test suite for order models
 """
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import translation
 
 from joanie.core import factories, models
 
@@ -32,3 +33,18 @@ class CourseRunModelsTestCase(TestCase):
         self.assertEqual(
             models.Course.objects.filter(code="THE-UNIQUE-CODE").count(), 1
         )
+
+    def test_models_course_get_cache_key(self):
+        """
+        The `get_cache_key` method should return a key related to the
+        code and the active language
+        """
+        course = factories.CourseFactory(code="00001")
+        self.assertEqual(course.get_cache_key(), "course-00001-en-us")
+
+        # - Switch to french
+        with translation.override("fr-fr"):
+            self.assertEqual(course.get_cache_key(), "course-00001-fr-fr")
+
+        # - Force language
+        self.assertEqual(course.get_cache_key("de-de"), "course-00001-de-de")


### PR DESCRIPTION
## Purpose

To avoid several requests to get the full course context and avoid extra works from the frontend, CourseSerializer is now able to retrieve authenticated user's orders and enrollments. In this way, by retrieving course details, frontend is aware of which products are already owned by the authenticated user and on which course runs the user is enrolled.

## Proposal
- [x] Retrieve products related to the course
- [x] Pass `user` to the `CourseSerializer` through context if he/she is authenticated
- [x] Inside CourseSerializer, bind user's orders and enrollments related to product and course runs. 
- [x] Add and update tests
