### PR TITLE
✨(OrderSerializer) bind certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to
 
 ### Changed
 
+- Update Order serializers to bind certificate
 - Order `state` is now a computed property
 - Split address fullname field into first_name and last_name fields
 - Update CourseSerializer to bind order and enrollment related to the user

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -213,11 +213,13 @@ class OrderLiteSerializer(serializers.ModelSerializer):
     )
     product = serializers.SlugRelatedField(read_only=True, slug_field="uid")
     main_invoice = serializers.SlugRelatedField(read_only=True, slug_field="reference")
+    certificate = serializers.SlugRelatedField(read_only=True, slug_field="uid")
 
     class Meta:
         model = models.Order
         fields = [
             "id",
+            "certificate",
             "created_on",
             "main_invoice",
             "total",
@@ -228,6 +230,7 @@ class OrderLiteSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "id",
+            "certificate",
             "created_on",
             "main_invoice",
             "total",
@@ -390,12 +393,14 @@ class OrderSerializer(serializers.ModelSerializer):
     )
     target_courses = serializers.SerializerMethodField(read_only=True)
     main_invoice = serializers.SlugRelatedField(read_only=True, slug_field="reference")
+    certificate = serializers.SlugRelatedField(read_only=True, slug_field="uid")
 
     class Meta:
         model = models.Order
         fields = [
             "course",
             "created_on",
+            "certificate",
             "enrollments",
             "id",
             "main_invoice",
@@ -407,6 +412,7 @@ class OrderSerializer(serializers.ModelSerializer):
             "target_courses",
         ]
         read_only_fields = [
+            "certificate",
             "created_on",
             "enrollments",
             "id",

--- a/src/backend/joanie/tests/test_api_order.py
+++ b/src/backend/joanie/tests/test_api_order.py
@@ -70,6 +70,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "course": order.course.code,
+                        "certificate": None,
                         "created_on": order.created_on.strftime(
                             "%Y-%m-%dT%H:%M:%S.%fZ"
                         ),
@@ -106,6 +107,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(other_order.uid),
+                        "certificate": None,
                         "course": other_order.course.code,
                         "created_on": other_order.created_on.strftime(
                             "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -156,6 +158,7 @@ class OrderApiTest(BaseAPITestCase):
             content,
             {
                 "id": str(order.uid),
+                "certificate": None,
                 "course": order.course.code,
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "state": order.state,
@@ -238,6 +241,7 @@ class OrderApiTest(BaseAPITestCase):
             content,
             {
                 "id": str(order.uid),
+                "certificate": None,
                 "course": course.code,
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "state": "validated",
@@ -299,6 +303,7 @@ class OrderApiTest(BaseAPITestCase):
             content,
             {
                 "id": str(order.uid),
+                "certificate": None,
                 "course": course.code,
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "state": "validated",
@@ -473,6 +478,7 @@ class OrderApiTest(BaseAPITestCase):
             content,
             {
                 "id": str(order.uid),
+                "certificate": None,
                 "course": course.code,
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "state": "pending",
@@ -538,6 +544,7 @@ class OrderApiTest(BaseAPITestCase):
             content,
             {
                 "id": str(order.uid),
+                "certificate": None,
                 "course": course.code,
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "state": "validated",
@@ -674,6 +681,7 @@ class OrderApiTest(BaseAPITestCase):
             [
                 "course",
                 "created_on",
+                "certificate",
                 "enrollments",
                 "id",
                 "main_invoice",


### PR DESCRIPTION
## Purpose

Currently, if a certificate has been generated, its related order is not serialized with his information. This gap must be filled.

## Proposal

- [x] Bind the order's certificate uid if there is one to Order serializers.

---
Related issue: #75 