### PR TITLE
🐛(admin) custom change form for translatable admin with actions

### DIFF
--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -67,6 +67,7 @@ class CourseAdmin(DjangoObjectActions, TranslatableAdmin):
 
     actions = (ACTION_NAME_GENERATE_CERTIFICATES,)
     change_actions = (ACTION_NAME_GENERATE_CERTIFICATES,)
+    change_form_template = "joanie/admin/translatable_change_form_with_actions.html"
     list_display = ("code", "title", "organization", "state")
     filter_horizontal = ("products",)
     fieldsets = (
@@ -157,10 +158,13 @@ class ProductCourseRelationInline(SortableInlineAdminMixin, admin.TabularInline)
 
 @admin.register(models.Product)
 class ProductAdmin(
-    DjangoObjectActions, SortableAdminBase, TranslatableAdmin
+    DjangoObjectActions,
+    SortableAdminBase,
+    TranslatableAdmin,
 ):  # pylint: disable=too-many-ancestors
     """Admin class for the Product model"""
 
+    change_form_template = "joanie/admin/translatable_change_form_with_actions.html"
     list_display = ("title", "type", "price")
     fields = (
         "type",

--- a/src/backend/joanie/core/templates/joanie/admin/translatable_change_form_with_actions.html
+++ b/src/backend/joanie/core/templates/joanie/admin/translatable_change_form_with_actions.html
@@ -1,0 +1,23 @@
+{% extends "admin/parler/change_form.html" %}
+{% load add_preserved_filters from admin_urls %}
+{% comment %}
+    This template must be used when a model admin class inherits both from
+    TranslatableAdmin and DjangoObjectActions.
+    https://github.com/crccheck/django-object-actions/blob/master/django_object_actions/templates/django_object_actions/change_form.html
+{% endcomment %}
+
+{% block object-tools-items %}
+{% for tool in objectactions %}
+<li class="objectaction-item" data-tool-name="{{ tool.name }}">
+    {% url tools_view_name pk=object_id tool=tool.name as action_url %}
+    <a href="{% add_preserved_filters action_url %}" title="{{ tool.standard_attrs.title }}"
+       {% for k, v in tool.custom_attrs.items %}
+       {{ k }}="{{ v }}"
+       {% endfor %}
+       class="{{ tool.standard_attrs.class }}">
+        {{ tool.label|capfirst }}
+    </a>
+</li>
+{% endfor %}
+{{ block.super }}
+{% endblock %}

--- a/src/backend/joanie/tests/test_admin_course.py
+++ b/src/backend/joanie/tests/test_admin_course.py
@@ -1,0 +1,53 @@
+"""
+Test suite for courses admin pages
+"""
+
+from django.conf import settings
+from django.urls import reverse
+
+import lxml
+
+from joanie.core import factories
+
+from .base import BaseAPITestCase
+
+
+class CourseAdminTestCase(BaseAPITestCase):
+    """Test suite for admin to manipulate courses."""
+
+    def test_admin_course_use_translatable_change_form_with_actions_template(self):
+        """
+        The course admin change view should use a custom change form template
+        to display both translation tabs of django parler and action buttons of
+        django object actions.
+        """
+        # Create a course
+        course = factories.CourseFactory()
+
+        # Login a user with all permission to manage courses in django admin
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        # Now we go to the course admin change view
+        with self.assertTemplateUsed(
+            "joanie/admin/translatable_change_form_with_actions.html"
+        ):
+            response = self.client.get(
+                reverse("admin:core_course_change", args=(course.pk,)),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, course.title)
+
+        html = lxml.html.fromstring(response.content)
+
+        # Django parler tabs should be displayed
+        parler_tabs = html.cssselect(".parler-language-tabs span")
+        self.assertEqual(len(parler_tabs), len(settings.LANGUAGES))
+
+        # Django object actions should be displayed
+        object_actions = html.cssselect(".objectaction-item")
+        self.assertEqual(len(object_actions), 1)
+        self.assertEqual(
+            object_actions[0].attrib["data-tool-name"], "generate_certificates"
+        )

--- a/src/backend/joanie/tests/test_admin_order.py
+++ b/src/backend/joanie/tests/test_admin_order.py
@@ -1,0 +1,36 @@
+"""
+Test suite for orders admin pages
+"""
+
+from unittest import mock
+
+from django.urls import reverse
+
+from joanie.core import factories, models
+
+from .base import BaseAPITestCase
+
+
+class OrderAdminTestCase(BaseAPITestCase):
+    """Test suite for admin to manipulate orders."""
+
+    @mock.patch.object(models.Order, "cancel")
+    def test_admin_order_action_cancel(self, mock_cancel):
+        """
+        Order admin should display an action to cancel an order which call
+        order.cancel method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        order = factories.OrderFactory()
+        self.client.login(username=user.username, password="password")
+        order_changelist_page = reverse("admin:core_order_changelist")
+        response = self.client.get(order_changelist_page)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Cancel selected orders")
+
+        # - Trigger "cancel" action
+        self.client.post(
+            order_changelist_page, {"action": "cancel", "_selected_action": order.pk}
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_cancel.assert_called_once_with()


### PR DESCRIPTION
## Purpose

In order to use both TranslatableAdmin with DjangoObjectActions, we have to use
a custom change form template which extends the change form provided by django
parler then add the block to append object actions.

### Before
<img width="783" alt="image" src="https://user-images.githubusercontent.com/9265241/181462712-af2f9945-e9f7-402e-8075-54111d30a282.png">

### After
<img width="663" alt="image" src="https://user-images.githubusercontent.com/9265241/181240096-7bd07db7-3f3b-4fe7-9d5d-91d40e1cfc09.png">

## Proposal

- [x] Create a custom template `joanie/admin/translatable_change_form_with_actions.html`
