### PR TITLE
Dev/setup swagger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,7 @@ jobs:
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/joanie
+    resource_class: large
     environment:
       DJANGO_CONFIGURATION: ContinuousIntegration
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,8 @@ jobs:
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/joanie
+    environment:
+      DJANGO_CONFIGURATION: ContinuousIntegration
     steps:
       - checkout:
           path: ~/joanie
@@ -377,6 +379,7 @@ jobs:
             echo "joanie_image_name: ${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}/ci-joanie/joanie" >> ${VARS_FILE}
             echo "joanie_image_tag: ${CIRCLE_SHA1}" >> ${VARS_FILE}
             echo "joanie_app_replicas: 1" >> ${VARS_FILE}
+            echo "joanie_django_configuration: ${DJANGO_CONFIGURATION}" >> ${VARS_FILE}
       - run:
           name: Push joanie image to the k8s cluster docker registry
           command: |

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -9,7 +9,6 @@ https://docs.djangoproject.com/en/3.1/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.1/ref/settings/
 """
-
 import json
 import os
 
@@ -375,6 +374,23 @@ class Development(Base):
     CORS_ALLOW_ALL_ORIGINS = True
     DEBUG = True
     NGROK_ENDPOINT = values.Value(None, "NGROK_ENDPOINT", environ_prefix=None)
+
+    # Swagger security settings
+    # e.g: For API routes which requires a jwt token to authenticate user, you can
+    # fulfill this field with `Bearer <USER_JWT_TOKEN>`
+    SWAGGER_SETTINGS = {
+        "SECURITY_DEFINITIONS": {
+            "Bearer": {
+                "type": "apiKey",
+                "name": "Authorization",
+                "in": "header",
+            }
+        }
+    }
+
+    def __init__(self):
+        # pylint: disable=invalid-name
+        self.INSTALLED_APPS += ["drf_yasg"]
 
 
 class Test(Base):

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -65,10 +65,13 @@ exclude =
 dev =
     bandit==1.7.4
     black==22.10.0
+    cssselect==1.1.0
+    drf-yasg==1.21.4
     flake8==5.0.4
     ipdb==0.13.9
     ipython==8.5.0
     isort==5.10.1
+    lxml==4.9.1
     mypy==0.982
     pdfminer.six==20220524
     pyfakefs==5.0.0
@@ -79,8 +82,6 @@ dev =
     pytest==7.1.3
     responses==0.22.0
     types-requests==2.28.11.2
-    lxml==4.9.1
-    cssselect==1.1.0
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
## Purpose

In order to improve development experience, we want to set up swagger to watch api routes available and test them. The `drf_yasg` library fits this requirement so we installed then set up it.

<img width="1750" alt="Capture d’écran 2022-10-18 à 09 27 13" src="https://user-images.githubusercontent.com/9265241/196364683-56d591f2-2ad9-4c0d-9263-697da79b88a7.png">

## Proposal

- [x] Install drf_yasg
- [x] Set up swagger
