### PR TITLE
👷(tray) add arnold tray to deploy joanie to kubernetes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,6 +192,102 @@ jobs:
               -timeout 60s \
                 ~/.local/bin/pytest
 
+  # ---- Tray jobs (k8s) ----
+  tray:
+    machine:
+      image: ubuntu-2004:202201-02
+      # Prevent cache-related issues
+      docker_layer_caching: false
+    working_directory: ~/fun
+    steps:
+      - checkout
+      - *generate-version-file
+      - run:
+          name: Build production image
+          command: docker build -t joanie:${CIRCLE_SHA1} --target production .
+      - run:
+          name: Check built image availability
+          command: docker images "joanie:${CIRCLE_SHA1}*"
+      # Login to DockerHub to Publish new images
+      #
+      # Nota bene: you'll need to define the following secrets environment vars
+      # in CircleCI interface:
+      #
+      #   - DOCKER_HUB_USER
+      #   - DOCKER_HUB_PASSWORD
+      - run:
+          name: Login to DockerHub
+          command: echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USER" --password-stdin
+      - run:
+          name: Install the kubectl client and k3d
+          command: |
+            export KUBECTL_RELEASE="v1.23.5"
+            curl -Lo "${HOME}/bin/kubectl" "https://dl.k8s.io/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl"
+            curl -Lo /tmp/kubectl.sha256 "https://dl.k8s.io/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl.sha256"
+            echo "$(</tmp/kubectl.sha256) ${HOME}/bin/kubectl" | sha256sum --check
+            chmod 755 "${HOME}/bin/kubectl"
+            export K3D_RELEASE="v4.4.8"
+            curl -Lo "${HOME}/bin/k3d" "https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/k3d-linux-amd64"
+            curl -sL https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/sha256sum.txt | \
+              grep _dist/k3d-linux-amd64 | \
+              sed "s|_dist/k3d-linux-amd64|${HOME}/bin/k3d|" | \
+              sha256sum --check
+            chmod 755 "${HOME}/bin/k3d"
+      - run:
+          name: Run local k3d cluster & configure environment
+          command: |
+            curl -Lo "${HOME}/bin/init-cluster" "https://raw.githubusercontent.com/openfun/arnold/master/bin/init-cluster"
+            chmod +x "${HOME}/bin/init-cluster"
+            # Bootstrap the k3d cluster with the following specific settings :
+            # - use standard HTTP and HTTPS ports
+            # - pre-provision 15 volumes instead of 100
+            MINIMUM_AVAILABLE_RWX_VOLUME=15 \
+            K3D_BIND_HOST_PORT_HTTP=80 \
+            K3D_BIND_HOST_PORT_HTTPS=443 \
+            K3D_REGISTRY_HOST=registry.127.0.0.1.nip.io \
+            K3D_ENABLE_REGISTRY=1 \
+              init-cluster arnold
+            # Set environment variables for the CI
+            echo "export K8S_DOMAIN=$(hostname -I | awk '{print $1}')" >> $BASH_ENV
+            echo 'export ARNOLD_DEFAULT_VAULT_PASSWORD="arnold"' >> $BASH_ENV
+            echo 'export ANSIBLE_VAULT_PASSWORD="${ARNOLD_DEFAULT_VAULT_PASSWORD}"' >> $BASH_ENV
+            echo "export ARNOLD_IMAGE_TAG=master" >> $BASH_ENV
+            echo "export K3D_REGISTRY_NAME=k3d-registry.127.0.0.1.nip.io" >> $BASH_ENV
+            echo "export K3D_REGISTRY_PORT=5000" >> $BASH_ENV
+            source $BASH_ENV
+      - run:
+          name: Install arnold CLI
+          command: |
+            curl -Lo"${HOME}/bin/arnold" "https://raw.githubusercontent.com/openfun/arnold/master/bin/arnold"
+            chmod +x "${HOME}/bin/arnold"
+      - run:
+          name: Setup a new Arnold project
+          command: |
+            arnold -c joanie -e ci setup
+            arnold -d -c joanie -e ci -a joanie create_db_vault
+            arnold -d -c joanie -e ci -a joanie create_app_vaults
+            arnold -d -c joanie -e ci -- vault -a joanie decrypt
+            sed -i 's/^# JOANIE_/JOANIE_/g' group_vars/customer/joanie/ci/secrets/joanie.vault.yml
+            arnold -d -c joanie -e ci -- vault -a joanie encrypt
+            VARS_FILE="group_vars/customer/joanie/ci/main.yml"
+            echo "skip_verification: True" > ${VARS_FILE}
+            echo "apps:" >> ${VARS_FILE}
+            echo "  - name: joanie" >> ${VARS_FILE}
+            echo "joanie_image_name: ${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}/ci-joanie/joanie" >> ${VARS_FILE}
+            echo "joanie_image_tag: ${CIRCLE_SHA1}" >> ${VARS_FILE}
+            echo "joanie_app_replicas: 1" >> ${VARS_FILE}
+      - run:
+          name: Push joanie image to the k8s cluster docker registry
+          command: |
+            docker tag joanie:${CIRCLE_SHA1} "${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}/ci-joanie/joanie:${CIRCLE_SHA1}"
+            docker push "${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}/ci-joanie/joanie:${CIRCLE_SHA1}"
+      - run:
+          name: Bootstrap joanie application
+          command: |
+            arnold -d -c joanie -e ci -a joanie init
+            arnold -d -c joanie -e ci -a joanie deploy
+            kubectl -n ci-joanie get pods -l app=joanie | grep Running
+
   # ---- Packaging jobs ----
   package-back:
     docker:
@@ -236,11 +332,11 @@ jobs:
       # Nota bene: you'll need to define the following secrets environment vars
       # in CircleCI interface:
       #
-      #   - DOCKER_USER
-      #   - DOCKER_PASS
+      #   - DOCKER_HUB_USER
+      #   - DOCKER_HUB_PASSWORD
       - run:
           name: Login to DockerHub
-          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          command: echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_HUB_USER" --password-stdin
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #
       # Git tag: v1.0.1
@@ -337,6 +433,14 @@ workflows:
             tags:
               only: /.*/
 
+      # Tray
+      #
+      # Deploy ralph in a k8s cluster using arnold
+      - tray:
+          filters:
+            tags:
+              only: /.*/
+
       # Packaging: python
       #
       # Build the python package
@@ -356,6 +460,7 @@ workflows:
           requires:
             - build-docker
             - test-back
+            - tray
           filters:
             branches:
               only: main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add Arnold tray to facilitate deploying Joanie to Kubernetes
 - Add the `badges` application
 - Add `is_listed` boolean field to course run model
 - Add custom actions into admin to generate certificates

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,0 +1,6 @@
+# arnold.yml
+metadata:
+  name: joanie
+  version: 1.0.0
+source:
+  path: src/tray

--- a/src/tray/templates/services/app/_env.yml.j2
+++ b/src/tray/templates/services/app/_env.yml.j2
@@ -1,0 +1,1 @@
+DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004

--- a/src/tray/templates/services/app/configs/__init__.py.j2
+++ b/src/tray/templates/services/app/configs/__init__.py.j2
@@ -1,0 +1,1 @@
+"""custom settings."""

--- a/src/tray/templates/services/app/configs/settings.py.j2
+++ b/src/tray/templates/services/app/configs/settings.py.j2
@@ -1,0 +1,1 @@
+from ..settings import *

--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  labels:
+    app: joanie
+    service: joanie
+    version: "{{ joanie_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "joanie-app-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  replicas: {{ joanie_app_replicas }}
+  selector:
+    matchLabels:
+      app: joanie
+      service: joanie
+      version: "{{ joanie_image_tag }}"
+      deployment: "joanie-app-{{ deployment_stamp }}"
+      deployment_stamp: "{{ deployment_stamp }}"
+  template:
+    metadata:
+      labels:
+        app: joanie
+        service: joanie
+        version: "{{ joanie_image_tag }}"
+        deployment: "joanie-app-{{ deployment_stamp }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+    spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: deployment
+                      operator: In
+                      values:
+                        - "joanie-app-{{ deployment_stamp }}"
+                topologyKey: kubernetes.io/hostname
+{% set image_pull_secret_name = joanie_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - name: joanie
+          image: "{{ joanie_image_name }}:{{ joanie_image_tag }}"
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /__heartbeat__
+              port: {{ joanie_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ joanie_host }}"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: {{ joanie_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ joanie_host }}"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          env:
+            - name: DB_HOST
+              value: "joanie-{{ joanie_database_host }}-{{ deployment_stamp }}"
+            - name: DB_NAME
+              value: "{{ joanie_database_name }}"
+            - name: DB_PORT
+              value: "{{ joanie_database_port }}"
+            - name: DJANGO_ALLOWED_HOSTS
+              value: "{{ joanie_host }}"
+            - name: DJANGO_CONFIGURATION
+              value: "{{ joanie_django_configuration }}"
+            - name: DJANGO_SETTINGS_MODULE
+              value: joanie.settings
+          envFrom:
+            - secretRef:
+                name: "{{ joanie_secret_name }}"
+            - configMapRef:
+                name: "joanie-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ joanie_app_resources }}
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}

--- a/src/tray/templates/services/app/job_db_migrate.yml.j2
+++ b/src/tray/templates/services/app/job_db_migrate.yml.j2
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "joanie-app-dbmigrate-{{ job_stamp }}"
+  namespace: "{{ namespace_name }}"
+  labels:
+    app: joanie
+    service: joanie
+    version: "{{ joanie_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+    job_stamp: "{{ job_stamp }}"
+spec:
+  template:
+    metadata:
+      name: "joanie-app-dbmigrate-{{ job_stamp }}"
+      labels:
+        app: joanie
+        service: joanie
+        version: "{{ joanie_image_tag }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+        job_stamp: "{{ job_stamp }}"
+    spec:
+{% set image_pull_secret_name = joanie_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - name: joanie-dbmigrate
+          image: "{{ joanie_image_name }}:{{ joanie_image_tag }}"
+          imagePullPolicy: Always
+          env:
+            - name: DB_HOST
+              value: "joanie-{{ joanie_database_host }}-{{ deployment_stamp }}"
+            - name: DB_NAME
+              value: "{{ joanie_database_name }}"
+            - name: DB_PORT
+              value: "{{ joanie_database_port }}"
+            - name: DJANGO_ALLOWED_HOSTS
+              value: "{{ joanie_host }}"
+            - name: DJANGO_CONFIGURATION
+              value: "{{ joanie_django_configuration }}"
+            - name: DJANGO_SETTINGS_MODULE
+              value: joanie.settings
+          envFrom:
+            - secretRef:
+                name: "{{ joanie_secret_name }}"
+          command: ["python", "manage.py", "migrate"]
+          resources: {{ joanie_app_job_db_migrate_resources }}
+      restartPolicy: Never
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}

--- a/src/tray/templates/services/app/secret.yml.j2
+++ b/src/tray/templates/services/app/secret.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: joanie
+    service: joanie
+  name: "{{ joanie_secret_name }}"
+  namespace: "{{ namespace_name }}"
+data:
+{% for k, v in JOANIE_VAULT.items() %}
+  {{ k }}: {{ v | default('') | b64encode }}
+{% endfor %}

--- a/src/tray/templates/services/app/svc.yml.j2
+++ b/src/tray/templates/services/app/svc.yml.j2
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: joanie
+    service: app
+    version: "{{ joanie_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: joanie-app-{{ deployment_stamp }}  # name of the service should be host name in nginx
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+  - name: {{ joanie_django_port }}-tcp
+    port: {{ joanie_django_port }}
+    protocol: TCP
+    targetPort: {{ joanie_django_port }}
+  selector:
+    app: joanie
+    deployment: "joanie-app-{{ deployment_stamp }}"
+  type: ClusterIP

--- a/src/tray/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/src/tray/templates/services/nginx/configs/healthcheck.conf.j2
@@ -1,0 +1,14 @@
+server {
+  listen {{ joanie_nginx_healthcheck_port }};
+  server_name localhost;
+
+  location {{ joanie_nginx_healthcheck_endpoint }} {
+    add_header Content-Type text/plain;
+    return 200 "OK";
+  }
+
+  location {{ joanie_nginx_status_endpoint }} {
+     stub_status;
+  }
+
+}

--- a/src/tray/templates/services/nginx/configs/joanie.conf.j2
+++ b/src/tray/templates/services/nginx/configs/joanie.conf.j2
@@ -1,0 +1,69 @@
+{% set http_basic_auth_enabled = activate_http_basic_auth or joanie_activate_http_basic_auth %}
+{% set bypass_htaccess = joanie_nginx_bypass_htaccess_ip_whitelist | length > 0 %}
+upstream joanie-backend {
+  server joanie-app-{{ deployment_stamp }}:{{ joanie_django_port }} fail_timeout=0;
+}
+
+server {
+  listen {{ joanie_nginx_port }};
+  server_name localhost;
+
+{% if http_basic_auth_enabled %}
+{% if bypass_htaccess %}
+  location @basicauth {
+    auth_basic "{{ http_basic_auth_message }}";
+    auth_basic_user_file {{ http_basic_auth_user_file }};
+
+    try_files $uri @proxy_to_joanie_app;
+  }
+{% else %}
+  auth_basic "{{ http_basic_auth_message }}";
+  auth_basic_user_file {{ http_basic_auth_user_file }};
+{% endif %}
+{% endif %}
+
+  client_max_body_size 100M;
+
+  rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
+
+  # Disables server version feedback on pages and in headers
+  server_tokens off;
+  {% block server_extra %}{% endblock %}
+
+  location @proxy_to_joanie_app {
+    proxy_set_header Host $http_host;
+
+    proxy_redirect off;
+    proxy_pass http://joanie-backend;
+  }
+
+  location / {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ joanie_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 = @basicauth;
+      return 401;
+    }
+{% endif %}
+
+    try_files $uri @proxy_to_joanie_app;
+  }
+
+{% if joanie_nginx_admin_ip_whitelist | length > 0 %}
+  location /admin {
+    {#
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ joanie_nginx_admin_ip_whitelist | join("|") }})) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_joanie_app;
+  }
+{% endif %}
+
+}

--- a/src/tray/templates/services/nginx/deploy.yml.j2
+++ b/src/tray/templates/services/nginx/deploy.yml.j2
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: Deployment
+metadata:
+  labels:
+    app: joanie
+    service: nginx
+    version: "{{ joanie_nginx_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "joanie-nginx-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  replicas: {{ joanie_nginx_replicas }}
+  selector:
+    matchLabels:
+      app: joanie
+      service: nginx
+      version: "{{ joanie_nginx_image_tag }}"
+      deployment: "joanie-nginx-{{ deployment_stamp }}"
+      deployment_stamp: "{{ deployment_stamp }}"
+  template:
+    metadata:
+      labels:
+        app: joanie
+        service: nginx
+        version: "{{ joanie_nginx_image_tag }}"
+        deployment: "joanie-nginx-{{ deployment_stamp }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+    spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deployment
+                  operator: In
+                  values:
+                  - "joanie-nginx-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
+{% set image_pull_secret_name = joanie_nginx_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - image: "{{ joanie_nginx_image_name }}:{{ joanie_nginx_image_tag }}"
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: joanie-v-nginx
+              readOnly: true
+{% if activate_http_basic_auth or joanie_activate_http_basic_auth %}
+            - mountPath: "{{ http_basic_auth_user_file | dirname }}"
+              name: joanie-htpasswd
+{% endif %}
+
+          livenessProbe:
+            httpGet:
+              path: "{{ joanie_nginx_healthcheck_endpoint }}"
+              port: {{ joanie_nginx_healthcheck_port }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: "{{ joanie_nginx_healthcheck_endpoint }}"
+              port: {{ joanie_nginx_healthcheck_port }}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources: {{ joanie_nginx_resources }}
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}
+      volumes:
+        - name: joanie-v-nginx
+          configMap:
+            name: joanie-nginx-{{ deployment_stamp }}
+{% if activate_http_basic_auth or joanie_activate_http_basic_auth %}
+        - name: joanie-htpasswd
+          secret:
+            secretName: "{{ joanie_nginx_htpasswd_secret_name }}"
+{% endif %}

--- a/src/tray/templates/services/nginx/ingress.yml.j2
+++ b/src/tray/templates/services/nginx/ingress.yml.j2
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: "{{ namespace_name }}"
+  name: "joanie-nginx-{{ prefix }}"
+  labels:
+    env_type: "{{ env_type }}"
+    customer: "{{ customer }}"
+    app: "joanie"
+    service: "nginx"
+    route_prefix: "{{ prefix }}"
+    route_target_service: "app"
+  annotations:
+{% if prefix in acme_enabled_route_prefix %}
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
+spec:
+  rules:
+  - host: "{{ joanie_host | blue_green_host(prefix) }}"
+    http:
+      paths:
+      - backend:
+          service:
+            name: "joanie-nginx-{{ prefix }}"
+            port:
+              number: {{ joanie_nginx_port }}
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - "{{ joanie_host | blue_green_host(prefix) }}"
+    secretName: "joanie-app-tls-{{ prefix }}-{{ acme_env }}"

--- a/src/tray/templates/services/nginx/secret.yml.j2
+++ b/src/tray/templates/services/nginx/secret.yml.j2
@@ -1,0 +1,14 @@
+{% if activate_http_basic_auth or joanie_activate_http_basic_auth %}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: joanie
+    service: "nginx"
+  name: "{{ joanie_nginx_htpasswd_secret_name }}"
+  namespace: "{{ namespace_name }}"
+data:
+  # nota bene: the {{ app.name }}_htpasswd variable is set in
+  # tasks/get_vault_for_app.yml tasks list only if the pointed file exists
+  "{{ http_basic_auth_user_file | basename }}": "{{ lookup('file', joanie_htpasswd) | b64encode }}"
+{% endif %}

--- a/src/tray/templates/services/nginx/static-svc.yml.j2
+++ b/src/tray/templates/services/nginx/static-svc.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: joanie
+    service: nginx
+    deployment_stamp: "{{ deployment_stamp }}"
+    service_prefix: "{{ prefix }}"
+    type: static-service
+    removable: "no"
+  name: "joanie-nginx-{{ prefix }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+    - name: {{ joanie_nginx_port }}-tcp
+      port: {{ joanie_nginx_port }}
+      protocol: TCP
+      targetPort: {{ joanie_nginx_port }}
+    - name: "{{ joanie_nginx_healthcheck_port }}-tcp"
+      port: {{ joanie_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ joanie_nginx_healthcheck_port }}
+  selector:
+    app: joanie
+    deployment: "joanie-nginx-{{ deployment_stamp | default('undefined', true) }}"
+  type: ClusterIP

--- a/src/tray/templates/services/nginx/svc.yml.j2
+++ b/src/tray/templates/services/nginx/svc.yml.j2
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: joanie
+    service: nginx
+    version: "{{ joanie_nginx_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "joanie-nginx-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+    - name: {{ joanie_nginx_port }}-tcp
+      port: {{ joanie_nginx_port }}
+      protocol: TCP
+      targetPort: {{ joanie_nginx_port }}
+    - name: "{{ joanie_nginx_healthcheck_port }}-tcp"
+      port: {{ joanie_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ joanie_nginx_healthcheck_port }}
+  selector:
+    app: joanie
+    deployment: "joanie-nginx-{{ deployment_stamp }}"
+  type: ClusterIP

--- a/src/tray/templates/services/postgresql/deploy.yml.j2
+++ b/src/tray/templates/services/postgresql/deploy.yml.j2
@@ -1,0 +1,59 @@
+{% if env_type in trashable_env_types %}
+apiVersion: v1
+kind: Deployment
+metadata:
+  labels:
+    app: joanie
+    service: postgresql
+    version: "{{ joanie_database_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "joanie-postgresql-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: joanie
+      service: postgresql
+      version: "{{ joanie_database_image_tag }}"
+      deployment: "joanie-postgresql-{{ deployment_stamp }}"
+      deployment_stamp: "{{ deployment_stamp }}"
+  template:
+    metadata:
+      labels:
+        app: joanie
+        service: postgresql
+        version: "{{ joanie_database_image_tag }}"
+        deployment: "joanie-postgresql-{{ deployment_stamp }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+    spec:
+{% set image_pull_secret_name = joanie_database_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+      imagePullSecrets:
+        - name: "{{ image_pull_secret_name }}"
+{% endif %}
+      containers:
+        - image: {{ joanie_database_image_name }}:{{ joanie_database_image_tag }}
+          name: postgresql
+          ports:
+            - containerPort: {{ joanie_database_port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: "{{ joanie_database_name }}"
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          envFrom:
+            - secretRef:
+                name: "{{ joanie_database_secret_name }}"
+          resources: {{ joanie_database_resources }}
+          volumeMounts:
+            - mountPath: /var/lib/postgresql
+              name: postgresql-data
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}
+      volumes:
+        - name: postgresql-data
+          emptyDir: {}  # volume that lives as long as the pod lives
+{% endif %}

--- a/src/tray/templates/services/postgresql/ep.yml.j2
+++ b/src/tray/templates/services/postgresql/ep.yml.j2
@@ -1,0 +1,18 @@
+{% if endpoint_postgresql_ip | ipaddr != false %}
+apiVersion: v1
+kind: Endpoints
+metadata:
+  labels:
+    app: joanie
+    endpoint: postgresql
+    deployment_stamp: "{{ deployment_stamp }}"
+  # name of the endpoint should be the same as the corresponding service
+  name: "joanie-postgresql-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+subsets:
+  - addresses:
+    - ip: "{{ endpoint_postgresql_ip }}"
+    ports:
+    - port: 5432
+      name: 5432-tcp
+{% endif %}

--- a/src/tray/templates/services/postgresql/secret.yml.j2
+++ b/src/tray/templates/services/postgresql/secret.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: joanie
+    service: postgresql
+  name: "{{ joanie_database_secret_name }}"
+  namespace: "{{ namespace_name }}"
+data:
+  POSTGRES_USER: "{{ JOANIE_VAULT.DB_USER | default('joanie_user') | b64encode }}"
+  POSTGRES_PASSWORD: "{{ JOANIE_VAULT.DB_PASSWORD | default('pass') | b64encode }}"

--- a/src/tray/templates/services/postgresql/svc.yml.j2
+++ b/src/tray/templates/services/postgresql/svc.yml.j2
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: joanie
+    service: postgresql
+    version: "{{ joanie_database_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  # name of the service should be database host name in settings
+  name: "joanie-postgresql-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  ports:
+    - name: "{{ joanie_database_port }}-tcp"
+      port: {{ joanie_database_port }}
+      protocol: TCP
+      targetPort: {{ joanie_database_port }}
+# As commented in the ad hoc endpoint, the endpoint name points to this service
+# so that it does not rely on a deployment configuration when the "env_type" is
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
+{% if env_type in trashable_env_types %}
+  selector:
+    app: joanie
+    service: postgresql
+    deployment: "joanie-postgresql-{{ deployment_stamp }}"
+  type: ClusterIP
+{% endif%}

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,0 +1,3 @@
+metadata:
+  name: joanie
+  version: 1.0.0

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -1,0 +1,61 @@
+# Application default configuration
+
+# -- route
+joanie_host: "joanie.{{ namespace_name }}.{{ domain_name }}"
+
+# -- nginx
+joanie_nginx_image_name: "nginxinc/nginx-unprivileged"
+joanie_nginx_image_tag: "1.20"
+joanie_nginx_port: 8061
+joanie_nginx_replicas: 1
+joanie_nginx_htpasswd_secret_name: "joanie-htpasswd"
+joanie_nginx_healthcheck_port: 5000
+joanie_nginx_healthcheck_endpoint: "/__healthcheck__"
+joanie_nginx_status_endpoint: "/__status__"
+joanie_nginx_admin_ip_whitelist: []
+joanie_nginx_bypass_htaccess_ip_whitelist: []
+joanie_nginx_static_cache_expires: "1M"
+
+# -- postgresql
+joanie_postgresql_version: "9.6"
+joanie_database_engine: "django.db.backends.postgresql_psycopg2"
+joanie_database_image_name: "postgres"
+joanie_database_image_tag: "14.1"
+joanie_database_host: "postgresql"
+joanie_database_port: 5432
+joanie_database_name: "joanie"
+joanie_database_secret_name: "joanie-postgresql-{{ joanie_vault_checksum | default('undefined_joanie_vault_checksum') }}"
+
+# -- joanie
+joanie_image_name: "fundocker/joanie"
+joanie_image_tag: "1.0.0"
+# The image pull secret name should match the name of your secret created to
+# login to your private docker registry
+joanie_image_pull_secret_name: ""
+joanie_django_port: 8000
+joanie_app_replicas: 1
+joanie_django_settings_module: "joanie.settings"
+joanie_django_configuration: "Development"
+joanie_secret_name: "joanie-{{ joanie_vault_checksum | default('undefined_joanie_vault_checksum') }}"
+joanie_activate_http_basic_auth: false
+
+# -- resources
+{% set app_resources = {
+  "requests": {
+    "cpu": "50m",
+    "memory": "500Mi"
+  }
+} %}
+
+joanie_app_resources: "{{ app_resources }}"
+joanie_app_job_db_migrate_resources: "{{ app_resources }}"
+
+joanie_nginx_resources:
+  requests:
+    cpu: 10m
+    memory: 5Mi
+
+joanie_database_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi

--- a/src/tray/vars/settings.yml
+++ b/src/tray/vars/settings.yml
@@ -1,0 +1,3 @@
+databases:
+  - engine: "postgresql"
+    release: "9.6"

--- a/src/tray/vars/vault/main.yml.j2
+++ b/src/tray/vars/vault/main.yml.j2
@@ -1,0 +1,15 @@
+# customer: {{ customer }}
+# env_type: {{ env_type }}
+
+# postgresql
+{% set postgresql_credentials = databases.postgresql | json_query("[?release=='" ~ joanie_postgresql_version ~ "'].databases | [0][?application=='joanie'].{user: user, password: password} | [0]") %}
+DB_USER: {{ postgresql_credentials.user }}
+DB_PASSWORD: {{ postgresql_credentials.password }}
+
+# joanie environment
+DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=50') }}
+# FIXME uncomment this variable and replace with your sentry's credentials
+# DJANGO_SENTRY_DSN: https://super:django@sentry.io/foo
+
+# JWT Token
+DJANGO_JWT_PRIVATE_SIGNING_KEY: {{ lookup('password', '/dev/null length=50') }}


### PR DESCRIPTION
## Purpose

At FUN we would like to be able to deploy Joanie to Kubernetes using [Arnold](https://github.com.openfun/arnold), our tool based on Ansible to generate k8s definition files. 

## Proposal

Arnold supports remote trays to define a project directly in the app repository, so I propose to add this project under `src/tray`.