### PR TITLE
🔧(ngrok) add ngrok service to serve joanie from a public address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add ngrok to serve Joanie on a public address for development purpose
 - Add unique constraint to owner address field to allow only one main address
   per user
 - Add fullname field to address model

--- a/Makefile
+++ b/Makefile
@@ -198,3 +198,11 @@ help:
 demo-data: ## create fake data for dev purpose
 	@$(MANAGE) loaddatafake
 .PHONY: demo-data
+
+ngrok: ## Run a proxy through ngrok
+ngrok:
+	@$(COMPOSE) stop ngrok
+	@$(COMPOSE) up -d ngrok
+	@echo "Joanie is accessible on : "
+	@bin/get_ngrok_url
+.PHONE: ngrok

--- a/bin/get_ngrok_url
+++ b/bin/get_ngrok_url
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# Get public_url of the running ngrok through its API endpoint
+if docker-compose port ngrok 4040 &> /dev/null ; then
+    declare -r JQ="docker run --rm -i fundocker/jq:1.6"
+    curl --no-progress-meter "$(docker-compose port ngrok 4040)/api/tunnels/command_line" | \
+    ${JQ} .public_url  | \
+    sed 's/"//g'
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,12 @@ services:
     user: "${DOCKER_USER:-1000}"
     working_dir: /app
 
+  ngrok:
+    image: wernight/ngrok
+    command: ngrok http app:8000
+    ports:
+      - 4040:4040
+
 networks:
   lms_outside:
     driver: bridge

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -306,6 +306,7 @@ class Development(Base):
     ALLOWED_HOSTS = ["*"]
     CORS_ALLOW_ALL_ORIGINS = True
     DEBUG = True
+    NGROK_ENDPOINT = values.Value(None, "NGROK_ENDPOINT", environ_prefix=None)
 
 
 class Test(Base):


### PR DESCRIPTION
## Purpose

In development environment, we need that Joanie is accessible from a public address.
We decide to use ngrok to address this point.

Steps: 
1. Run ngrok service and retrieve the endpoint url
2. Define `NGROK_ENDPOINT` within `env.d/development/common`
3. Run Joanie App

## Proposal

- [x] Add a ngrok service to docker-compose
- [x] Use the same script used on Marsha, to retrieve the ngrok endpoint
