### PR TITLE
Misc/user email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Set and update user's email sent from the token
 - Add `certification_definition` field to `Certificate` model
 - Add Arnold tray to facilitate deploying Joanie to Kubernetes
 - Add the `badges` application

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -16,6 +16,7 @@ from joanie.core.enums import ORDER_STATE_PENDING
 from joanie.payment import get_payment_backend
 from joanie.payment.models import ProformaInvoice
 
+from ..core.models import User
 from ..payment.models import CreditCard
 from . import serializers
 
@@ -85,13 +86,12 @@ class EnrollmentViewSet(
 
     def get_queryset(self):
         """Custom queryset to limit to orders owned by the logged-in user."""
-        user = models.User.objects.get_or_create(username=self.request.user.username)[0]
+        user = User.update_or_create_from_request_user(request_user=self.request.user)
         return user.enrollments.all().select_related("course_run")
 
     def perform_create(self, serializer):
         """Force the enrollment's "owner" field to the logged-in user."""
-        username = self.request.user.username
-        user = models.User.objects.get_or_create(username=username)[0]
+        user = User.update_or_create_from_request_user(request_user=self.request.user)
         serializer.save(user=user)
 
 
@@ -122,7 +122,7 @@ class OrderViewSet(
 
     def get_queryset(self):
         """Custom queryset to limit to orders owned by the logged-in user."""
-        user = models.User.objects.get_or_create(username=self.request.user.username)[0]
+        user = User.update_or_create_from_request_user(request_user=self.request.user)
         return (
             user.orders.all()
             .select_related("owner", "product")
@@ -131,8 +131,7 @@ class OrderViewSet(
 
     def perform_create(self, serializer):
         """Force the order's "owner" field to the logged-in user."""
-        username = self.request.user.username
-        owner = models.User.objects.get_or_create(username=username)[0]
+        owner = User.update_or_create_from_request_user(request_user=self.request.user)
         serializer.save(owner=owner)
 
     @transaction.atomic
@@ -304,12 +303,12 @@ class AddressViewSet(
 
     def get_queryset(self):
         """Custom queryset to get user addresses"""
-        user = models.User.objects.get_or_create(username=self.request.user.username)[0]
+        user = User.update_or_create_from_request_user(request_user=self.request.user)
         return user.addresses.all()
 
     def perform_create(self, serializer):
         """Create a new address for user authenticated"""
-        user = models.User.objects.get_or_create(username=self.request.user.username)[0]
+        user = User.update_or_create_from_request_user(request_user=self.request.user)
         serializer.save(owner=user)
 
 
@@ -335,8 +334,7 @@ class CertificateViewSet(
         """
         Custom queryset to get user certificates
         """
-        user = models.User.objects.get_or_create(username=self.request.user.username)[0]
-
+        user = User.update_or_create_from_request_user(request_user=self.request.user)
         return models.Certificate.objects.filter(order__owner=user)
 
     @action(detail=True, methods=["GET"])

--- a/src/backend/joanie/core/models/accounts.py
+++ b/src/backend/joanie/core/models/accounts.py
@@ -22,6 +22,16 @@ class User(auth_models.AbstractUser):
     def __str__(self):
         return self.username
 
+    @staticmethod
+    def update_or_create_from_request_user(request_user):
+        """Create user from token or update it"""
+        user = User.objects.update_or_create(
+            username=request_user.username,
+            defaults={"email": request_user.email},
+        )[0]
+
+        return user
+
 
 class Address(models.Model):
     """Address model stores address information (to generate bill after payment)"""

--- a/src/backend/joanie/payment/api.py
+++ b/src/backend/joanie/payment/api.py
@@ -62,5 +62,5 @@ class CreditCardViewSet(
 
     def get_queryset(self):
         """Custom queryset to get user's credit cards"""
-        user = User.objects.get_or_create(username=self.request.user.username)[0]
+        user = User.update_or_create_from_request_user(request_user=self.request.user)
         return user.credit_cards.all()

--- a/src/backend/joanie/tests/base.py
+++ b/src/backend/joanie/tests/base.py
@@ -42,3 +42,28 @@ class BaseAPITestCase(TestCase):
             }
         )
         return token
+
+    @staticmethod
+    def generate_token_from_user(user, expires_at=None):
+        """
+        Generate a jwt token used to authenticate a user from a user registered in
+        the database
+
+        Args:
+            user: User
+            expires_at: datetime.datetime, time after which the token should expire.
+
+        Returns:
+            token, the jwt token generated as it should
+        """
+        issued_at = datetime.utcnow()
+        token = AccessToken()
+        token.payload.update(
+            {
+                "email": user.email,
+                "username": user.username,
+                "exp": expires_at or issued_at + timedelta(days=2),
+                "iat": issued_at,
+            }
+        )
+        return token

--- a/src/backend/joanie/tests/test_api_base.py
+++ b/src/backend/joanie/tests/test_api_base.py
@@ -1,0 +1,26 @@
+"""
+Test suite for BaseTest class
+"""
+from datetime import datetime, timedelta
+
+from joanie.core import factories
+
+from .base import BaseAPITestCase
+
+
+class BaseAPITestTestCase(BaseAPITestCase):
+    """Test suite for BaseAPITest class"""
+
+    def test_base_api_generate_token_from_users(self):
+        """If a user is passed to the method generate_token_from_user,
+        the token attributes should correspond to the data of the user
+        """
+        user = factories.UserFactory(username="Sam", email="sam@fun-test.fr")
+        token = self.generate_token_from_user(user)
+        self.assertEqual("sam@fun-test.fr", token.payload.get("email"))
+        self.assertEqual("Sam", token.payload.get("username"))
+
+        # expiration date is over a day from now
+        self.assertGreater(
+            token.payload.get("exp"), datetime.utcnow() + timedelta(days=1)
+        )

--- a/src/backend/joanie/tests/test_models_user.py
+++ b/src/backend/joanie/tests/test_models_user.py
@@ -1,0 +1,66 @@
+"""Test suite for badge models."""
+from django.db import IntegrityError
+from django.test import RequestFactory, TestCase
+
+from joanie.core.factories import UserFactory
+from joanie.core.models import User
+
+
+class UserModelTestCase(TestCase):
+    """Test suite for the User model."""
+
+    def test_model_create(self):
+        """A simple test to check model consistency."""
+
+        UserFactory(username="Sam", email="sam@fun-test.fr")
+        UserFactory(username="Joanie")
+
+        self.assertEqual(User.objects.count(), 2)
+
+        first_user = User.objects.first()
+        self.assertEqual(first_user.username, "Sam")
+        self.assertEqual(first_user.email, "sam@fun-test.fr")
+        self.assertEqual(str(first_user), "Sam")
+
+    def test_models_unique_username(self):
+        """
+        There should be a db constraint forcing uniqueness of username
+        """
+        UserFactory(username="Sam", email="sam@fun-test.fr")
+
+        with self.assertRaises(IntegrityError):
+            UserFactory(username="Sam")
+
+    def test_models_multiple_emails(self):
+        """
+        Multiple users can have the same email
+        """
+        UserFactory(username="Sam", email="mail@fun-test.fr")
+        UserFactory(username="Joanie", email="mail@fun-test.fr")
+        self.assertEqual(User.objects.filter(email="mail@fun-test.fr").count(), 2)
+
+    def test_models_create_or_update_from_request(self):
+        """
+        Check using the method create_or_update_from_request, a user
+        is created if non existing or else updated
+        """
+        user = UserFactory(username="Sam", email="mail@fun-test.fr")
+
+        request = RequestFactory()
+        request.username = "Sam"
+        request.email = "sam@fun-test.fr"
+
+        User.update_or_create_from_request_user(request)
+        user.refresh_from_db()
+
+        # email has been updated
+        self.assertEqual(user.email, "sam@fun-test.fr")
+        # no new object has been created
+        self.assertEqual(User.objects.count(), 1)
+
+        request.username = "Sam2"
+        User.update_or_create_from_request_user(request)
+        # a new object has been created
+        self.assertEqual(User.objects.count(), 2)
+        user2 = User.objects.get(username="Sam2")
+        self.assertEqual(user2.email, "sam@fun-test.fr")


### PR DESCRIPTION
## Purpose

So far the token sent in the email was not updated or even
set up in the first place. In order to save this data, we've
centralized a method `update_or_create` from the user's
model used in the different API calls.
This feat will enable us to send email in a future feature and
save the right email in the payment model.

## Proposal

Description...

- misc generate a token from a user object
- update or create user object from requests API + add test model user
