### PR TITLE
✨(api) add course runs and products endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Added
 
-- Add CourseRun API endpoint
+- Add CourseRun & Product API endpoints
 - Configure language through environment variables
 - Send email when the payment is successful
 - Transform `mjml` files (email's template files) to html and plaintext

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add CourseRun API endpoint
 - Configure language through environment variables
 - Send email when the payment is successful
 - Transform `mjml` files (email's template files) to html and plaintext

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -69,6 +69,15 @@ class CourseViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
         return context
 
 
+class CourseRunViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    """API ViewSet for all interactions with course runs."""
+
+    lookup_field = "id"
+    permissions_classes = [permissions.AllowAny]
+    queryset = models.CourseRun.objects.filter(is_listed=True)
+    serializer_class = serializers.CourseRunSerializer
+
+
 # pylint: disable=too-many-ancestors
 class EnrollmentViewSet(
     mixins.ListModelMixin,

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -78,6 +78,17 @@ class CourseRunViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = serializers.CourseRunSerializer
 
 
+class ProductViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    """API ViewSet for all interactions with products."""
+
+    lookup_field = "id"
+    permissions_classes = [permissions.AllowAny]
+    queryset = models.Product.objects.filter(courses__isnull=False).select_related(
+        "certificate_definition"
+    )
+    serializer_class = serializers.ProductSerializer
+
+
 # pylint: disable=too-many-ancestors
 class EnrollmentViewSet(
     mixins.ListModelMixin,

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -230,7 +230,7 @@ class ProductFactory(factory.django.DjangoModelFactory):
         - link the list of courses passed in "extracted" if any
         - otherwise create a random course and link it
         """
-        courses = extracted or [CourseFactory()]
+        courses = extracted if extracted is not None else [CourseFactory()]
         self.courses.set(courses)
 
     @factory.post_generation

--- a/src/backend/joanie/tests/core/test_api_course_run.py
+++ b/src/backend/joanie/tests/core/test_api_course_run.py
@@ -1,0 +1,281 @@
+"""Test suite for the CourseRun API"""
+from joanie.core import factories, models
+from joanie.tests.base import BaseAPITestCase
+
+
+class CourseRunApiTest(BaseAPITestCase):
+    """Test the API of the CourseRun resource."""
+
+    def test_api_course_run_read_list_anonymous(self):
+        """
+        It should not be possible to retrieve the list of course runs
+        for anonymous users.
+        """
+        factories.CourseRunFactory()
+
+        response = self.client.get("/api/course-runs/")
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+
+    def test_api_course_run_read_list_authenticated(self):
+        """
+        It should not be possible to retrieve the list of course runs
+        for authenticated users.
+        """
+        factories.CourseRunFactory()
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            "/api/course-runs/", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+
+    def test_api_course_run_read_detail(self):
+        """
+        Any users should be allowed to retrieve a course run with minimal db access.
+        """
+        course_run = factories.CourseRunFactory()
+
+        with self.assertNumQueries(1):
+            response = self.client.get(f"/api/course-runs/{course_run.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(course_run.id),
+                "resource_link": course_run.resource_link,
+                "title": course_run.title,
+                "state": {
+                    "priority": course_run.state["priority"],
+                    "datetime": course_run.state["datetime"]
+                    .isoformat()
+                    .replace("+00:00", "Z")
+                    if course_run.state["datetime"]
+                    else None,
+                    "call_to_action": course_run.state["call_to_action"],
+                    "text": course_run.state["text"],
+                },
+                "enrollment_start": course_run.enrollment_start.isoformat().replace(
+                    "+00:00", "Z"
+                ),
+                "enrollment_end": course_run.enrollment_end.isoformat().replace(
+                    "+00:00", "Z"
+                ),
+                "start": course_run.start.isoformat().replace("+00:00", "Z"),
+                "end": course_run.end.isoformat().replace("+00:00", "Z"),
+            },
+        )
+
+    def test_api_course_run_read_detail_not_listed_anonymous(self):
+        """
+        An anonymous user should not be allowed to retrieve a course run not listed.
+        """
+        course_run = factories.CourseRunFactory(is_listed=False)
+
+        response = self.client.get(f"/api/course-runs/{course_run.id}/")
+
+        self.assertContains(
+            response,
+            "Not found.",
+            status_code=404,
+        )
+
+    def test_api_course_run_read_detail_not_listed_authenticated(self):
+        """
+        An authenticated user should not be allowed to retrieve a course run not listed.
+        """
+        course_run = factories.CourseRunFactory(is_listed=False)
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            f"/api/course-runs/{course_run.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(
+            response,
+            "Not found.",
+            status_code=404,
+        )
+
+    def test_api_course_run_create_anonymous(self):
+        """Anonymous users should not be allowed to create a course run."""
+        course = factories.CourseFactory()
+        data = {
+            "resource_link": "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "course": course.id,
+        }
+
+        response = self.client.post("/api/course-runs/", data=data)
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+        self.assertEqual(models.CourseRun.objects.count(), 0)
+
+    def test_api_course_run_create_authenticated(self):
+        """Authenticated users should not be allowed to create a course run."""
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        course = factories.CourseFactory()
+        data = {
+            "resource_link": "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+            "course": course.id,
+        }
+
+        response = self.client.post(
+            "/api/course-runs/", data=data, HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+        self.assertEqual(models.CourseRun.objects.count(), 0)
+
+    def test_api_course_run_update_anonymous(self):
+        """Anonymous users should not be allowed to update a course run."""
+        course_run = factories.CourseRunFactory(
+            resource_link="https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        )
+        course = factories.CourseFactory()
+
+        data = {
+            "resource_link": "https://perdu.com",
+            "course": course.id,
+            "languages": ["en", "fr"],
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+        }
+
+        response = self.client.put(f"/api/course-runs/{course_run.id}/", data=data)
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        course_run.refresh_from_db()
+        self.assertEqual(
+            course_run.resource_link,
+            "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+        )
+
+    def test_api_course_run_update_authenticated(self):
+        """Authenticated users should not be allowed to update a course run."""
+        course_run = factories.CourseRunFactory(
+            resource_link="https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        )
+        course = factories.CourseFactory()
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        data = {
+            "resource_link": "https://perdu.com",
+            "course": course.id,
+            "languages": ["en", "fr"],
+            "start": "2020-12-09T09:31:59.417817Z",
+            "end": "2021-03-14T09:31:59.417895Z",
+            "enrollment_start": "2020-11-09T09:31:59.417936Z",
+            "enrollment_end": "2020-12-24T09:31:59.417972Z",
+        }
+
+        response = self.client.put(
+            f"/api/course-runs/{course_run.id}/",
+            data=data,
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        course_run.refresh_from_db()
+        self.assertEqual(
+            course_run.resource_link,
+            "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+        )
+
+    def test_api_course_run_partial_update_anonymous(self):
+        """Anonymous users should not be allowed to partially update a course run."""
+        course_run = factories.CourseRunFactory(
+            resource_link="https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        )
+
+        data = {
+            "resource_link": "https://perdu.com",
+        }
+
+        response = self.client.patch(f"/api/course-runs/{course_run.id}/", data=data)
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+        course_run.refresh_from_db()
+        self.assertEqual(
+            course_run.resource_link,
+            "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+        )
+
+    def test_api_course_run_partial_update_authenticated(self):
+        """Authenticated users should not be allowed to partially update a course run."""
+        course_run = factories.CourseRunFactory(
+            resource_link="https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
+        )
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        data = {
+            "resource_link": "https://perdu.com",
+        }
+
+        response = self.client.patch(
+            f"/api/course-runs/{course_run.id}/",
+            data=data,
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+        course_run.refresh_from_db()
+        self.assertEqual(
+            course_run.resource_link,
+            "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
+        )
+
+    def test_api_course_run_delete_anonymous(self):
+        """Anonymous users should not be allowed to delete a course run."""
+        course_run = factories.CourseRunFactory()
+
+        response = self.client.delete(f"/api/course-runs/{course_run.id}/")
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )
+        self.assertEqual(models.CourseRun.objects.count(), 1)
+
+    def test_api_course_run_delete_authenticated(self):
+        """Authenticated users should not be allowed to delete a course run."""
+        course_run = factories.CourseRunFactory()
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        response = self.client.delete(
+            f"/api/course-runs/{course_run.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )
+        self.assertEqual(models.CourseRun.objects.count(), 1)

--- a/src/backend/joanie/tests/core/test_api_products.py
+++ b/src/backend/joanie/tests/core/test_api_products.py
@@ -1,0 +1,287 @@
+"""Test suite for the Product API"""
+from joanie.core import enums, factories, models
+from joanie.tests.base import BaseAPITestCase
+
+
+class ProductApiTest(BaseAPITestCase):
+    """Test the API of the Product resource."""
+
+    def test_api_product_read_list_anonymous(self):
+        """
+        It should not be possible to retrieve the list of products for anonymous users.
+        """
+        factories.ProductFactory()
+
+        response = self.client.get("/api/products/")
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+
+    def test_api_product_read_list_authenticated(self):
+        """
+        It should not be possible to retrieve the list of products for authenticated users.
+        """
+        factories.ProductFactory()
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            "/api/products/", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+
+    def test_api_product_read_detail(self):
+        """
+        Any users should be allowed to retrieve a product with minimal db access.
+        """
+        product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CREDENTIAL)
+
+        with self.assertNumQueries(2):
+            response = self.client.get(f"/api/products/{product.id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "call_to_action": product.call_to_action,
+                "certificate": {
+                    "description": product.certificate_definition.description,
+                    "name": product.certificate_definition.name,
+                    "title": product.certificate_definition.title,
+                },
+                "id": str(product.id),
+                "price": float(product.price.amount),
+                "price_currency": str(product.price.currency),
+                "target_courses": [
+                    {
+                        "code": target_course.code,
+                        "organization": {
+                            "code": target_course.organization.code,
+                            "title": target_course.organization.title,
+                        },
+                        "course_runs": [
+                            {
+                                "id": course_run.id,
+                                "title": course_run.title,
+                                "resource_link": course_run.resource_link,
+                                "state": {
+                                    "priority": course_run.state["priority"],
+                                    "datetime": course_run.state["datetime"]
+                                    .isoformat()
+                                    .replace("+00:00", "Z"),
+                                    "call_to_action": course_run.state[
+                                        "call_to_action"
+                                    ],
+                                    "text": course_run.state["text"],
+                                },
+                                "start": course_run.start.isoformat().replace(
+                                    "+00:00", "Z"
+                                ),
+                                "end": course_run.end.isoformat().replace(
+                                    "+00:00", "Z"
+                                ),
+                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                    "+00:00", "Z"
+                                ),
+                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                    "+00:00", "Z"
+                                ),
+                            }
+                            for course_run in target_course.course_runs.all().order_by(
+                                "start"
+                            )
+                        ],
+                        "position": target_course.product_relations.get(
+                            product=product
+                        ).position,
+                        "is_graded": target_course.product_relations.get(
+                            product=product
+                        ).is_graded,
+                        "title": target_course.title,
+                    }
+                    for target_course in product.target_courses.all().order_by(
+                        "product_relations__position"
+                    )
+                ],
+                "title": product.title,
+                "type": product.type,
+            },
+        )
+
+    def test_api_product_read_detail_without_course_anonymous(self):
+        """
+        An anonymous user should not be allowed to retrieve a product linked to any course.
+        """
+        product = factories.ProductFactory(courses=[])
+        response = self.client.get(f"/api/products/{product.id}/")
+
+        self.assertContains(response, "Not found.", status_code=404)
+
+    def test_api_product_read_detail_without_course_authenticated(self):
+        """
+        An authenticated user should not be allowed to retrieve a product linked to any course.
+        """
+        product = factories.ProductFactory(courses=[])
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            f"/api/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(response, "Not found.", status_code=404)
+
+    def test_api_product_create_anonymous(self):
+        """Anonymous users should not be allowed to create a product."""
+        data = {
+            "type": "credential",
+            "price": 1337.00,
+            "price_currency": "EUR",
+            "title": "A lambda product",
+            "call_to_action": "Purchase now!",
+        }
+
+        response = self.client.post("/api/products/", data=data)
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+        self.assertEqual(models.Product.objects.count(), 0)
+
+    def test_api_product_create_authenticated(self):
+        """Authenticated users should not be allowed to create a product."""
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        data = {
+            "type": "credential",
+            "price": 1337.00,
+            "price_currency": "EUR",
+            "title": "A lambda product",
+            "call_to_action": "Purchase now!",
+        }
+
+        response = self.client.post(
+            "/api/products/", data=data, HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(
+            response,
+            "The requested resource was not found on this server.",
+            status_code=404,
+        )
+        self.assertEqual(models.Product.objects.count(), 0)
+
+    def test_api_product_update_anonymous(self):
+        """Anonymous users should not be allowed to update a product."""
+        product = factories.ProductFactory(price=100.0)
+
+        data = {
+            "type": "credential",
+            "price": 1337.00,
+            "price_currency": "EUR",
+            "title": "A lambda product",
+            "call_to_action": "Purchase now!",
+        }
+
+        response = self.client.put(f"/api/products/{product.id}/", data=data)
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        product.refresh_from_db()
+        self.assertEqual(product.price.amount, 100.0)
+
+    def test_api_product_update_authenticated(self):
+        """Authenticated users should not be allowed to update a product."""
+        product = factories.ProductFactory(price=100.0)
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        data = {
+            "type": "credential",
+            "price": 1337.00,
+            "price_currency": "EUR",
+            "title": "A lambda product",
+            "call_to_action": "Purchase now!",
+        }
+
+        response = self.client.put(
+            f"/api/products/{product.id}/",
+            data=data,
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        product.refresh_from_db()
+        self.assertEqual(product.price.amount, 100.0)
+
+    def test_api_product_partial_update_anonymous(self):
+        """Anonymous users should not be allowed to partially update a product."""
+        product = factories.ProductFactory(price=100.0)
+
+        data = {"price": 1337.00}
+
+        response = self.client.patch(f"/api/products/{product.id}/", data=data)
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+        product.refresh_from_db()
+        self.assertEqual(product.price.amount, 100.0)
+
+    def test_api_product_partial_update_authenticated(self):
+        """Authenticated users should not be allowed to partially update a product."""
+        product = factories.ProductFactory(price=100.0)
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        data = {
+            "price": 1337.00,
+        }
+
+        response = self.client.patch(
+            f"/api/products/{product.id}/",
+            data=data,
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+        product.refresh_from_db()
+        self.assertEqual(product.price.amount, 100.0)
+
+    def test_api_product_delete_anonymous(self):
+        """Anonymous users should not be allowed to delete a product."""
+        product = factories.ProductFactory()
+
+        response = self.client.delete(f"/api/products/{product.id}/")
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )
+        self.assertEqual(models.Product.objects.count(), 1)
+
+    def test_api_product_delete_authenticated(self):
+        """Authenticated users should not be allowed to delete a product."""
+        product = factories.ProductFactory()
+        user = factories.UserFactory.build()
+        token = self.get_user_token(user.username)
+
+        response = self.client.delete(
+            f"/api/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )
+        self.assertEqual(models.Product.objects.count(), 1)

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -37,6 +37,7 @@ router.register("courses", api.CourseViewSet, basename="courses")
 router.register("enrollments", api.EnrollmentViewSet, basename="enrollments")
 router.register("orders", api.OrderViewSet, basename="orders")
 router.register("course-runs", api.CourseRunViewSet, basename="course-runs")
+router.register("products", api.ProductViewSet, basename="products")
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -36,6 +36,7 @@ router.register("certificates", api.CertificateViewSet, basename="certificates")
 router.register("courses", api.CourseViewSet, basename="courses")
 router.register("enrollments", api.EnrollmentViewSet, basename="enrollments")
 router.register("orders", api.OrderViewSet, basename="orders")
+router.register("course-runs", api.CourseRunViewSet, basename="course-runs")
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
## Purpose

Richie must be able to retrieve course runs and products information through an API endpoint. Currently those endpoints do not exist, we have to create them.

#151

## Proposal

- [x] Add a `/course-runs` endpoints (read only)
- [x] Add a `/products` endpoints (read only)
