### PR TITLE
🐛(tray) specify ingress class name to use

### DIFF
--- a/src/tray/templates/services/nginx/ingress.yml.j2
+++ b/src/tray/templates/services/nginx/ingress.yml.j2
@@ -15,6 +15,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ joanie_ingress_class_name }}"
   rules:
   - host: "{{ joanie_host | blue_green_host(prefix) }}"
     http:

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -1,8 +1,9 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 joanie_host: "joanie.{{ namespace_name }}.{{ domain_name }}"
 richie_host: "richie.{{ namespace_name }}.{{ domain_name }}"
+joanie_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx
 joanie_nginx_image_name: "nginxinc/nginx-unprivileged"


### PR DESCRIPTION
## Purpose

To use the correct ingress controller, we have to specify in the ingress
spec wich one to use with the ingressClassName parameter set to nginx

## Proposal

- [x] specify ingress class name to use
