### PR TITLE
For production environment, serve static files with Whitenoise and host media files in Swift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,15 @@ ENV/
 env.bak/
 venv.bak/
 env.d/development/crowdin
+env.d/terraform
 
 # Logs
 *.log
+
+# Terraform
+.terraform
+*.tfstate
+*.tfstate.backup
 
 # Test & lint
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Serve static files with `whitenoise` third party app
 - Add collected static files to the production Docker image
 - Install django-money to manage currencies
 - Improve course and product admin change views

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add collected static files to the production Docker image
 - Install django-money to manage currencies
 - Improve course and product admin change views
 - Add ngrok to serve Joanie on a public address for development purpose

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ DOCKER_GID           = $(shell id -g)
 DOCKER_USER          = $(DOCKER_UID):$(DOCKER_GID)
 COMPOSE              = DOCKER_USER=$(DOCKER_USER) docker-compose
 COMPOSE_RUN          = $(COMPOSE) run --rm
-COMPOSE_RUN_APP      = $(COMPOSE_RUN) app
+COMPOSE_RUN_APP      = $(COMPOSE_RUN) app-dev
 COMPOSE_RUN_CROWDIN  = $(COMPOSE_RUN) crowdin crowdin
 COMPOSE_TEST_RUN     = $(COMPOSE_RUN)
-COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app
+COMPOSE_TEST_RUN_APP = $(COMPOSE_TEST_RUN) app-dev
 MANAGE               = $(COMPOSE_RUN_APP) python manage.py
 WAIT_DB              = @$(COMPOSE_RUN) dockerize -wait tcp://$(DB_HOST):$(DB_PORT) -timeout 60s
 
@@ -68,20 +68,21 @@ bootstrap: \
 .PHONY: bootstrap
 
 # -- Docker/compose
-build: ## build the app container
-	@$(COMPOSE) build app
+build: ## build the app-dev container
+	@$(COMPOSE) build app-dev
 .PHONY: build
 
 down: ## stop and remove containers, networks, images, and volumes
 	@$(COMPOSE) down
 .PHONY: down
 
-logs: ## display app logs (follow mode)
-	@$(COMPOSE) logs -f app
+logs: ## display app-dev logs (follow mode)
+	@$(COMPOSE) logs -f app-dev
 .PHONY: logs
 
-run: ## start the development server using Docker
-	@$(COMPOSE) up -d
+run: ## start the wsgi (production) and development server
+	@$(COMPOSE) up -d nginx
+	@$(COMPOSE) up -d app-dev
 	@echo "Wait for postgresql to be up..."
 	@$(WAIT_DB)
 .PHONY: run

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ bootstrap: ## Prepare Docker images for the project
 bootstrap: \
 	data/media \
 	data/static \
-  env.d/development/crowdin \
+	env.d/development/crowdin \
 	build \
 	run \
 	migrate \

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Finally, you can see all available commands in our `Makefile` with :
 $ make help
 ```
 
+If you're preparing for production, it is recommended to host media files in an object storage.
+We've cooked [Terraform scripts](https://www.terraform.io/) and a [documentation](docs/media.md)
+to make it easy if, like us, you are planning to use [Swift](https://docs.openstack.org/swift). Read more about it: docs/media.md.
+
+If you're planning to use AWS S3 or another object storage service, please let us know by opening
+an [issue](https://github.com/openfun/joanie/issues) or even better a
+[pull request](https://github.com/openfun/joanie/pulls) to add it to the project.
+
 ### Django admin
 
 You can access the Django admin site at [http://localhost:8071/admin](http://localhost:8071).

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -4,9 +4,11 @@ set -eo pipefail
 
 REPO_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
 UNSET_USER=0
+
+TERRAFORM_DIRECTORY="./env.d/terraform"
+COMPOSE_FILE="${REPO_DIR}/docker-compose.yml"
 COMPOSE_PROJECT="joanie"
 
-COMPOSE_FILE="${REPO_DIR}/docker-compose.yml"
 
 # _set_user: set (or unset) default user id used to run docker commands
 #
@@ -89,4 +91,67 @@ function _dc_exec() {
 # ARGS : django's manage.py command arguments
 function _django_manage() {
     _dc_run -w /app/src/backend/joanie "joanie" python manage.py "$@"
+}
+
+# _set_openstack_project: select an OpenStack project from the openrc files defined in the
+# terraform directory.
+#
+# usage: _set_openstack_project
+#
+# If necessary the script will prompt the user to choose a project from those available
+function _set_openstack_project() {
+
+    declare prompt
+    declare -a projects
+    declare -i default=1
+    declare -i choice=0
+    declare -i n_projects
+
+    # List projects by looking in the "./env.d/terraform" directory
+    # and store them in an array
+    read -r -a projects <<< "$(
+        find "${TERRAFORM_DIRECTORY}" -maxdepth 1 -mindepth 1 -type d |
+        sed 's|'"${TERRAFORM_DIRECTORY}\/"'||' |
+        xargs
+    )"
+    nb_projects=${#projects[@]}
+
+    if [[ ${nb_projects} -le 0 ]]; then
+        echo "There are no OpenStack projects defined..." >&2
+        echo "To add one, create a subdirectory in \"${TERRAFORM_DIRECTORY}\" with the name" \
+            "of your project and copy your \"openrc.sh\" file into it." >&2
+        exit 10
+    fi
+
+    if [[ ${nb_projects} -gt 1 ]]; then
+        prompt="Select an OpenStack project to target:\\n"
+        for (( i=0; i<nb_projects; i++ )); do
+            prompt+="[$((i+1))] ${projects[$i]}"
+            if [[ $((i+1)) -eq ${default} ]]; then
+                prompt+=" (default)"
+            fi
+            prompt+="\\n"
+        done
+        prompt+="If your OpenStack project is not listed, add it to the \"env.d/terraform\" directory.\\n"
+        prompt+="Your choice: "
+        read -r -p "$(echo -e "${prompt}")" choice
+
+        if [[ ${choice} -gt nb_projects ]]; then
+            (>&2 echo "Invalid choice ${choice} (should be <= ${nb_projects})")
+            exit 11
+        fi
+
+        if [[ ${choice} -le 0 ]]; then
+            choice=${default}
+        fi
+    fi
+
+    project=${projects[$((choice-1))]}
+    # Check that the openrc.sh file exists for this project
+    if [ ! -f "${TERRAFORM_DIRECTORY}/${project}/openrc.sh" ]; then
+        (>&2 echo "Missing \"openrc.sh\" file in \"${TERRAFORM_DIRECTORY}/${project}\". Check documentation.")
+        exit 12
+    fi
+
+    echo "${project}"
 }

--- a/bin/joanie
+++ b/bin/joanie
@@ -5,4 +5,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
 _docker_compose up -d postgresql
 _dc_run dockerize dockerize -wait tcp://postgresql:5432 -timeout 60s
-_dc_run --service-ports app
+_dc_run --service-ports app-dev

--- a/bin/pylint
+++ b/bin/pylint
@@ -6,4 +6,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 # Fix docker vs local path when project sources are mounted as a volume
 params=$(echo $@ | sed "s|src/backend/||g")
 
-_dc_run app pylint "${params}"
+_dc_run app-dev pylint "${params}"

--- a/bin/pytest
+++ b/bin/pytest
@@ -4,5 +4,5 @@ source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
 _dc_run \
     -e DJANGO_CONFIGURATION=Test \
-    app \
+    app-dev \
     pytest "$@"

--- a/bin/state
+++ b/bin/state
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+project=$(_set_openstack_project)
+echo "Using \"${project}\" project..."
+
+source "${TERRAFORM_DIRECTORY}/${project}/openrc.sh"
+
+# Run Terraform commands in the Hashicorp docker container via docker compose
+# shellcheck disable=SC2068
+DOCKER_USER="$(id -u):$(id -g)" \
+    PROJECT="${project}" \
+    docker-compose run --rm \
+    -e OS_AUTH_URL \
+    -e OS_IDENTITY_API_VERSION \
+    -e OS_USER_DOMAIN_NAME \
+    -e OS_PROJECT_DOMAIN_NAME \
+    -e OS_TENANT_ID \
+    -e OS_TENANT_NAME \
+    -e OS_USERNAME \
+    -e OS_PASSWORD \
+    -e OS_REGION_NAME \
+    terraform-state "$@"

--- a/bin/terraform
+++ b/bin/terraform
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+project=$(_set_openstack_project)
+echo "Using \"${project}\" project..."
+
+source "${TERRAFORM_DIRECTORY}/${project}/openrc.sh"
+
+# Run Terraform commands in the Hashicorp docker container via docker compose
+# shellcheck disable=SC2068
+DOCKER_USER="$(id -u):$(id -g)" \
+    PROJECT="${project}" \
+    docker-compose run --rm \
+    -e OS_AUTH_URL \
+    -e OS_IDENTITY_API_VERSION \
+    -e OS_USER_DOMAIN_NAME \
+    -e OS_PROJECT_DOMAIN_NAME \
+    -e OS_TENANT_ID \
+    -e OS_TENANT_NAME \
+    -e OS_USERNAME \
+    -e OS_PASSWORD \
+    -e OS_REGION_NAME \
+    -e TF_VAR_user_name \
+    terraform "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "15432:5432"
 
-  app:
+  app-dev:
     build:
       context: .
       target: development
@@ -17,7 +17,8 @@ services:
     user: ${DOCKER_USER:-1000}
     image: joanie:development
     environment:
-      PYLINTHOME: /app/.pylint.d
+      - PYLINTHOME=/app/.pylint.d
+      - DJANGO_CONFIGURATION=Development
     env_file:
       - env.d/development/common
       - env.d/development/postgresql
@@ -25,15 +26,42 @@ services:
       - "8071:8000"
     volumes:
       - ./src/backend:/app
-      - ./data/static:/data/static
       - ./data/media:/data/media
     depends_on:
       - "postgresql"
+
+  app:
+    build:
+      context: .
+      target: production
+      args:
+        DOCKER_USER: ${DOCKER_USER:-1000}
+    user: ${DOCKER_USER:-1000}
+    image: joanie:production
+    environment:
+      - DJANGO_CONFIGURATION=ContinuousIntegration
+    env_file:
+      - env.d/development/common
+      - env.d/development/postgresql
+    volumes:
+      - ./data/media:/data/media
+    depends_on:
+      - postgresql
     networks:
       default:
       lms_outside:
         aliases:
           - joanie
+
+  nginx:
+    image: nginx:1.13
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./docker/files/etc/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./data/media:/data/media:ro
+    depends_on:
+      - app
 
   dockerize:
     image: jwilder/dockerize

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,22 @@ services:
     ports:
       - 4040:4040
 
+  terraform-state:
+    image: hashicorp/terraform:1.0.7
+    environment:
+      - TF_WORKSPACE=${PROJECT:-} # avoid env conflict in local state
+    user: ${DOCKER_USER:-1000}
+    working_dir: /app
+    volumes:
+      - ./src/terraform/create_state_bucket:/app
+
+  terraform:
+    image: hashicorp/terraform:1.0.7
+    user: ${DOCKER_USER:-1000}
+    working_dir: /app
+    volumes:
+      - ./src/terraform:/app
+
 networks:
   lms_outside:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
   nginx:
     image: nginx:1.13
     ports:
-      - "8081:8081"
+      - "8082:8082"
     volumes:
       - ./docker/files/etc/nginx/conf.d:/etc/nginx/conf.d:ro
       - ./data/media:/data/media:ro

--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -1,6 +1,6 @@
 server {
 
-    listen 8081;
+    listen 8082;
     server_name localhost;
     charset utf-8;
 

--- a/docker/files/etc/nginx/conf.d/default.conf
+++ b/docker/files/etc/nginx/conf.d/default.conf
@@ -1,0 +1,19 @@
+server {
+
+    listen 8081;
+    server_name localhost;
+    charset utf-8;
+
+    location /media {
+        alias /data/media;
+    }
+
+    location / {
+        proxy_pass http://app:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+}
+

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,0 +1,158 @@
+# Media files in Joanie
+
+Media files are kept private in Joanie and are not served on the web. They
+are only used to render pdf documents with code using WeasyPrint via
+[Marion](https://github.com/openfun/marion).
+
+At [France Université Numérique](https://www.france-universite-numerique.fr),
+we host our media files in [Swift](https://docs.openstack.org/swift) at
+[OVHcloud](https://www.ovhcloud.com), and automate it with code using
+[Terraform](https://www.terraform.io/).
+
+> ✋ If you plan to develop locally on a site, you don't have to configure
+> anything more. The following documentation targets operational users willing
+> to setup a production infrastructure.
+
+## OpenStack Users
+
+To create the media files bucket via Terraform, you first need to create two
+users in an OpenStack project:
+- a user to run the Terraform script with admin role on object storage,
+- a joanie user with no specific role. This is the user Django will use to
+  access the media files bucket. Read and write accesses on the media files
+  bucket will be granted specifically to this user by the Terraform script.
+
+After creating the admin user, export its [`openrc.sh` file][1]. Create a new
+directory under `env.d/terraform` with the name of your OpenStack project. For
+example at FUN, we use 2 separate OpenStack projects: `fun_development` and
+`fun_production`.
+
+Place the `openrc.sh` file for the admin user under this directory.
+
+> Note that you will be able to create several media files buckets per
+> OpenStack project in case you want to host several environments in the same
+> project. For example at FUN, the following environments are all in the
+> `fun_development` project: `staging`, `preprod`, `PR branches`,...
+
+Finally, edit the `openrc.sh` file and add the following variable with the
+name of the second user you created for Django (by name we mean Keystone's
+username).
+
+```
+export TF_VAR_user_name="joanie-user"
+```
+
+Your complete `env.d/terraform/production/openrc.sh` file should look
+something like:
+
+```
+#!/bin/bash
+
+# To use an Openstack cloud you need to authenticate against keystone, which
+# returns a **Token** and **Service Catalog**. The catalog contains the
+# endpoint for all services the user/tenant has access to - including nova,
+# glance, keystone, swift.
+#
+export OS_AUTH_URL=https://auth.cloud.ovh.net/v3/
+export OS_IDENTITY_API_VERSION=3
+
+export OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-"Default"}
+export OS_PROJECT_DOMAIN_NAME=${OS_PROJECT_DOMAIN_NAME:-"Default"}
+
+
+# With the addition of Keystone we have standardized on the term **tenant**
+# as the entity that owns the resources.
+export OS_TENANT_ID=f5h78jko9aex435gt3d4rfg76n1a3ze4
+export OS_TENANT_NAME=2643565598702422
+
+# In addition to the owning entity (tenant), openstack stores the entity
+# performing the action as the **user**.
+export OS_USERNAME="my-openstack-admin-user"
+
+# With Keystone you pass the keystone password.
+echo "Please enter your OpenStack Password: "
+read -sr OS_PASSWORD_INPUT
+export OS_PASSWORD=$OS_PASSWORD_INPUT
+
+# If your configuration has multiple regions, we set that information here.
+# OS_REGION_NAME is optional and only valid in certain environments.
+export OS_REGION_NAME="GRA"
+# Don't leave a blank variable, unset it if it was empty
+if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi
+
+# Configure the name of the Django user that will connect to the media bucket
+export TF_VAR_user_name="joanie-user"
+```
+
+## Setup a shared Terraform state
+
+> ✋ If the project already exists with a shared state, you should skip this
+> section and start fetching the state locally to apply changes.
+
+If the project doesn't exist at all, you will need to create a Swift bucket
+to store your Terraform state file by typing the following commands in your
+terminal:
+
+```
+$ bin/state init
+$ bin/state apply
+```
+
+And voilà! Your shared state is now available to anyone contributing to the
+project. It was placed in a bucket named `joanie-terraform` and a backup
+bucket named `joanie-terraform-archive` was also created to historize all
+changes.
+
+## Create the media bucket
+
+If everything went smoothly, it's time to initialize and run the main
+terraform project using the shared state:
+
+```
+$ bin/terraform init
+$ bin/terraform apply
+```
+
+A new bucket named `tf-default-joanie-media-storage` should
+have been created in your OpenStack project.
+
+To create a bucket for another environment in the same OpenStack project, we
+make use of Terraform workspaces. By default, only the `default` workspace
+exists (hence the "default" in the name of the bucket created above). For
+example, you can create a new workspace for a `staging` environment _via_:
+
+```
+$ bin/terraform workspace new staging
+```
+
+And create the media files bucket for this environment as well:
+
+```
+$ bin/terraform apply
+```
+
+The new bucket will be named `tf-staging-joanie-media-storage`.
+
+To list existing Terraform workspaces and switch to another one:
+
+```
+$ bin/terraform list
+$ bin/terraform select {environment}
+```
+
+## Configure runtime environment
+
+Once your media files bucket has been created for a targeted environment, you
+will need to configure your project's runtime environment with the details and
+secrets allowing your Django application to access it.
+
+The following environment variables should be defined:
+
+- `DJANGO_AWS_S3_ENDPOINT_URL`: the S3 compatible endpoint of your Swift
+    service e.g. for OVH "https://s3.{region}.cloud.ovh.net"
+- `DJANGO_AWS_ACCESS_KEY_ID` and `DJANGO_AWS_SECRET_ACCESS_KEY`: the S3
+    credentials for your Joanie user in OpenStack, not the admin user!
+- `DJANGO_AWS_S3_REGION_NAME`: the S3 region name of your hosting provider
+    in which your media bucket was created
+
+[1]: https://docs.openstack.org/newton/user-guide/common/cli-set-environment-variables-using-openstack-rc.html

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -1,7 +1,7 @@
 # Django
 DJANGO_SETTINGS_MODULE=joanie.settings
-DJANGO_CONFIGURATION=Development
 DJANGO_SECRET_KEY=ThisIsAnExampleKeyForDevPurposeOnly
+DJANGO_ALLOWED_HOSTS=*
 
 # Python
 PYTHONPATH=/app/src/backend

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -52,8 +52,12 @@ class OrganizationFactory(factory.django.DjangoModelFactory):
 
     code = factory.Faker("ean", length=8)
     title = factory.Sequence(lambda n: f"Organization {n}")
-    signature = factory.django.FileField(filename="signature.png")
-    logo = factory.django.FileField(filename="logo.png")
+    signature = factory.django.ImageField(
+        filename="signature.png", format="png", width=1, height=1
+    )
+    logo = factory.django.ImageField(
+        filename="logo.png", format="png", width=1, height=1
+    )
 
 
 class CourseFactory(factory.django.DjangoModelFactory):

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -20,7 +20,7 @@ from parler import models as parler_models
 from joanie.core.exceptions import EnrollmentError
 from joanie.lms_handler import LMSHandler
 
-from .. import enums
+from .. import enums, utils
 from . import accounts as customers_models
 from . import certifications as certifications_models
 from . import courses as courses_models
@@ -318,8 +318,8 @@ class Order(models.Model):
                 "organization": {
                     "name": organization.title,
                     "representative": organization.representative,
-                    "signature": organization.signature.path,
-                    "logo": organization.logo.path,
+                    "signature": utils.image_to_base64(organization.signature),
+                    "logo": utils.image_to_base64(organization.logo),
                 },
             },
         }

--- a/src/backend/joanie/core/utils.py
+++ b/src/backend/joanie/core/utils.py
@@ -1,9 +1,50 @@
 """
 Utils that can be useful throughout Joanie's core app
 """
+import base64
+
 from django.utils.text import slugify
+
+from PIL import ImageFile as PillowImageFile
 
 
 def normalize_code(code):
     """Normalize object codes to avoid duplicates."""
     return slugify(code, allow_unicode=False).upper() if code else None
+
+
+def image_to_base64(file_or_path, close=False):
+    """
+    Return the src string of the base64 encoding of an image represented by its path
+    or file opened or not.
+
+    Inspired by Django's "get_image_dimensions"
+    """
+    pil_parser = PillowImageFile.Parser()
+    if hasattr(file_or_path, "read"):
+        file = file_or_path
+        file_pos = file.tell()
+        file.seek(0)
+    else:
+        try:
+            # pylint: disable=consider-using-with
+            file = open(file_or_path, "rb")
+        except OSError:
+            return ""
+        close = True
+
+    try:
+        image_data = file.read()
+        if not image_data:
+            return ""
+        pil_parser.feed(image_data)
+        if pil_parser.image:
+            mime_type = pil_parser.image.get_format_mimetype()
+            encoded_string = base64.b64encode(image_data)
+            return f"data:{mime_type:s};base64, {encoded_string.decode('utf-8'):s}"
+        return ""
+    finally:
+        if close:
+            file.close()
+        else:
+            file.seek(file_pos)

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -387,6 +387,14 @@ class Production(Base):
     # Privacy
     SECURE_REFERRER_POLICY = "same-origin"
 
+    # Media
+    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    AWS_S3_ENDPOINT_URL = values.Value()
+    AWS_S3_ACCESS_KEY_ID = values.Value()
+    AWS_S3_SECRET_ACCESS_KEY = values.Value()
+    AWS_STORAGE_BUCKET_NAME = values.Value("tf-default-joanie-media-storage")
+    AWS_S3_REGION_NAME = values.Value()
+
 
 class Feature(Production):
     """

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -306,6 +306,17 @@ class Base(Configuration):
                 scope.set_extra("application", "backend")
 
 
+class Build(Base):
+    """Settings used when the application is built.
+
+    This environment should not be used to run the application. Just to build it with non blocking
+    settings.
+    """
+
+    ALLOWED_HOSTS = None
+    SECRET_KEY = values.Value("DummyKey")
+
+
 class Development(Base):
     """
     Development environment settings

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -68,7 +68,7 @@ class Base(Configuration):
     * DB_USER
     """
 
-    DEBUG = True
+    DEBUG = False
 
     # Security
     ALLOWED_HOSTS = values.ListValue([])

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -141,6 +141,7 @@ class Base(Configuration):
 
     MIDDLEWARE = [
         "django.middleware.security.SecurityMiddleware",
+        "whitenoise.middleware.WhiteNoiseMiddleware",
         "django.contrib.sessions.middleware.SessionMiddleware",
         "django.middleware.locale.LocaleMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -315,6 +316,9 @@ class Build(Base):
 
     ALLOWED_HOSTS = None
     SECRET_KEY = values.Value("DummyKey")
+    STATICFILES_STORAGE = values.Value(
+        "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    )
 
 
 class Development(Base):
@@ -361,8 +365,8 @@ class Production(Base):
     # For static files in production, we want to use a backend that includes a hash in
     # the filename, that is calculated from the file content, so that browsers always
     # get the updated version of each file.
-    STATICFILES_STORAGE = (
-        "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+    STATICFILES_STORAGE = values.Value(
+        "whitenoise.storage.CompressedManifestStaticFilesStorage"
     )
 
     # SECURE_PROXY_SSL_HEADER allows to fix the scheme in Django's HttpRequest

--- a/src/backend/joanie/tests/test_models_product.py
+++ b/src/backend/joanie/tests/test_models_product.py
@@ -102,6 +102,19 @@ class ProductModelsTestCase(TestCase):
 
         certificate = order.generate_certificate()
         self.assertEqual(DocumentRequest.objects.count(), 1)
+        document_request = DocumentRequest.objects.get()
+        blue_square_base64 = (
+            "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgY"
+            "PgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
+        )
+        self.assertEqual(
+            document_request.context["course"]["organization"]["logo"],
+            blue_square_base64,
+        )
+        self.assertEqual(
+            document_request.context["course"]["organization"]["signature"],
+            blue_square_base64,
+        )
         self.assertEqual(
             certificate.attachment.name,
             f"{DocumentRequest.objects.get().document_id}.pdf",

--- a/src/backend/joanie/tests/test_utils_image_to_base64.py
+++ b/src/backend/joanie/tests/test_utils_image_to_base64.py
@@ -1,0 +1,58 @@
+"""
+Test suite for utils of the joanie core app
+"""
+import io
+
+from django.test import TestCase
+
+from joanie.core import factories, utils
+
+BLUE_SQUARE_BASE64 = (
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgY"
+    "PgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
+)
+
+
+class UtilsTestCase(TestCase):
+    """Test suite for utils."""
+
+    def test_utils_image_to_base64_file_closed(self):
+        """Image to base64 from closed file."""
+        course = factories.CourseFactory()
+        logo = course.organization.logo
+
+        self.assertEqual(utils.image_to_base64(logo), BLUE_SQUARE_BASE64)
+        self.assertEqual(logo.tell(), 0)
+
+    def test_utils_image_to_base64_file_opened(self):
+        """Image to base64 from opened file."""
+        course = factories.CourseFactory()
+        logo = course.organization.logo
+        with logo.open() as logo_file:
+            logo_file.seek(3)
+
+            self.assertEqual(utils.image_to_base64(logo_file), BLUE_SQUARE_BASE64)
+
+            self.assertEqual(logo_file.tell(), 3)
+
+    def test_utils_image_to_base64_path(self):
+        """Image to base64 from path."""
+        course = factories.CourseFactory()
+
+        self.assertEqual(
+            utils.image_to_base64(course.organization.logo.path), BLUE_SQUARE_BASE64
+        )
+
+    def test_utils_image_to_base64_path_not_found(self):
+        """Image to base64 from path that does not exist."""
+        self.assertEqual(utils.image_to_base64("not_found.png"), "")
+
+    def test_utils_image_to_base64_file_empty(self):
+        """Image to base64 from empty file."""
+        empty_file = io.BytesIO()
+        self.assertEqual(utils.image_to_base64(empty_file), "")
+
+    def test_utils_image_to_base64_file_not_image(self):
+        """Image to base64 from a file that is not an image."""
+        text_file = io.BytesIO("this is not an image".encode("utf-8"))
+        self.assertEqual(utils.image_to_base64(text_file), "")

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -29,15 +29,15 @@ router.register("courses", api.CourseViewSet, basename="courses")
 router.register("enrollments", api.EnrollmentViewSet, basename="enrollments")
 router.register("orders", api.OrderViewSet, basename="orders")
 
-urlpatterns = (
-    [
-        path("admin/", admin.site.urls),
-        path("api/", include([*router.urls, *lms_urlpatterns])),
-        path("api/documents/", include("marion.urls")),
-    ]
-    + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-)
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/", include([*router.urls, *lms_urlpatterns])),
+    path("api/documents/", include("marion.urls")),
+]
 
 if settings.DEBUG:
-    urlpatterns += [path("__debug__/", include("marion.urls.debug"))]
+    urlpatterns = (
+        urlpatterns
+        + [path("__debug__/", include("marion.urls.debug"))]
+        + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    )

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 install_requires =
     arrow==1.2.1
     Brotli==1.0.9
+    boto3==1.20.26
     django<4
     django-admin-sortable2==1.0.3
     django-configurations==2.3.1
@@ -37,6 +38,7 @@ install_requires =
     django-parler==2.3
     djangorestframework==3.13.1
     djangorestframework-simplejwt==5.0.0
+    django-storages==1.12.3
     dockerflow==2021.7.0
     factory_boy==3.2.1
     gunicorn==20.1.0

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
 [options]
 install_requires =
     arrow==1.2.1
+    Brotli==1.0.9
     django<4
     django-admin-sortable2==1.0.3
     django-configurations==2.3.1
@@ -44,6 +45,7 @@ install_requires =
     PyJWT>=2.1.0,<2.2.0
     requests==2.26.0
     sentry-sdk==1.5.1
+    whitenoise==5.3.0
 
 package_dir =
     =.

--- a/src/terraform/.terraform.lock.hcl
+++ b/src/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/terraform-provider-openstack/openstack" {
+  version     = "1.46.0"
+  constraints = "1.46.0"
+  hashes = [
+    "h1:wufxfGcIYWkD3WUwF1y+qLJeOXrquAY2AHOWdN8qlnI=",
+    "zh:2885bd08022db89aa43c4a7915968d91c0ad43f9e4f28a7f5dca6a56f0eac67d",
+    "zh:2af26173ca311ac5ead3fca4e291b3c91ba3f51dd3edee0ae08b857190cb7844",
+    "zh:3164b1f613622cbfd97d535377dea914d3ef1089d983e39b07b419332559bbe1",
+    "zh:4222fa7209661e263253391e18014c7a846fd2c1d24c9e1d9c9dfed49f592399",
+    "zh:537677192f2625080e164ba46572a1ae2baca259724f460b4b4fc1cff5a27fad",
+    "zh:75ab614467f3bb50faf289b1af109e7779fb8069c157b8c6a636d8bfde7d739a",
+    "zh:896c819d1833bdb835548c1b28d74a36abcfd360b3cc607d604101219a14691b",
+    "zh:965cbf520341d8a51348f76dddba36dd53eb7b63025a909ff8c38fdfdfedd860",
+    "zh:c08209806c97a6adf5b4c1d0aa529eabb03e2225f48dd2f05766137f8c02337c",
+    "zh:c39d6d0845993f1b479b99a03afa3aea2c07fae61004b80d475a7793be8dcce2",
+    "zh:c481d7bc9794a9447308d5af50bff98d963e55222efccda5c3a63c7637adabdf",
+    "zh:e668d9adfabf287e1353d4149b11fe1eb0d28da3226e04fa2e63e03b900f72c0",
+    "zh:f0a2731b9bc8a7affbdc467e49ae11959007a90729a306715dd6508a803363f8",
+    "zh:f6e2bce5e88e6dc78a0593e18bb9e3c4bdd315018d18f609f8e867e0290a4819",
+  ]
+}

--- a/src/terraform/create_state_bucket/.terraform.lock.hcl
+++ b/src/terraform/create_state_bucket/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/terraform-provider-openstack/openstack" {
+  version     = "1.46.0"
+  constraints = "1.46.0"
+  hashes = [
+    "h1:wufxfGcIYWkD3WUwF1y+qLJeOXrquAY2AHOWdN8qlnI=",
+    "zh:2885bd08022db89aa43c4a7915968d91c0ad43f9e4f28a7f5dca6a56f0eac67d",
+    "zh:2af26173ca311ac5ead3fca4e291b3c91ba3f51dd3edee0ae08b857190cb7844",
+    "zh:3164b1f613622cbfd97d535377dea914d3ef1089d983e39b07b419332559bbe1",
+    "zh:4222fa7209661e263253391e18014c7a846fd2c1d24c9e1d9c9dfed49f592399",
+    "zh:537677192f2625080e164ba46572a1ae2baca259724f460b4b4fc1cff5a27fad",
+    "zh:75ab614467f3bb50faf289b1af109e7779fb8069c157b8c6a636d8bfde7d739a",
+    "zh:896c819d1833bdb835548c1b28d74a36abcfd360b3cc607d604101219a14691b",
+    "zh:965cbf520341d8a51348f76dddba36dd53eb7b63025a909ff8c38fdfdfedd860",
+    "zh:c08209806c97a6adf5b4c1d0aa529eabb03e2225f48dd2f05766137f8c02337c",
+    "zh:c39d6d0845993f1b479b99a03afa3aea2c07fae61004b80d475a7793be8dcce2",
+    "zh:c481d7bc9794a9447308d5af50bff98d963e55222efccda5c3a63c7637adabdf",
+    "zh:e668d9adfabf287e1353d4149b11fe1eb0d28da3226e04fa2e63e03b900f72c0",
+    "zh:f0a2731b9bc8a7affbdc467e49ae11959007a90729a306715dd6508a803363f8",
+    "zh:f6e2bce5e88e6dc78a0593e18bb9e3c4bdd315018d18f609f8e867e0290a4819",
+  ]
+}

--- a/src/terraform/create_state_bucket/provider.tf
+++ b/src/terraform/create_state_bucket/provider.tf
@@ -1,0 +1,5 @@
+
+# This provider is configured with the OS_* environment variables
+provider "openstack" {
+  alias = "ovh"
+}

--- a/src/terraform/create_state_bucket/state.tf
+++ b/src/terraform/create_state_bucket/state.tf
@@ -1,0 +1,15 @@
+# A separate terraform project that just creates the bucket where
+# we will store the state. It needs to be created before the other
+# project because that's where the other project will store its
+# state. The state is encrypted using a KMS key because it will
+# contain sensitive information.
+
+terraform {
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "1.46.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}

--- a/src/terraform/create_state_bucket/swift.tf
+++ b/src/terraform/create_state_bucket/swift.tf
@@ -1,0 +1,22 @@
+resource "openstack_objectstorage_container_v1" "backend" {
+  name     = "joanie-terraform"
+  provider = openstack.ovh
+
+  # all objects should be deleted from the container so that the container
+  # can be destroyed without error.
+  force_destroy = true
+
+  versioning {
+    location = "joanie-terraform-archive"
+    type     = "versions"
+  }
+}
+
+resource "openstack_objectstorage_container_v1" "backend_archive" {
+  name     = "joanie-terraform-archive"
+  provider = openstack.ovh
+
+  # all objects should be deleted from the container so that the container
+  # can be destroyed without error.
+  force_destroy = true
+}

--- a/src/terraform/output.tf
+++ b/src/terraform/output.tf
@@ -1,0 +1,3 @@
+output "objectstorage_bucket_name" {
+  value = openstack_objectstorage_container_v1.joanie_media_storage.name
+}

--- a/src/terraform/providers.tf
+++ b/src/terraform/providers.tf
@@ -1,0 +1,3 @@
+provider "openstack" {
+  alias = "ovh"
+}

--- a/src/terraform/state.tf
+++ b/src/terraform/state.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+    openstack = {
+      source = "terraform-provider-openstack/openstack"
+      version = "1.46.0"
+    }
+  }
+
+  backend "swift" {
+    container = "joanie-terraform"
+    archive_container = "joanie-terraform-archive"
+  }
+
+  required_version = ">= 1.0.0"
+}

--- a/src/terraform/storage.tf
+++ b/src/terraform/storage.tf
@@ -1,0 +1,22 @@
+
+data "openstack_identity_auth_scope_v3" "current" {
+  name = "current"
+}
+
+resource "openstack_objectstorage_container_v1" "joanie_media_storage" {
+  name          = "tf-${terraform.workspace}-joanie-media-storage"
+  provider      = openstack.ovh
+
+  # all objects should be deleted from the container so that the container
+  # can be destroyed without error.
+  force_destroy = true
+
+  metadata    = {
+    workspace = terraform.workspace
+  }
+
+  # Bucket is in read only for anonymous users.
+  # https://docs.openstack.org/swift/latest/overview_acl.html
+  container_read = "${data.openstack_identity_auth_scope_v3.current.project_id}:${var.user_name}"
+  container_write = "${data.openstack_identity_auth_scope_v3.current.project_id}:${var.user_name}"
+}

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -1,0 +1,5 @@
+
+variable "user_name" {
+  type = string
+  description = "The OpenStack name of the user Django will use to connect to the media bucket"
+}


### PR DESCRIPTION
## Purpose

We want to use whitenoise to serve static files.
We want to use Swift object storage to store media files (not served on the web but used by internal scripts)

## Proposal

- [x] Collect static files in the production docker image
- [x] Add a service to run the production app in docker-compose behind nginx (no volume mount of app sources, placed behind nginx...)
- [x] Add whitenoise to the project
- [x] Add a terraform project to create/manage the media bucket
- [x] Add documentation about managing the media files bucket
- [x] Allow configuring media storage backend for production in the Django app
- [x] Change nginx port from 8081 to 8082 in docker-compose project

