### PR TITLE
💚(circleci) migrate to new circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   # Check that the git history is clean and complies with our expectations
   lint-git:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     working_directory: ~/joanie
     steps:
       - checkout
@@ -93,7 +93,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     working_directory: ~/joanie
     steps:
       - checkout
@@ -111,7 +111,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     working_directory: ~/joanie/src/backend
     steps:
       - checkout:
@@ -140,7 +140,7 @@ jobs:
 
   test-back:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
         environment:
           DJANGO_SETTINGS_MODULE: joanie.settings
           DJANGO_CONFIGURATION: Test
@@ -164,6 +164,11 @@ jobs:
       - restore_cache:
           keys:
             - v1-back-dependencies-{{ .Revision }}
+      - run:
+          name: Install libpangocairo required by pdfminer.six
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y libpangocairo-1.0-0
       # While running tests, we need to make the /data directory writable for
       # the circleci user
       - run:
@@ -190,7 +195,7 @@ jobs:
   # ---- Packaging jobs ----
   package-back:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
     working_directory: ~/joanie/src/backend
     steps:
       - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   # Check that the git history is clean and complies with our expectations
   lint-git:
     docker:
-      - image: circleci/python:3.8-bullseye
+      - image: cimg/python:3.8
     working_directory: ~/joanie
     steps:
       - checkout
@@ -36,7 +36,7 @@ jobs:
       - run:
           name: Install gitlint
           command: |
-            pip install --user gitlint
+            pip install --user requests gitlint
       - run:
           name: lint commit messages added to main
           command: |
@@ -45,7 +45,7 @@ jobs:
   # Check that the CHANGELOG has been updated in the current branch
   check-changelog:
     docker:
-      - image: circleci/buildpack-deps:stretch-scm
+      - image: cimg/base:2022.06
     working_directory: ~/joanie
     steps:
       - checkout
@@ -71,7 +71,7 @@ jobs:
   # Build the Docker image ready for production
   build-docker:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:2022.06
     working_directory: ~/joanie
     steps:
       # Checkout repository sources
@@ -93,7 +93,7 @@ jobs:
   # Build backend development environment
   build-back:
     docker:
-      - image: circleci/python:3.8-bullseye
+      - image: cimg/python:3.8
     working_directory: ~/joanie
     steps:
       - checkout
@@ -111,7 +111,7 @@ jobs:
 
   lint-back:
     docker:
-      - image: circleci/python:3.8-bullseye
+      - image: cimg/python:3.8
     working_directory: ~/joanie/src/backend
     steps:
       - checkout:
@@ -140,7 +140,7 @@ jobs:
 
   test-back:
     docker:
-      - image: circleci/python:3.8-bullseye
+      - image: cimg/python:3.8
         environment:
           DJANGO_SETTINGS_MODULE: joanie.settings
           DJANGO_CONFIGURATION: Test
@@ -153,7 +153,7 @@ jobs:
           DB_PASSWORD: pass
           DB_PORT: 5432
       # services
-      - image: circleci/postgres:12-ram
+      - image: cimg/postgres:12.10
         environment:
           POSTGRES_DB: test_joanie
           POSTGRES_USER: fun
@@ -190,7 +190,7 @@ jobs:
   # ---- Packaging jobs ----
   package-back:
     docker:
-      - image: circleci/python:3.8-bullseye
+      - image: cimg/python:3.8
     working_directory: ~/joanie/src/backend
     steps:
       - checkout:
@@ -210,7 +210,7 @@ jobs:
   # ---- DockerHub publication job ----
   hub:
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:2022.05
     working_directory: ~/joanie
     steps:
       # Checkout repository sources

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Joanie, power up Richie catalog
 
 # ---- base image to inherit from ----
-FROM python:3.8-slim-bullseye as base
+FROM python:3.10-slim-bullseye as base
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 # /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\ /!\
 #
-# Note to developpers:
+# Note to developers:
 #
 # While editing this file, please respect the following statements:
 #
@@ -81,8 +81,8 @@ logs: ## display app-dev logs (follow mode)
 .PHONY: logs
 
 run: ## start the wsgi (production) and development server
-	@$(COMPOSE) up -d nginx
-	@$(COMPOSE) up -d app-dev
+	@$(COMPOSE) up --force-recreate -d nginx
+	@$(COMPOSE) up --force-recreate -d app-dev
 	@echo "Wait for postgresql to be up..."
 	@$(WAIT_DB)
 .PHONY: run


### PR DESCRIPTION
## Purpose

circleci/* images has been deprecated, we have to migrate to
the new cimg/* images.

- circleci/buildpack-deps -> cimg/base
- circleci/postgres -> cimg/postgres
- circleci/python -> cimg/python

I take this opportunity to also upgrade to python 3.10

## Proposal

- [x] Replace all circleci/* images by cimg/*
- [x] Upgrade to python 3.10