### PR TITLE
♻️(api) use viewset for the address api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to
 
 ### Changed
 
+- Use a ViewSet to create address api
 - Rename the "name" field to "title" (avoid confusion with new "fullname" field)
 - Rename "main" field to "is_main" as our naming convention for boolean fields
 - Pin base Docker image to `python8-slim-bullseye`

--- a/src/backend/joanie/tests/test_api_address.py
+++ b/src/backend/joanie/tests/test_api_address.py
@@ -251,14 +251,14 @@ class AddressAPITestCase(BaseAPITestCase):
         new_address = factories.AddressFactory.build()
         payload = get_payload(new_address)
 
-        # check bad request returned if address_id is missing
+        # Put request without address uid should not be allowed
         response = self.client.put(
             "/api/addresses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=payload,
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 405)
 
         bad_payload = payload.copy()
         bad_payload["country"] = "FRANCE"
@@ -272,9 +272,7 @@ class AddressAPITestCase(BaseAPITestCase):
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            content, {"errors": {"country": ['"FRANCE" is not a valid choice.']}}
-        )
+        self.assertEqual(content, {"country": ['"FRANCE" is not a valid choice.']})
 
         del bad_payload["title"]
         bad_payload["country"] = "FR"
@@ -287,7 +285,7 @@ class AddressAPITestCase(BaseAPITestCase):
         content = json.loads(response.content)
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(content, {"errors": {"title": ["This field is required."]}})
+        self.assertEqual(content, {"title": ["This field is required."]})
 
     def test_api_address_update_with_bad_user(self):
         """User token has to match with owner of address to update"""
@@ -303,7 +301,7 @@ class AddressAPITestCase(BaseAPITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
 
     def test_api_address_update_to_demote_address(self):
         """
@@ -412,7 +410,7 @@ class AddressAPITestCase(BaseAPITestCase):
             f"/api/addresses/{address.uid}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
 
     def test_api_address_delete(self):
         """Delete address is allowed with valid token"""

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -24,6 +24,7 @@ from joanie.core import api
 from joanie.lms_handler.urls import urlpatterns as lms_urlpatterns
 
 router = DefaultRouter()
+router.register("addresses", api.AddressViewSet, basename="addresses")
 router.register("courses", api.CourseViewSet, basename="courses")
 router.register("enrollments", api.EnrollmentViewSet, basename="enrollments")
 router.register("orders", api.OrderViewSet, basename="orders")
@@ -31,8 +32,6 @@ router.register("orders", api.OrderViewSet, basename="orders")
 urlpatterns = (
     [
         path("admin/", admin.site.urls),
-        path("api/addresses/", api.AddressView.as_view()),
-        path("api/addresses/<str:address_uid>/", api.AddressView.as_view()),
         path("api/", include([*router.urls, *lms_urlpatterns])),
         path("api/documents/", include("marion.urls")),
     ]


### PR DESCRIPTION
## Purpose

Code related to the address api can be simplified by the use of a viewset.
Furthermore, it allows us to homogenize api route and responses.


## Proposal

- [x] Use a ViewSet for the address api
