### PR TITLE
🔧(tray) rename CORS_ALLOWED_ORIGINS into DJANGO_CORS_ALLOWED_ORIGINS

### DIFF
--- a/src/tray/templates/services/app/deploy.yml.j2
+++ b/src/tray/templates/services/app/deploy.yml.j2
@@ -67,8 +67,6 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 5
           env:
-            - name: CORS_ALLOWED_ORIGINS
-              value: "{{ richie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DB_HOST
               value: "joanie-{{ joanie_database_host }}-{{ deployment_stamp }}"
             - name: DB_NAME
@@ -81,6 +79,8 @@ spec:
               value: "{{ joanie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DJANGO_CONFIGURATION
               value: "{{ joanie_django_configuration }}"
+            - name: DJANGO_CORS_ALLOWED_ORIGINS
+              value: "{{ richie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DJANGO_SETTINGS_MODULE
               value: joanie.settings
           envFrom:


### PR DESCRIPTION
## Purpose

Django settings have been updated with new CORS variables which use `DJANGO`
prefix but before this prefix was not use. So we have to update the tray to
rename the environment variable `CORS_ALLOWED_ORIGINS` into
`DJANGO_CORS_ALLOWED_ORIGINS`.

## Proposal

- [x] rename CORS_ALLOWED_ORIGINS into DJANGO_CORS_ALLOWED_ORIGINS
