### PR TITLE
🔧(settings) make cache durations configurable

### DIFF
--- a/env.d/development/common
+++ b/env.d/development/common
@@ -7,7 +7,7 @@ DJANGO_ALLOWED_HOSTS=*
 PYTHONPATH=/app/src/backend
 
 # LMS BACKENDS
-# OpenEdX 
+# OpenEdX
 EDX_BASE_URL=http://edx:8073
 EDX_SELECTOR_REGEX=^.*/courses/(?P<course_id>.*)/course/?$
 EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/course/?$
@@ -18,6 +18,10 @@ EDX_BACKEND=joanie.lms_handler.backends.dummy.DummyLMSBackend
 DJANGO_JWT_PRIVATE_SIGNING_KEY=ThisIsAnExampleKeyForDevPurposeOnly
 
 # Joanie settings
+
+# Cache
+JOANIE_ANONYMOUS_COURSE_SERIALIZER_CACHE_TTL=3600
+JOANIE_ENROLLMENT_GRADE_CACHE_TTL=600
 
 # Payment Backend
 JOANIE_PAYMENT_BACKEND=joanie.payment.backends.dummy.DummyPaymentBackend

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -197,8 +197,12 @@ class Base(Configuration):
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
     }
 
-    JOANIE_ANONYMOUS_COURSE_SERIALIZER_CACHE_TTL = 3600  # 1 hour
-    JOANIE_ENROLLMENT_GRADE_CACHE_TTL = 600  # 10 minutes
+    JOANIE_ANONYMOUS_COURSE_SERIALIZER_CACHE_TTL = values.PositiveIntegerValue(
+        3600, environ_prefix=None
+    )  # 1 hour
+    JOANIE_ENROLLMENT_GRADE_CACHE_TTL = values.PositiveIntegerValue(
+        600, environ_prefix=None
+    )  # 10 minutes
 
     LANGUAGES = (
         ("en-us", _("English")),


### PR DESCRIPTION
## Purpose
We want to be able to configure cache durations through environment variables in order to customize then according to the deployment environment.

## Proposal

- [x] Make `JOANIE_ANONYMOUS_COURSE_SERIALIZER_CACHE_TTL` and `JOANIE_ENROLLMENT_GRADE_CACHE_TTL` configurable through environment variables.
