### PR TITLE
Feat/course run/computed state field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add a computed "state" to Course and CourseRun models
 - Add Payplug payment backend and related API routes
 - Add Invoice and Transaction models for accounting purposes
 - Add credit card model and related api to retrieve, update, delete it

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -31,7 +31,7 @@ class CertificateAdmin(admin.ModelAdmin):
 class CourseAdmin(TranslatableAdmin):
     """Admin class for the Course model"""
 
-    list_display = ("code", "title", "organization")
+    list_display = ("code", "title", "organization", "state")
     filter_vertical = ("products",)
     fieldsets = (
         (_("Main information"), {"fields": ("code", "title", "organization")}),
@@ -51,7 +51,7 @@ class CourseAdmin(TranslatableAdmin):
 class CourseRunAdmin(TranslatableAdmin):
     """Admin class for the CourseRun model"""
 
-    list_display = ("title", "resource_link", "start", "end")
+    list_display = ("title", "resource_link", "start", "end", "state")
 
 
 @admin.register(models.Organization)

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -1,17 +1,128 @@
 """
 Declare and configure the models for the courses part
 """
+from collections.abc import Mapping
+from datetime import MAXYEAR, datetime
+
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils import timezone
 from django.utils.functional import lazy
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 
+import pytz
 from parler import models as parler_models
 from url_normalize import url_normalize
 
 from joanie.core import utils
 from joanie.core.enums import ALL_LANGUAGES
 from joanie.core.fields.multiselect import MultiSelectField
+
+MAX_DATE = datetime(MAXYEAR, 12, 31, tzinfo=pytz.utc)
+
+
+class CourseState(Mapping):
+    """An immutable object to describe a course (resp. course run) state."""
+
+    (
+        ONGOING_OPEN,
+        FUTURE_OPEN,
+        ARCHIVED_OPEN,
+        FUTURE_NOT_YET_OPEN,
+        FUTURE_CLOSED,
+        ONGOING_CLOSED,
+        ARCHIVED_CLOSED,
+        TO_BE_SCHEDULED,
+    ) = range(8)
+
+    STATE_CALLS_TO_ACTION = {
+        ONGOING_OPEN: _("enroll now"),
+        FUTURE_OPEN: _("enroll now"),
+        ARCHIVED_OPEN: _("study now"),
+        FUTURE_NOT_YET_OPEN: None,
+        FUTURE_CLOSED: None,
+        ONGOING_CLOSED: None,
+        ARCHIVED_CLOSED: None,
+        TO_BE_SCHEDULED: None,
+    }
+
+    STATE_TEXTS = {
+        ONGOING_OPEN: _("closing on"),
+        FUTURE_OPEN: _("starting on"),
+        ARCHIVED_OPEN: _("closing on"),
+        FUTURE_NOT_YET_OPEN: _("starting on"),
+        FUTURE_CLOSED: _("enrollment closed"),
+        ONGOING_CLOSED: _("on-going"),
+        ARCHIVED_CLOSED: _("archived"),
+        TO_BE_SCHEDULED: _("to be scheduled"),
+    }
+
+    def __init__(self, priority, date_time=None):
+        """
+        Initialize a course state with a priority and optionally a datetime.
+
+        Several states are possible for a course run each of which is given a priority. The
+        lower the priority, the more interesting the course run is (a course run open for
+        enrollment is more interesting than an archived course run):
+        - 0 | ONGOING_OPEN: a run is ongoing and open for enrollment
+              > "closing on": {enrollment_end}
+        - 1 | FUTURE_OPEN: a run is future and open for enrollment > "starting on": {start}
+        - 2 | ARCHIVED_OPEN: a run is past but open for enrollment > "closing on": {enrollment_end}
+        - 3 | FUTURE_NOT_YET_OPEN: a run is future and not yet open for enrollment
+              > "starting on": {start}
+        - 4 | FUTURE_CLOSED: a run is future and no more open for enrollment > "closed": {None}
+        - 5 | ONGOING_CLOSED: a run is ongoing but closed for enrollment > "on going": {None}
+        - 6 | ARCHIVED_CLOSED: there's a finished run in the past > "archived": {None}
+        - 7 | TO_BE_SCHEDULED: there is no run with a start date or no run at all
+              > "to be scheduled": {None}
+        """
+        # Check that `date_time` is set when it should be
+        if date_time is None and priority in [
+            CourseState.ONGOING_OPEN,
+            CourseState.FUTURE_OPEN,
+            CourseState.ARCHIVED_OPEN,
+            CourseState.FUTURE_NOT_YET_OPEN,
+        ]:
+            raise ValidationError(
+                f"date_time should not be null for a {priority:d} course state."
+            )
+
+        # A special case of being open is when enrollment never ends
+        text = self.STATE_TEXTS[priority]
+        if (
+            priority in [CourseState.ONGOING_OPEN, CourseState.ARCHIVED_OPEN]
+            and date_time.year == MAXYEAR
+        ):
+            text = _("forever open")
+            date_time = None
+        kwargs = {
+            "priority": priority,
+            "datetime": date_time,
+            "call_to_action": self.STATE_CALLS_TO_ACTION[priority],
+            "text": text,
+        }
+        self._d = dict(**kwargs)
+
+    def __str__(self):
+        """String representation"""
+        return str(self._d["text"])
+
+    def __iter__(self):
+        """Iterate on the inner dictionary."""
+        return iter(self._d)
+
+    def __len__(self):
+        """Return length of the inner dictionary."""
+        return len(self._d)
+
+    def __getitem__(self, key):
+        """Access the inner dictionary."""
+        return self._d[key]
+
+    def __lt__(self, other):
+        """Make it easy to compare two course states."""
+        return self._d["priority"] < other["priority"]
 
 
 class Organization(parler_models.TranslatableModel):
@@ -77,9 +188,31 @@ class Course(parler_models.TranslatableModel):
     def __str__(self):
         return self.safe_translation_getter("title", any_language=True)
 
+    @property
+    def state(self):
+        """
+        The state of the course carrying information on what to display on a course glimpse.
+
+        The game is to find the highest priority state for this course among its course runs.
+        """
+        # The default state is for a course that has no course runs
+        best_state = CourseState(CourseState.TO_BE_SCHEDULED)
+
+        for course_run in self.course_runs.only(
+            "start", "end", "enrollment_start", "enrollment_end"
+        ):
+            state = course_run.state
+            if state < best_state:
+                best_state = state
+            if state["priority"] == CourseState.ONGOING_OPEN:
+                # We found the best state, don't waste more time
+                break
+
+        return best_state
+
     def get_cache_key(self, language=None):
         """
-        Return a course cache key related to its code and the current language
+        Return a course cache key related to its code and the current
         language can be forced by through the language argument.
         """
         current_language = language or get_language()
@@ -139,6 +272,52 @@ class CourseRun(parler_models.TranslatableModel):
         db_table = "joanie_course_run"
         verbose_name = _("Course run")
         verbose_name_plural = _("Course runs")
+
+    # pylint: disable=too-many-return-statements
+    @staticmethod
+    def compute_state(start, end, enrollment_start, enrollment_end):
+        """
+        Compute at the current time the state of a course run that would have the dates
+        passed in argument.
+
+        A static method not using the instance allows to call it with an Elasticsearch result.
+        """
+        if not start or not enrollment_start:
+            return CourseState(CourseState.TO_BE_SCHEDULED)
+
+        # course run end dates are not required and should default to forever
+        # e.g. a course run with no end date is presumed to be always on-going
+        end = end or MAX_DATE
+        enrollment_end = enrollment_end or MAX_DATE
+
+        now = timezone.now()
+        if start < now:
+            if end > now:
+                if enrollment_end > now:
+                    # ongoing open
+                    return CourseState(CourseState.ONGOING_OPEN, enrollment_end)
+                # ongoing closed
+                return CourseState(CourseState.ONGOING_CLOSED)
+            if enrollment_start < now < enrollment_end:
+                # archived open
+                return CourseState(CourseState.ARCHIVED_OPEN, enrollment_end)
+            # archived closed
+            return CourseState(CourseState.ARCHIVED_CLOSED)
+        if enrollment_start > now:
+            # future not yet open
+            return CourseState(CourseState.FUTURE_NOT_YET_OPEN, start)
+        if enrollment_end > now:
+            # future open
+            return CourseState(CourseState.FUTURE_OPEN, start)
+        # future already closed
+        return CourseState(CourseState.FUTURE_CLOSED)
+
+    @property
+    def state(self):
+        """Return the state of the course run at the current time."""
+        return self.compute_state(
+            self.start, self.end, self.enrollment_start, self.enrollment_end
+        )
 
     def __str__(self):
         return (

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -313,6 +313,7 @@ class CourseRunSerializer(serializers.ModelSerializer):
             "resource_link",
             "start",
             "title",
+            "state",
         ]
         read_only_fields = [
             "end",
@@ -322,6 +323,7 @@ class CourseRunSerializer(serializers.ModelSerializer):
             "resource_link",
             "start",
             "title",
+            "state",
         ]
 
 

--- a/src/backend/joanie/tests/test_api_course.py
+++ b/src/backend/joanie/tests/test_api_course.py
@@ -1,8 +1,10 @@
 """Tests for the Course API."""
 import json
 import random
+from datetime import timedelta
 
 from django.test import override_settings
+from django.utils import timezone
 
 from joanie.core import enums, factories, models
 from joanie.payment.factories import InvoiceFactory
@@ -58,7 +60,12 @@ class CourseApiTest(BaseAPITestCase):
         Anonymous users should be allowed to retrieve a course
         with a minimal db access
         """
-        target_course_runs = factories.CourseRunFactory.create_batch(2)
+        target_course_runs = factories.CourseRunFactory.create_batch(
+            2,
+            start=timezone.now() - timedelta(hours=1),
+            end=timezone.now() + timedelta(hours=2),
+            enrollment_end=timezone.now() + timedelta(hours=1),
+        )
         product = factories.ProductFactory.create(
             target_courses=[course_run.course for course_run in target_course_runs],
         )
@@ -119,6 +126,16 @@ class CourseApiTest(BaseAPITestCase):
                                     "id": course_run.id,
                                     "title": course_run.title,
                                     "resource_link": course_run.resource_link,
+                                    "state": {
+                                        "priority": course_run.state["priority"],
+                                        "datetime": course_run.state["datetime"]
+                                        .isoformat()
+                                        .replace("+00:00", "Z"),
+                                        "call_to_action": course_run.state[
+                                            "call_to_action"
+                                        ],
+                                        "text": course_run.state["text"],
+                                    },
                                     "start": course_run.start.isoformat().replace(
                                         "+00:00", "Z"
                                     ),
@@ -191,16 +208,28 @@ class CourseApiTest(BaseAPITestCase):
         with its related order and enrollment bound.
         """
         target_course_run11 = factories.CourseRunFactory(
-            resource_link="http://lms.test/courses/course-v1:edx+000011+Demo_Course/course"
+            resource_link="http://lms.test/courses/course-v1:edx+000011+Demo_Course/course",
+            start=timezone.now() - timedelta(hours=1),
+            end=timezone.now() + timedelta(hours=2),
+            enrollment_end=timezone.now() + timedelta(hours=1),
         )
         target_course_run12 = factories.CourseRunFactory(
-            resource_link="http://lms.test/courses/course-v1:edx+000012+Demo_Course/course"
+            resource_link="http://lms.test/courses/course-v1:edx+000012+Demo_Course/course",
+            start=timezone.now() - timedelta(hours=1),
+            end=timezone.now() + timedelta(hours=2),
+            enrollment_end=timezone.now() + timedelta(hours=1),
         )
         target_course_run21 = factories.CourseRunFactory(
-            resource_link="http://lms.test/courses/course-v1:edx+000021+Demo_Course/course"
+            resource_link="http://lms.test/courses/course-v1:edx+000021+Demo_Course/course",
+            start=timezone.now() - timedelta(hours=1),
+            end=timezone.now() + timedelta(hours=2),
+            enrollment_end=timezone.now() + timedelta(hours=1),
         )
         target_course_run22 = factories.CourseRunFactory(
-            resource_link="http://lms.test/courses/course-v1:edx+000022+Demo_Course/course"
+            resource_link="http://lms.test/courses/course-v1:edx+000022+Demo_Course/course",
+            start=timezone.now() - timedelta(hours=1),
+            end=timezone.now() + timedelta(hours=2),
+            enrollment_end=timezone.now() + timedelta(hours=1),
         )
 
         product1 = factories.ProductFactory(
@@ -342,6 +371,16 @@ class CourseApiTest(BaseAPITestCase):
                                     "id": course_run.id,
                                     "title": course_run.title,
                                     "resource_link": course_run.resource_link,
+                                    "state": {
+                                        "priority": course_run.state["priority"],
+                                        "datetime": course_run.state["datetime"]
+                                        .isoformat()
+                                        .replace("+00:00", "Z"),
+                                        "call_to_action": course_run.state[
+                                            "call_to_action"
+                                        ],
+                                        "text": course_run.state["text"],
+                                    },
                                     "start": course_run.start.isoformat().replace(
                                         "+00:00", "Z"
                                     ),
@@ -464,7 +503,13 @@ class CourseApiTest(BaseAPITestCase):
         user = factories.UserFactory()
         token = self.get_user_token(user.username)
         course, tc1, tc2 = factories.CourseFactory.create_batch(3)
-        cr1 = factories.CourseRunFactory.create_batch(5, course=tc1)[1]
+        cr1 = factories.CourseRunFactory.create_batch(
+            5,
+            course=tc1,
+            start=timezone.now() - timedelta(hours=1),
+            end=timezone.now() + timedelta(hours=2),
+            enrollment_end=timezone.now() + timedelta(hours=1),
+        )[1]
 
         product = factories.ProductFactory(courses=[course], target_courses=[tc1, tc2])
 

--- a/src/backend/joanie/tests/test_models_course.py
+++ b/src/backend/joanie/tests/test_models_course.py
@@ -1,15 +1,19 @@
 """
-Test suite for order models
+Test suite for course models
 """
+from datetime import timedelta
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
-from django.utils import translation
+from django.utils import timezone, translation
 
 from joanie.core import factories, models
+from joanie.core.factories import CourseFactory, CourseRunFactory
+from joanie.core.models import CourseState
 
 
-class CourseRunModelsTestCase(TestCase):
-    """Test suite for the CourseRun model."""
+class CourseModelsTestCase(TestCase):
+    """Test suite for the Course model."""
 
     def test_models_course_fields_code_normalize(self):
         """The `code` field should be normalized to an ascii slug on save."""
@@ -48,3 +52,169 @@ class CourseRunModelsTestCase(TestCase):
 
         # - Force language
         self.assertEqual(course.get_cache_key("de-de"), "course-00001-de-de")
+
+
+class CourseStateModelsTestCase(TestCase):
+    """
+    Unit test suite for computing a date to display on the course glimpse depending on the state
+    of its related course runs:
+        0: a run is ongoing and open for enrollment > "closing on": {enrollment_end}
+        1: a run is future and open for enrollment > "starting on": {start}
+        2: a run is future and not yet open or already closed for enrollment >
+        "starting on": {start}
+        3: a run is ongoing but closed for enrollment > "on going": {None}
+        4: there's a finished run in the past > "archived": {None}
+        5: there are no runs at all > "coming soon": {None}
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.now = timezone.now()
+
+    def create_run_ongoing_open(self, course):
+        """Create an ongoing course run that is open for enrollment."""
+        return CourseRunFactory(
+            course=course,
+            start=self.now - timedelta(hours=1),
+            end=self.now + timedelta(hours=2),
+            enrollment_end=self.now + timedelta(hours=1),
+        )
+
+    def create_run_ongoing_closed(self, course):
+        """Create an ongoing course run that is closed for enrollment."""
+        return CourseRunFactory(
+            course=course,
+            start=self.now - timedelta(hours=1),
+            end=self.now + timedelta(hours=1),
+            enrollment_end=self.now,
+        )
+
+    def create_run_archived_open(self, course):
+        """Create an archived course run."""
+        return CourseRunFactory(
+            course=course,
+            start=self.now - timedelta(hours=1),
+            end=self.now,
+            enrollment_end=self.now + timedelta(hours=1),
+        )
+
+    def create_run_archived_closed(self, course):
+        """Create an archived course run."""
+        return CourseRunFactory(
+            course=course,
+            start=self.now - timedelta(hours=1),
+            end=self.now,
+            enrollment_end=self.now - timedelta(hours=1),
+        )
+
+    def create_run_future_not_yet_open(self, course):
+        """Create a course run in the future and not yet open for enrollment."""
+        return CourseRunFactory(
+            course=course,
+            start=self.now + timedelta(hours=2),
+            enrollment_start=self.now + timedelta(hours=1),
+        )
+
+    def create_run_future_closed(self, course):
+        """Create a course run in the future and already closed for enrollment."""
+        return CourseRunFactory(
+            course=course,
+            start=self.now + timedelta(hours=1),
+            enrollment_start=self.now - timedelta(hours=2),
+            enrollment_end=self.now - timedelta(hours=1),
+        )
+
+    def create_run_future_open(self, course):
+        """Create a course run in the future and open for enrollment."""
+        return CourseRunFactory(
+            course=course,
+            start=self.now + timedelta(hours=1),
+            enrollment_start=self.now - timedelta(hours=1),
+            enrollment_end=self.now + timedelta(hours=1),
+        )
+
+    def test_models_course_state_to_be_scheduled(self):
+        """
+        Confirm course state result when there is no course runs at all.
+        """
+        course = CourseFactory()
+        with self.assertNumQueries(1):
+            state = course.state
+        self.assertEqual(state, CourseState(7))
+
+    def test_models_course_state_archived_closed(self):
+        """
+        Confirm course state when there is a course run only in the past.
+        """
+        course = CourseFactory()
+        self.create_run_archived_closed(course)
+        with self.assertNumQueries(3):
+            state = course.state
+        self.assertEqual(state, CourseState(6))
+
+    def test_models_course_state_archived_open(self):
+        """
+        Confirm course state when there is a past course run but open for enrollment.
+        """
+        course = CourseFactory()
+        course_run = self.create_run_archived_open(course)
+        with self.assertNumQueries(3):
+            state = course.state
+        self.assertEqual(state, CourseState(2, course_run.enrollment_end))
+
+    def test_models_course_state_ongoing_enrollment_closed(self):
+        """
+        Confirm course state when there is an ongoing course run but closed for
+        enrollment.
+        """
+        course = CourseFactory()
+        self.create_run_ongoing_closed(course)
+        with self.assertNumQueries(3):
+            state = course.state
+        self.assertEqual(state, CourseState(5))
+
+    def test_models_course_state_future_enrollment_not_yet_open(self):
+        """
+        Confirm course state when there is a future course run but not yet open for
+        enrollment.
+        """
+        course = CourseFactory()
+        course_run = self.create_run_future_not_yet_open(course)
+        with self.assertNumQueries(3):
+            state = course.state
+        expected_state = CourseState(3, course_run.start)
+        self.assertEqual(state, expected_state)
+
+    def test_models_course_state_future_enrollment_closed(self):
+        """
+        Confirm course state when there is a future course run but closed for
+        enrollment.
+        """
+        course = CourseFactory()
+        self.create_run_future_closed(course)
+        with self.assertNumQueries(3):
+            state = course.state
+        expected_state = CourseState(4)
+        self.assertEqual(state, expected_state)
+
+    def test_models_course_state_future_enrollment_open(self):
+        """
+        Confirm course state when there is a future course run open for enrollment.
+        """
+        course = CourseFactory()
+        course_run = self.create_run_future_open(course)
+        with self.assertNumQueries(3):
+            state = course.state
+        expected_state = CourseState(1, course_run.start)
+        self.assertEqual(state, expected_state)
+
+    def test_models_course_state_ongoing_open(self):
+        """
+        Confirm course state when there is an ongoing course run open for enrollment.
+        """
+        course = CourseFactory()
+        course_run = self.create_run_ongoing_open(course)
+        with self.assertNumQueries(3):
+            state = course.state
+        expected_state = CourseState(0, course_run.enrollment_end)
+        self.assertEqual(state, expected_state)

--- a/src/backend/joanie/tests/test_models_course_run.py
+++ b/src/backend/joanie/tests/test_models_course_run.py
@@ -1,14 +1,26 @@
 """
 Test suite for order models
 """
+import random
+from datetime import datetime, timedelta
+from unittest import mock
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
+from django.utils import timezone
+
+import pytz
 
 from joanie.core import factories
+from joanie.core.factories import CourseRunFactory
 
 
 class CourseRunModelsTestCase(TestCase):
     """Test suite for the CourseRun model."""
+
+    def setUp(self):
+        super().setUp()
+        self.now = timezone.now()
 
     def test_models_course_run_normalized(self):
         """
@@ -41,4 +53,338 @@ class CourseRunModelsTestCase(TestCase):
         self.assertEqual(
             "{'resource_link': ['Course run with this Resource link already exists.']}",
             str(context.exception),
+        )
+
+    def test_models_course_run_state_start_to_be_scheduled(self):
+        """
+        A course run that has no start date should return a state with priority 6
+        and "to be scheduled" as text.
+        """
+        course_run = CourseRunFactory(start=None)
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 7,
+                "text": "to be scheduled",
+                "call_to_action": None,
+                "datetime": None,
+            },
+        )
+
+    def test_models_course_run_state_enrollment_start_to_be_scheduled(self):
+        """
+        A course run that has no enrollment start date should return a state with priority 6
+        and "to be scheduled" as text.
+        """
+        course_run = CourseRunFactory(enrollment_start=None)
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 7,
+                "text": "to be scheduled",
+                "call_to_action": None,
+                "datetime": None,
+            },
+        )
+
+    def test_models_course_run_state_no_end_date(self):
+        """
+        A course run with no end date is deemed to be forever on-going.
+        """
+        course_run = CourseRunFactory(end=None)
+
+        # The course run should be open during its enrollment period
+        now = datetime.utcfromtimestamp(
+            random.randrange(
+                int(course_run.enrollment_start.timestamp()) + 1,
+                int(course_run.enrollment_end.timestamp()) - 1,
+            )
+        ).replace(tzinfo=pytz.utc)
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            state = course_run.state
+
+        self.assertIn(dict(state)["priority"], [0, 1])
+
+        # The course run should be on-going at any date after its end of enrollment
+        now = datetime.utcfromtimestamp(
+            random.randrange(
+                int(course_run.enrollment_end.timestamp()),
+                int(datetime(9999, 12, 31).timestamp()),
+            )
+        ).replace(tzinfo=pytz.utc)
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            state = course_run.state
+
+        self.assertEqual(
+            dict(state),
+            {
+                "priority": 5,
+                "text": "on-going",
+                "call_to_action": None,
+                "datetime": None,
+            },
+        )
+
+    def test_models_course_run_state_no_enrollment_end(self):
+        """
+        A course run that has no end of enrollment is deemed to be always open.
+        """
+        course_run = CourseRunFactory(enrollment_end=None)
+
+        # The course run should be open between its start of enrollment and its start
+        now = datetime.utcfromtimestamp(
+            random.randrange(
+                int(course_run.enrollment_start.timestamp()) + 1,
+                int(course_run.start.timestamp()) - 1,
+            )
+        ).replace(tzinfo=pytz.utc)
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            state = course_run.state
+
+        self.assertEqual(
+            dict(state),
+            {
+                "priority": 1,
+                "text": "starting on",
+                "call_to_action": "enroll now",
+                "datetime": course_run.start,
+            },
+        )
+
+        # The course run should be on-going & open between its start and its end
+        now = datetime.utcfromtimestamp(
+            random.randrange(
+                int(course_run.start.timestamp()) + 1,
+                int(course_run.end.timestamp()) - 1,
+            )
+        ).replace(tzinfo=pytz.utc)
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            state = course_run.state
+
+        self.assertEqual(
+            dict(state),
+            {
+                "priority": 0,
+                "text": "forever open",
+                "call_to_action": "enroll now",
+                "datetime": None,
+            },
+        )
+
+        # The course run should be archived open after its end
+        now = datetime.utcfromtimestamp(
+            random.randrange(
+                int(course_run.end.timestamp()) + 1,
+                int(datetime(9999, 12, 31).timestamp()) - 1,
+            )
+        ).replace(tzinfo=pytz.utc)
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            state = course_run.state
+
+        self.assertEqual(
+            dict(state),
+            {
+                "priority": 2,
+                "text": "forever open",
+                "call_to_action": "study now",
+                "datetime": None,
+            },
+        )
+
+    def test_models_course_run_state_forever_open(self):
+        """
+        A course run that has no end of enrollement and no end should be forever open.
+        """
+        course_run = CourseRunFactory(enrollment_end=None, end=None)
+
+        # The course run should be open between its start of enrollment and its start
+        now = datetime.utcfromtimestamp(
+            random.randrange(
+                int(course_run.enrollment_start.timestamp()) + 1,
+                int(course_run.start.timestamp()) - 1,
+            )
+        ).replace(tzinfo=pytz.utc)
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            state = course_run.state
+
+        self.assertEqual(
+            dict(state),
+            {
+                "priority": 1,
+                "text": "starting on",
+                "call_to_action": "enroll now",
+                "datetime": course_run.start,
+            },
+        )
+
+        # The course run should be on-going & open forever after its start
+        now = datetime.utcfromtimestamp(
+            random.randrange(
+                int(course_run.start.timestamp()) + 1,
+                int(datetime(9999, 12, 31).timestamp()) - 1,
+            )
+        ).replace(tzinfo=pytz.utc)
+
+        with mock.patch.object(timezone, "now", return_value=now):
+            state = course_run.state
+
+        self.assertEqual(
+            dict(state),
+            {
+                "priority": 0,
+                "text": "forever open",
+                "call_to_action": "enroll now",
+                "datetime": None,
+            },
+        )
+
+    def test_models_course_run_state_archived_open_closing_on(self):
+        """
+        A course run that is passed and has an enrollment end in the future should return
+        a state with priority 2 and "closing on" as text.
+        """
+        course_run = CourseRunFactory(
+            start=self.now - timedelta(hours=2),
+            end=self.now - timedelta(hours=1),
+            enrollment_end=self.now + timedelta(hours=1),
+        )
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 2,
+                "text": "closing on",
+                "call_to_action": "study now",
+                "datetime": course_run.enrollment_end,
+            },
+        )
+
+    def test_models_course_run_state_archived_closed(self):
+        """
+        A course run that is passed should return a state with priority 6 and "archived"
+        as text.
+        """
+        course_run = CourseRunFactory(
+            start=self.now - timedelta(hours=2),
+            end=self.now - timedelta(hours=1),
+            enrollment_end=self.now - timedelta(hours=1),
+        )
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 6,
+                "text": "archived",
+                "call_to_action": None,
+                "datetime": None,
+            },
+        )
+
+    def test_models_course_run_state_ongoing_open(self):
+        """
+        A course run that is on-going and open for enrollment should return a state with a CTA
+        to enroll and the date of the end of enrollment.
+        """
+        course_run = CourseRunFactory(
+            enrollment_start=self.now - timedelta(hours=3),
+            start=self.now - timedelta(hours=2),
+            enrollment_end=self.now + timedelta(hours=1),
+            end=self.now + timedelta(hours=2),
+        )
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 0,
+                "text": "closing on",
+                "call_to_action": "enroll now",
+                "datetime": self.now + timedelta(hours=1),
+            },
+        )
+
+    def test_models_course_run_state_ongoing_closed(self):
+        """
+        A course run that is on-going but closed for enrollment should return a state with
+        "on-going" as text and no CTA.
+        """
+        course_run = CourseRunFactory(
+            enrollment_start=self.now - timedelta(hours=3),
+            start=self.now - timedelta(hours=2),
+            enrollment_end=self.now - timedelta(hours=1),
+            end=self.now + timedelta(hours=1),
+        )
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 5,
+                "text": "on-going",
+                "call_to_action": None,
+                "datetime": None,
+            },
+        )
+
+    def test_models_course_run_state_coming(self):
+        """
+        A course run that is future and not yet open for enrollment should return a state
+        with a CTA to see details with the start date.
+        """
+        course_run = CourseRunFactory(
+            enrollment_start=self.now + timedelta(hours=1),
+            enrollment_end=self.now + timedelta(hours=2),
+            start=self.now + timedelta(hours=3),
+            end=self.now + timedelta(hours=4),
+        )
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 3,
+                "text": "starting on",
+                "call_to_action": None,
+                "datetime": self.now + timedelta(hours=3),
+            },
+        )
+
+    def test_models_course_run_state_future_open(self):
+        """
+        A course run that is future and open for enrollment should return a state with a CTA
+        to enroll and the start date.
+        """
+        course_run = CourseRunFactory(
+            enrollment_start=self.now - timedelta(hours=1),
+            enrollment_end=self.now + timedelta(hours=1),
+            start=self.now + timedelta(hours=2),
+            end=self.now + timedelta(hours=3),
+        )
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 1,
+                "text": "starting on",
+                "call_to_action": "enroll now",
+                "datetime": self.now + timedelta(hours=2),
+            },
+        )
+
+    def test_models_course_run_state_future_closed(self):
+        """
+        A course run that is future and already closed for enrollment should return a state
+        with "enrollment closed" as text and no CTA.
+        """
+        course_run = CourseRunFactory(
+            enrollment_start=self.now - timedelta(hours=2),
+            enrollment_end=self.now - timedelta(hours=1),
+            start=self.now + timedelta(hours=1),
+            end=self.now + timedelta(hours=2),
+        )
+        self.assertEqual(
+            dict(course_run.state),
+            {
+                "priority": 4,
+                "text": "enrollment closed",
+                "call_to_action": None,
+                "datetime": None,
+            },
         )


### PR DESCRIPTION
## Purpose

Enrollment should be allow only if course run is open. To achieve that, we decided to replicate the course run computed state implemented to Richie.

To ease review, this PR is currently based on `feature/payplug-integration` but it should be merged into `main` after #51.


## Proposal

- [x] Add a computed `state` property to `CourseRun` and `Course` models.
