### PR TITLE
Fix/delete enrollments on order cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Delete enrollments on order cancellation
 - Add custom actions into admin to generate certificates
 - Add a management command to generate certificate for eligible orders
 - Add `is_passed` cached property to enrollment model

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -312,11 +312,14 @@ class Order(models.Model):
         Mark order instance as "canceled" then unroll user to all active
         course runs related to the order.
         """
-        # Unroll user to all active enrollment related to the order
+        # Unenroll user to all active enrollment related to the order
         enrollments = self.enrollments.filter(is_active=True)
         for enrollment in enrollments:
             enrollment.is_active = False
-            enrollment.save()
+            enrollment.set()
+
+        # Then delete enrollments
+        enrollments.delete()
 
         self.is_canceled = True
         self.save()


### PR DESCRIPTION
## Purpose

As enrollments have unique constraint per user and course run, we have to delete
enrollments on an order cancellation to allow a user to enroll once again to a
course run from a new order.

## Proposal

- [x] Delete enrollments on order cancellation
- [x] Improve order admin actions
