### PR TITLE
Feat/lms handler get grades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add a `get_grades` method to LMSHandler
 - Add a computed "state" to Course and CourseRun models
 - Add Payplug payment backend and related API routes
 - Add Invoice and Transaction models for accounting purposes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,12 @@ services:
       - ./src/backend:/app
       - ./data/media:/data/media
     depends_on:
-      - "postgresql"
+      - postgresql
+    networks:
+      default:
+      lms_outside:
+        aliases:
+          - joanie
 
   app:
     build:
@@ -77,7 +82,7 @@ services:
 
   ngrok:
     image: wernight/ngrok
-    command: ngrok http app:8000
+    command: ngrok http app-dev:8000
     ports:
       - 4040:4040
 

--- a/src/backend/joanie/core/exceptions.py
+++ b/src/backend/joanie/core/exceptions.py
@@ -7,6 +7,10 @@ class EnrollmentError(Exception):
     """An exception to raise if an enrollment fails."""
 
 
+class GradeError(Exception):
+    """An exception to raise when grade processing fails."""
+
+
 class InvalidCourseRuns(Exception):
     """
     Exception raised when course runs selected for a product order mismatch with course runs

--- a/src/backend/joanie/lms_handler/backends/base.py
+++ b/src/backend/joanie/lms_handler/backends/base.py
@@ -24,3 +24,9 @@ class BaseLMSBackend:
         raise NotImplementedError(
             "subclasses of BaseLMSBackend must provide a set_enrollment() method"
         )
+
+    def get_grades(self, username, resource_link):
+        """Get user's grades for a course run given its url."""
+        raise NotImplementedError(
+            "subclasses of BaseLMSBackend must provide a get_grades() method"
+        )

--- a/src/backend/joanie/lms_handler/backends/dummy.py
+++ b/src/backend/joanie/lms_handler/backends/dummy.py
@@ -75,3 +75,35 @@ class DummyLMSBackend(BaseLMSBackend):
             cache.set(cache_key, True)
         else:
             cache.delete(cache_key)
+
+    def get_grades(self, username, resource_link):
+        """
+        Get a fake user's grade for a course run given its resource_link.
+
+        The return dict looks like a grade summary of a course run which has only one
+        graded exercice called "Final Exam" which have a grade of 0.0.
+        """
+        return {
+            "passed": False,
+            "grade": None,
+            "percent": 0.0,
+            "totaled_scores": {
+                "Final Exam": [[0.0, 1.0, True, "First section", None]],
+            },
+            "grade_breakdown": [
+                {
+                    "category": "Final Exam",
+                    "percent": 0.0,
+                    "detail": "Final Exam = 0.00% of a possible 0.00%",
+                }
+            ],
+            "section_breakdown": [
+                {
+                    "category": "Final Exam",
+                    "prominent": True,
+                    "percent": 0.0,
+                    "detail": "Final Exam = 0%",
+                    "label": "FE",
+                },
+            ],
+        }

--- a/src/backend/joanie/lms_handler/backends/failing.py
+++ b/src/backend/joanie/lms_handler/backends/failing.py
@@ -5,7 +5,7 @@ Failing LMS Backend for tests
 import logging
 import re
 
-from joanie.core.exceptions import EnrollmentError
+from joanie.core.exceptions import EnrollmentError, GradeError
 
 from .base import BaseLMSBackend
 
@@ -29,3 +29,8 @@ class FailingLMSBackend(BaseLMSBackend):
         """Set enrollment for a user with a course run given its url."""
         logger.error("Internal server error")
         raise EnrollmentError()
+
+    def get_grades(self, username, resource_link):
+        """Get user's grades for a course run given its url."""
+        logger.error("Internal server error")
+        raise GradeError()

--- a/src/backend/joanie/lms_handler/tests/test_backend_dummy.py
+++ b/src/backend/joanie/lms_handler/tests/test_backend_dummy.py
@@ -97,3 +97,59 @@ class DummyLMSBackendTestCase(TestCase):
             "course-v1:edx+000001+Demo_Course",
         )
         self.assertFalse(enrollment["is_active"])
+
+    def test_backend_dummy_get_grades(self):
+        """It should return a blank grade dictionary"""
+        username = "joanie"
+        resource_link = (
+            "http://dummy-lms.test/courses/course-v1:edx+000001+Demo_Course/course"
+        )
+
+        backend = LMSHandler.select_lms(resource_link)
+        self.assertIsInstance(backend, DummyLMSBackend)
+
+        grade_summary = backend.get_grades(username, resource_link)
+
+        # - grade summary should contain 6 properties
+        self.assertEqual(len(grade_summary), 6)
+
+        # - a boolean `passed`
+        self.assertEqual(grade_summary["passed"], False)
+
+        # - a string `grade`
+        self.assertEqual(grade_summary["grade"], None)
+
+        # - a float `percent`
+        self.assertEqual(grade_summary["percent"], 0.0)
+
+        # - a dict `totaled_scores`
+        self.assertEqual(
+            grade_summary["totaled_scores"],
+            {"Final Exam": [[0.0, 1.0, True, "First section", None]]},
+        )
+
+        # - a list `grade_breakdown`
+        self.assertEqual(
+            grade_summary["grade_breakdown"],
+            [
+                {
+                    "category": "Final Exam",
+                    "percent": 0.0,
+                    "detail": "Final Exam = 0.00% of a possible 0.00%",
+                }
+            ],
+        )
+
+        # - a list `section_breakdown`
+        self.assertEqual(
+            grade_summary["section_breakdown"],
+            [
+                {
+                    "category": "Final Exam",
+                    "prominent": True,
+                    "percent": 0.0,
+                    "detail": "Final Exam = 0%",
+                    "label": "FE",
+                }
+            ],
+        )


### PR DESCRIPTION
## Purpose
In order to retrieve user's progression for a course run, joanie should be able to retrieve this information from the LMS. For OpenEdX, [we have implemented a custom route to get this information](https://github.com/openfun/fun-apps/pull/721).
Add a `get_grades` method to LMSHandler. This method aims to retrieve user's grades summary for a given course.

## Proposal

- [x] Add a `get_grades` method to `LMSHandler` classes
