### PR TITLE
Settings/env language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Configure language through environment variables
 - Send email when the payment is successful
 - Transform `mjml` files (email's template files) to html and plaintext
 - Add email settings and configure `mailcatcher` in docker-compose stack

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -104,13 +104,16 @@ class Base(Configuration):
     # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
     # Languages
-    LANGUAGE_CODE = "en-us"
+    LANGUAGE_CODE = values.Value("en-us", environ_name="LANGUAGE_CODE")
 
     # Careful! Languages should be ordered by priority, as this tuple is used to get
     # fallback/default languages throughout the app.
-    LANGUAGES = (
-        ("en-us", _("English")),
-        ("fr-fr", _("French")),
+    LANGUAGES = values.SingleNestedTupleValue(
+        (
+            ("en-us", _("English")),
+            ("fr-fr", _("French")),
+        ),
+        environ_name="LANGUAGES",
     )
 
     LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
@@ -459,13 +462,6 @@ class Production(Base):
 
     # Privacy
     SECURE_REFERRER_POLICY = "same-origin"
-
-    # Language
-    LANGUAGE_CODE = "fr-fr"
-    LANGUAGES = (
-        ("fr-fr", _("French")),
-        ("en-us", _("English")),
-    )
 
     # Media
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"

--- a/src/tray/templates/services/app/_env.yml.j2
+++ b/src/tray/templates/services/app/_env.yml.j2
@@ -1,1 +1,3 @@
 DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
+DJANGO_LANGUAGE_CODE: 'fr-fr'
+DJANGO_LANGUAGES: 'fr-fr,French;en-us,English'


### PR DESCRIPTION
## Purpose

We want to be able to configure language through environment variables.


## Proposal

- [x] Use django-configurations to set `LANGUAGE_CODE` & `LANGUAGES` settings through env variables
- [x] Update tray default env variables to use French as default language
