### PR TITLE
🔒️(jwt) remove dummy key used as default for JWT signing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
           DJANGO_SETTINGS_MODULE: joanie.settings
           DJANGO_CONFIGURATION: Test
           DJANGO_SECRET_KEY: ThisIsAnExampleKeyForTestPurposeOnly
+          DJANGO_JWT_PRIVATE_SIGNING_KEY: ThisIsAnExampleKeyForDevPurposeOnly
           PYTHONPATH: /home/circleci/joanie/src/backend
           DB_HOST: localhost
           DB_NAME: joanie

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ COPY ./src/backend /app/
 WORKDIR /app
 
 # collectstatic
-RUN DJANGO_CONFIGURATION=Build python manage.py collectstatic --noinput
+RUN DJANGO_CONFIGURATION=Build DJANGO_JWT_PRIVATE_SIGNING_KEY=Dummy \
+    python manage.py collectstatic --noinput
 
 # Replace duplicated file by a symlink to decrease the overall size of the
 # final image

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -13,3 +13,6 @@ EDX_SELECTOR_REGEX=^.*/courses/(?P<course_id>.*)/course/?$
 EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/course/?$
 EDX_API_TOKEN=FakeEdXAPIKey
 EDX_BACKEND=joanie.lms_handler.backends.openedx.OpenEdXLMSBackend
+
+#JWT
+DJANGO_JWT_PRIVATE_SIGNING_KEY=ThisIsAnExampleKeyForDevPurposeOnly

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -224,8 +224,7 @@ class Base(Configuration):
 
     SIMPLE_JWT = {
         "ALGORITHM": values.Value("HS256", environ_name="JWT_ALGORITHM"),
-        "SIGNING_KEY": values.Value(
-            "ThisIsAnExampleKeyForDevPurposeOnly",
+        "SIGNING_KEY": values.SecretValue(
             environ_name="JWT_PRIVATE_SIGNING_KEY",
         ),
         "AUTH_HEADER_TYPES": ("Bearer",),


### PR DESCRIPTION
## Purpose

Using a dummy key as default is the best way to end-up with a dummy key in production if we overlook this setting.

## Proposal

Remove the default value for `JWT_PRIVATE_SIGNING_KEY` and use Django Configuration's `SecretValue` to force explicit configuration in production.