### PR TITLE
Feat/nested drf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add logo in organization serializer
 - Configure language through environment variables
 - Send email when the payment is successful
 - Transform `mjml` files (email's template files) to html and plaintext

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Enabling specifying returned fields for course endpoint
 - Delete nested orders from course endpoint
 - Add logo in organization serializer
 - Configure language through environment variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Delete nested orders from course endpoint
 - Add logo in organization serializer
 - Configure language through environment variables
 - Send email when the payment is successful

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to
 ### Added
 
 - Enabling specifying returned fields for course endpoint
-- Delete nested orders from course endpoint
 - Add logo in organization serializer
 - Configure language through environment variables
 - Send email when the payment is successful

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -41,6 +41,22 @@ def exception_handler(exc, context):
     return drf_exception_handler(exc, context)
 
 
+class DynamicGetFieldContext(viewsets.GenericViewSet):
+    """
+    Add query param fields to the context
+    """
+
+    def get_serializer_context(self):
+        """Add query param fields to the context"""
+        context = super().get_serializer_context()
+        if self.request.method == "GET":
+            query_fields = self.request.query_params.get("fields", None)
+            if query_fields:
+                context.update({"fields": query_fields.split(",")})
+
+        return context
+
+
 class Pagination(pagination.PageNumberPagination):
     """Pagination to display no more than 100 objects per page sorted by creation date."""
 
@@ -48,7 +64,7 @@ class Pagination(pagination.PageNumberPagination):
     page_size = 100
 
 
-class CourseViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+class CourseViewSet(mixins.RetrieveModelMixin, DynamicGetFieldContext):
     """API ViewSet for all interactions with courses."""
 
     lookup_field = "code"

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -30,8 +30,8 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Organization
-        fields = ["code", "title"]
-        read_only_fields = ["code", "title"]
+        fields = ["code", "title", "logo"]
+        read_only_fields = ["code", "title", "logo"]
 
 
 class TargetCourseSerializer(serializers.ModelSerializer):

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -187,62 +187,6 @@ class ProductSerializer(serializers.ModelSerializer):
         ).data
 
 
-class OrderLiteSerializer(serializers.ModelSerializer):
-    """
-    Minimal Order model serializer
-    """
-
-    id = serializers.CharField(read_only=True, source="uid")
-    total = MoneyField(
-        coerce_to_string=False,
-        decimal_places=2,
-        max_digits=9,
-        min_value=0,
-        read_only=True,
-    )
-    enrollments = serializers.SerializerMethodField(read_only=True)
-    product = serializers.SlugRelatedField(read_only=True, slug_field="uid")
-    main_proforma_invoice = serializers.SlugRelatedField(
-        read_only=True, slug_field="reference"
-    )
-    certificate = serializers.SlugRelatedField(read_only=True, slug_field="uid")
-
-    class Meta:
-        model = models.Order
-        fields = [
-            "id",
-            "certificate",
-            "created_on",
-            "main_proforma_invoice",
-            "total",
-            "total_currency",
-            "enrollments",
-            "product",
-            "state",
-        ]
-        read_only_fields = [
-            "id",
-            "certificate",
-            "created_on",
-            "main_proforma_invoice",
-            "total",
-            "total_currency",
-            "enrollments",
-            "product",
-            "state",
-        ]
-
-    def get_enrollments(self, order):
-        """
-        For the current order, retrieve its related enrollments.
-        """
-        return EnrollmentSerializer(
-            instance=order.get_enrollments(),
-            many=True,
-            context=self.context,
-        ).data
-
-
 class CourseSerializer(DynamicFieldsModelSerializer):
     """
     Serialize all information about a course.

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -2,7 +2,6 @@
 
 from django.conf import settings
 from django.core.cache import cache
-from django.db.models import Q
 
 from djmoney.contrib.django_rest_framework import MoneyField
 from rest_framework import serializers
@@ -245,24 +244,6 @@ class CourseSerializer(serializers.ModelSerializer):
             "products",
         ]
 
-    def get_orders(self, instance):
-        """
-        If a user is authenticated, retrieves its orders related to the serializer
-        Course instance else return None
-        """
-        try:
-            username = self.context["username"]
-            orders = models.Order.objects.filter(
-                Q(total=0) | Q(proforma_invoices__isnull=False),
-                owner__username=username,
-                course=instance,
-                is_canceled=False,
-            ).select_related("product")
-
-            return OrderLiteSerializer(orders, many=True).data
-        except KeyError:
-            return None
-
     def to_representation(self, instance):
         """
         Cache the serializer representation that does not vary from user to user
@@ -278,8 +259,6 @@ class CourseSerializer(serializers.ModelSerializer):
                 representation,
                 settings.JOANIE_ANONYMOUS_COURSE_SERIALIZER_CACHE_TTL,
             )
-
-        representation["orders"] = self.get_orders(instance)
 
         return representation
 

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -14,6 +14,8 @@ from joanie.tests.base import BaseAPITestCase
 class CourseApiTest(BaseAPITestCase):
     """Test the API of the Course object."""
 
+    test_media = "http://testserver/media/"
+
     def test_api_course_read_list_anonymous(self):
         """It should not be possible to retrieve the list of courses for anonymous users."""
         factories.CourseFactory()
@@ -97,12 +99,12 @@ class CourseApiTest(BaseAPITestCase):
         with self.assertNumQueries(11):
             response = self.client.get(f"/api/courses/{course.code}/")
 
-        content = json.loads(response.content)
         expected = {
             "code": course.code,
             "organization": {
                 "code": course.organization.code,
                 "title": course.organization.title,
+                "logo": f"{self.test_media}{course.organization.logo}",
             },
             "title": course.title,
             "orders": None,
@@ -119,6 +121,7 @@ class CourseApiTest(BaseAPITestCase):
                             "organization": {
                                 "code": target_course.organization.code,
                                 "title": target_course.organization.title,
+                                "logo": f"{self.test_media}{target_course.organization.logo}",
                             },
                             "course_runs": [
                                 {
@@ -172,7 +175,7 @@ class CourseApiTest(BaseAPITestCase):
         }
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(content, expected)
+        self.assertEqual(response.json(), expected)
 
         # - An other request should get the cached response
         with self.assertNumQueries(1):
@@ -317,12 +320,12 @@ class CourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        content = json.loads(response.content)
         expected = {
             "code": course.code,
             "organization": {
                 "code": course.organization.code,
                 "title": course.organization.title,
+                "logo": f"{self.test_media}{course.organization.logo}",
             },
             "title": course.title,
             "orders": [
@@ -394,6 +397,7 @@ class CourseApiTest(BaseAPITestCase):
                             "organization": {
                                 "code": target_course.organization.code,
                                 "title": target_course.organization.title,
+                                "logo": f"{self.test_media}{target_course.organization.logo}",
                             },
                             "course_runs": [
                                 {
@@ -447,7 +451,7 @@ class CourseApiTest(BaseAPITestCase):
         }
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(content, expected)
+        self.assertEqual(response.json(), expected)
 
         # - When user is authenticated, response should be partially cached.
         # Course information should have been cached, but orders not.


### PR DESCRIPTION
## Purpose

CourseSerializer nested orders to give direct access to
these data from the API call. This avoided the front to
do multiple distinct API calls. Nesting data is convenient
until it's not. To maintain a robust API we have decided to
keep the relations simples as much as possible. Orders will
now need to be called from another endpoint
A course can embed further data. As it implies adding queries,
we don't want them to be executed each time an API call on
`courses` is made. We add a filtering system that will allow the
front to ask for specific fields. Depending on how the API call
is done, results from the serializer will differ.


## Proposal

- add logo in the organization serializer.
- delete orders from CourseSerializer
- enabling filtering on API endpoint
