### PR TITLE
Improve/admin product management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Improve course and product admin change views
 - Add ngrok to serve Joanie on a public address for development purpose
 - Add unique constraint to owner address field to allow only one main address
   per user

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -165,6 +165,7 @@ class Base(Configuration):
         "django.contrib.messages",
         "django.contrib.staticfiles",
         # Third party apps
+        "adminsortable2",
         "corsheaders",
         "dockerflow.django",
         "rest_framework",

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -26,6 +26,7 @@ classifiers =
 install_requires =
     arrow==1.2.1
     django==3.2.9
+    django-admin-sortable2==1.0.2
     django-configurations==2.3.1
     django-cors-headers==3.10.1
     django-countries==7.2.1

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -71,6 +71,8 @@ dev =
     responses==0.16.0
     types-pytz==2021.3.1
     types-requests==2.26.1
+    lxml==4.6.4
+    cssselect==1.1.0
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
## Purpose

Currently, it's hard for an editor to manage course and products from the admin interface. While waiting to have a dedicated interface, as a first step, we can improve django admin views.

### Link a course to a product has been improved
![2021-12-06 10 52 32](https://user-images.githubusercontent.com/9265241/144841363-28821946-4ff7-47e6-8b59-5c435a3582c7.gif)


### Manage product's targeted courses has been improved
![2021-12-06 10 53 24](https://user-images.githubusercontent.com/9265241/144841368-45a0413f-6b25-4526-89b1-c6fd82b637f9.gif)


## Proposal

- [x] Improve Course and Product change views
