### PR TITLE
🔧(tests) fix the command make test-back

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ test: \
 .PHONY: test
 
 test-back: ## run back-end tests
-	bin/pytest -k test_api_enrollment_create_with_unknown_course_run
+	bin/pytest
 .PHONY: test-back
 
 migrate:  ## run django migrations for the joanie project.


### PR DESCRIPTION


## Purpose

Shortcuts of the make file enable us to speed up our development. A command has been changed by mistake that does the opposite. We restore the original command.

## Proposal

- fix the make test-back command line
