### PR TITLE
⬆️(deps) upgrade marion to version 0.4.0 and howard to version 0.3.0

### DIFF
--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -33,8 +33,8 @@ install_requires =
     django-cors-headers==3.13.0
     django-countries==7.3.2
     django-object-actions==4.0.0
-    django-marion==0.3.2
-    django-marion-howard==0.2.7
+    django-marion==0.4.0
+    django-marion-howard==0.3.0
     django-money==3.0.0
     django-parler==2.3
     djangorestframework==3.13.1


### PR DESCRIPTION
## Purpose

Currently, when we configure static files to be managed through whitenoise, document issued through howard templates are corrupted. We [fixed this problem](https://github.com/openfun/marion/pull/117) then release a new version of marion and howard. So now we have to upgrade those dependencies into Joanie.

## Proposal

- [x] Upgrade marion to version 0.4.0
- [x] Upgrade howard to version 0.3.0
