### PR TITLE
🔧(tray/settings) add setting for CSRF trusted origins

### DIFF
--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -384,6 +384,7 @@ class Production(Base):
 
     # Security
     ALLOWED_HOSTS = values.ListValue(None)
+    CSRF_TRUSTED_ORIGINS = values.ListValue([])
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
 

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -275,10 +275,10 @@ class Base(Configuration):
         },
     }
 
-    # CORS headers
-    CORS_ALLOWED_ORIGINS = values.ListValue(
-        [], environ_name="CORS_ALLOWED_ORIGINS", environ_prefix=None
-    )
+    # CORS
+    CORS_ALLOW_ALL_ORIGINS = values.BooleanValue(False)
+    CORS_ALLOWED_ORIGINS = values.ListValue([])
+    CORS_ALLOWED_ORIGIN_REGEXES = values.ListValue([])
 
     # Sentry
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")

--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -75,6 +75,8 @@ spec:
               value: "{{ joanie_database_port }}"
             - name: DJANGO_ALLOWED_HOSTS
               value: "{{ joanie_host }}"
+            - name: DJANGO_CSRF_TRUSTED_ORIGINS
+              value: "{{ joanie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DJANGO_CONFIGURATION
               value: "{{ joanie_django_configuration }}"
             - name: DJANGO_SETTINGS_MODULE

--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -67,6 +67,8 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
           env:
+            - name: CORS_ALLOWED_ORIGINS
+              value: "{{ richie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DB_HOST
               value: "joanie-{{ joanie_database_host }}-{{ deployment_stamp }}"
             - name: DB_NAME
@@ -74,7 +76,7 @@ spec:
             - name: DB_PORT
               value: "{{ joanie_database_port }}"
             - name: DJANGO_ALLOWED_HOSTS
-              value: "{{ joanie_host }}"
+              value: "{{ joanie_host | blue_green_hosts }}"
             - name: DJANGO_CSRF_TRUSTED_ORIGINS
               value: "{{ joanie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DJANGO_CONFIGURATION

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -2,6 +2,7 @@
 
 # -- route
 joanie_host: "joanie.{{ namespace_name }}.{{ domain_name }}"
+richie_host: "richie.{{ namespace_name }}.{{ domain_name }}"
 
 # -- nginx
 joanie_nginx_image_name: "nginxinc/nginx-unprivileged"


### PR DESCRIPTION
## Purpose
This is a new setting in Django 4. It needs to be explicitly set to the origins from which we want to receive form posts.

## Proposal

- Add new setting for CSRF trusted origins
- Add new setting to configure CORS allowed origins
- Add environment variable in deploy manifest of Arnold tray to automatically define the CSRF trusted origins.
- Add environment variable in deploy manifest of Arnold tray to automatically define the CORS allowed origins.