### PR TITLE
🐛(env.d) fix env compatibility issue with docker compose 2.7.0

### DIFF
--- a/env.d/development/common
+++ b/env.d/development/common
@@ -9,8 +9,8 @@ PYTHONPATH=/app/src/backend
 # LMS BACKENDS
 # OpenEdX
 EDX_BASE_URL=http://edx:8073
-EDX_SELECTOR_REGEX=^.*/courses/(?P<course_id>.*)/course/?$
-EDX_COURSE_REGEX=^.*/courses/(?P<course_id>.*)/course/?$
+EDX_SELECTOR_REGEX='^.*/courses/(?P<course_id>.*)/course/?$'
+EDX_COURSE_REGEX='^.*/courses/(?P<course_id>.*)/course/?$'
 EDX_API_TOKEN=FakeEdXAPIKey
 EDX_BACKEND=joanie.lms_handler.backends.dummy.DummyLMSBackend
 


### PR DESCRIPTION
## Purpose

Since docker compose 2.7.0, there is an "Invalid template" error when a
environment variable which is a regex is not quoted. This is the case of
`EDX_SELECTOR_REGEX` and `EDX_COURSE_REGEX`. So we quote those two variables.


## Proposal

- [x] Quote environment variables that are regex within env.d 
