### PR TITLE
✨(all) version api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add api versioning
 - Add CourseRun & Product API endpoints
 - Configure language through environment variables
 - Send email when the payment is successful

--- a/src/backend/joanie/lms_handler/urls.py
+++ b/src/backend/joanie/lms_handler/urls.py
@@ -10,5 +10,5 @@ from .api import course_runs_sync
 ROUTER = routers.SimpleRouter()
 
 urlpatterns = ROUTER.urls + [
-    re_path("course-runs-sync/?$", course_runs_sync, name="course_run_sync"),
+    re_path("course-runs-sync/?$", course_runs_sync, name="course-runs-sync"),
 ]

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -239,6 +239,7 @@ class Base(Configuration):
             "rest_framework_simplejwt.authentication.JWTTokenUserAuthentication",
         ),
         "EXCEPTION_HANDLER": "joanie.core.api.exception_handler",
+        "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
     }
 
     SIMPLE_JWT = {

--- a/src/backend/joanie/tests/core/test_api_address.py
+++ b/src/backend/joanie/tests/core/test_api_address.py
@@ -33,7 +33,7 @@ class AddressAPITestCase(BaseAPITestCase):
     def test_api_address_get_addresses_without_authorization(self):
         """Get user addresses not allowed without HTTP AUTH"""
         # Try to get addresses without Authorization
-        response = self.client.get("/api/addresses/")
+        response = self.client.get("/api/v1.0/addresses/")
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
         self.assertEqual(
@@ -44,7 +44,7 @@ class AddressAPITestCase(BaseAPITestCase):
         """Get user addresses not allowed with bad user token"""
         # Try to get addresses with bad token
         response = self.client.get(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION="Bearer nawak",
         )
         self.assertEqual(response.status_code, 401)
@@ -59,7 +59,7 @@ class AddressAPITestCase(BaseAPITestCase):
             expires_at=arrow.utcnow().shift(days=-1).datetime,
         )
         response = self.client.get(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -72,7 +72,7 @@ class AddressAPITestCase(BaseAPITestCase):
         username = "panoramix"
         token = self.get_user_token(username)
         response = self.client.get(
-            "/api/addresses/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/addresses/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 200)
         addresses_data = response.data
@@ -86,7 +86,7 @@ class AddressAPITestCase(BaseAPITestCase):
         address1 = factories.AddressFactory.create(owner=user, title="Office")
         address2 = factories.AddressFactory.create(owner=user, title="Home")
         response = self.client.get(
-            "/api/addresses/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/addresses/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -107,7 +107,7 @@ class AddressAPITestCase(BaseAPITestCase):
         address = factories.AddressFactory.build()
 
         response = self.client.post(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             data=get_payload(address),
             content_type="application/json",
         )
@@ -125,7 +125,7 @@ class AddressAPITestCase(BaseAPITestCase):
         new_address = factories.AddressFactory.build()
 
         response = self.client.put(
-            f"/api/addresses/{address.id}",
+            f"/api/v1.0/addresses/{address.id}",
             data=get_payload(new_address),
             follow=True,
             content_type="application/json",
@@ -143,7 +143,7 @@ class AddressAPITestCase(BaseAPITestCase):
         address = factories.AddressFactory.build()
 
         response = self.client.post(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION="Bearer nawak",
             data=get_payload(address),
             content_type="application/json",
@@ -160,7 +160,7 @@ class AddressAPITestCase(BaseAPITestCase):
         new_address = factories.AddressFactory.build()
 
         response = self.client.put(
-            f"/api/addresses/{address.id}",
+            f"/api/v1.0/addresses/{address.id}",
             HTTP_AUTHORIZATION="Bearer nawak",
             data=get_payload(new_address),
             follow=True,
@@ -182,7 +182,7 @@ class AddressAPITestCase(BaseAPITestCase):
         address = factories.AddressFactory.build()
 
         response = self.client.post(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=get_payload(address),
             content_type="application/json",
@@ -204,7 +204,7 @@ class AddressAPITestCase(BaseAPITestCase):
         new_address = factories.AddressFactory.build()
 
         response = self.client.put(
-            f"/api/addresses/{address.id}",
+            f"/api/v1.0/addresses/{address.id}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=get_payload(new_address),
             follow=True,
@@ -224,7 +224,7 @@ class AddressAPITestCase(BaseAPITestCase):
         bad_payload["country"] = "FRANCE"
 
         response = self.client.post(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=bad_payload,
         )
@@ -237,7 +237,7 @@ class AddressAPITestCase(BaseAPITestCase):
         del bad_payload["title"]
         bad_payload["country"] = "FR"
         response = self.client.post(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=bad_payload,
             content_type="application/json",
@@ -256,7 +256,7 @@ class AddressAPITestCase(BaseAPITestCase):
 
         # Put request without address id should not be allowed
         response = self.client.put(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=payload,
             content_type="application/json",
@@ -267,7 +267,7 @@ class AddressAPITestCase(BaseAPITestCase):
         bad_payload["country"] = "FRANCE"
 
         response = self.client.put(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=bad_payload,
             content_type="application/json",
@@ -280,7 +280,7 @@ class AddressAPITestCase(BaseAPITestCase):
         del bad_payload["title"]
         bad_payload["country"] = "FR"
         response = self.client.put(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=bad_payload,
             content_type="application/json",
@@ -298,7 +298,7 @@ class AddressAPITestCase(BaseAPITestCase):
         # now use a token for an other user to update address
         token = self.get_user_token("panoramix")
         response = self.client.put(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=get_payload(new_address),
             content_type="application/json",
@@ -318,7 +318,7 @@ class AddressAPITestCase(BaseAPITestCase):
         payload["is_main"] = False
 
         response = self.client.put(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data=payload,
@@ -338,7 +338,7 @@ class AddressAPITestCase(BaseAPITestCase):
         payload = get_payload(address)
 
         response = self.client.post(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=payload,
             content_type="application/json",
@@ -358,7 +358,7 @@ class AddressAPITestCase(BaseAPITestCase):
         # finally update address
         payload["title"] = "Office"
         response = self.client.put(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=payload,
             content_type="application/json",
@@ -383,7 +383,7 @@ class AddressAPITestCase(BaseAPITestCase):
         payload["id"] = uuid.uuid4()
 
         response = self.client.post(
-            "/api/addresses/",
+            "/api/v1.0/addresses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=payload,
             content_type="application/json",
@@ -400,7 +400,7 @@ class AddressAPITestCase(BaseAPITestCase):
         payload["title"] = "Work"
 
         response = self.client.put(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data=payload,
             content_type="application/json",
@@ -416,7 +416,7 @@ class AddressAPITestCase(BaseAPITestCase):
         user = factories.UserFactory()
         address = factories.AddressFactory.create(owner=user, title="Office")
         response = self.client.delete(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
         )
         self.assertEqual(response.status_code, 401)
 
@@ -425,7 +425,7 @@ class AddressAPITestCase(BaseAPITestCase):
         user = factories.UserFactory()
         address = factories.AddressFactory.create(owner=user)
         response = self.client.delete(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION="Bearer nawak",
         )
         self.assertEqual(response.status_code, 401)
@@ -439,7 +439,7 @@ class AddressAPITestCase(BaseAPITestCase):
         )
         address = factories.AddressFactory.create(owner=user)
         response = self.client.delete(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 401)
@@ -451,7 +451,7 @@ class AddressAPITestCase(BaseAPITestCase):
         # now use a token for an other user to update address
         token = self.get_user_token("panoramix")
         response = self.client.delete(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 404)
@@ -462,7 +462,7 @@ class AddressAPITestCase(BaseAPITestCase):
         token = self.get_user_token(user.username)
         address = factories.AddressFactory.create(owner=user)
         response = self.client.delete(
-            f"/api/addresses/{address.id}/",
+            f"/api/v1.0/addresses/{address.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 204)

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -22,7 +22,7 @@ class CertificateApiTest(BaseAPITestCase):
     def test_api_certificate_read_list_anonymous(self):
         """It should not be possible to retrieve the list of certificates for anonymous user"""
         CertificateFactory.create_batch(2)
-        response = self.client.get("/api/certificates/")
+        response = self.client.get("/api/v1.0/certificates/")
 
         self.assertEqual(response.status_code, 401)
 
@@ -46,7 +46,7 @@ class CertificateApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.get(
-            "/api/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertEqual(response.status_code, 200)
@@ -60,7 +60,7 @@ class CertificateApiTest(BaseAPITestCase):
         """
         certificate = CertificateFactory()
 
-        response = self.client.get(f"/api/certificates/{certificate.id}/")
+        response = self.client.get(f"/api/v1.0/certificates/{certificate.id}/")
 
         self.assertEqual(response.status_code, 401)
 
@@ -85,7 +85,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         # - Try to retrieve a not owned certificate should return a 404
         response = self.client.get(
-            f"/api/certificates/{not_owned_certificate.id}/",
+            f"/api/v1.0/certificates/{not_owned_certificate.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -96,7 +96,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         # - Try to retrieve an owned certificate should return the certificate id
         response = self.client.get(
-            f"/api/certificates/{certificate.id}/",
+            f"/api/v1.0/certificates/{certificate.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -111,7 +111,7 @@ class CertificateApiTest(BaseAPITestCase):
         """
         certificate = CertificateFactory()
 
-        response = self.client.get(f"/api/certificates/{certificate.id}/download/")
+        response = self.client.get(f"/api/v1.0/certificates/{certificate.id}/download/")
 
         self.assertEqual(response.status_code, 401)
 
@@ -142,7 +142,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         # - Try to retrieve a not owned certificate should return a 404
         response = self.client.get(
-            f"/api/certificates/{not_owned_certificate.id}/download/",
+            f"/api/v1.0/certificates/{not_owned_certificate.id}/download/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -156,7 +156,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         # - Try to retrieve an owned certificate should return the certificate id
         response = self.client.get(
-            f"/api/certificates/{certificate.id}/download/",
+            f"/api/v1.0/certificates/{certificate.id}/download/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -177,7 +177,7 @@ class CertificateApiTest(BaseAPITestCase):
         user = UserFactory(is_staff=True, is_superuser=True)
         token = self.get_user_token(user.username)
         response = self.client.post(
-            "/api/certificates/",
+            "/api/v1.0/certificates/",
             {"id": uuid.uuid4()},
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -194,7 +194,7 @@ class CertificateApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
         certificate = CertificateFactory()
         response = self.client.put(
-            f"/api/certificates/{certificate.id}/",
+            f"/api/v1.0/certificates/{certificate.id}/",
             {"id": uuid.uuid4()},
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -211,7 +211,7 @@ class CertificateApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
         certificate = CertificateFactory()
         response = self.client.delete(
-            f"/api/certificates/{certificate.id}/",
+            f"/api/v1.0/certificates/{certificate.id}/",
             {"id": uuid.uuid4()},
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -19,7 +19,7 @@ class CourseApiTest(BaseAPITestCase):
         factories.CourseFactory()
 
         response = self.client.get(
-            "/api/courses/",
+            "/api/v1.0/courses/",
         )
 
         self.assertContains(
@@ -34,7 +34,7 @@ class CourseApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.get(
-            "/api/courses/",
+            "/api/v1.0/courses/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -95,7 +95,7 @@ class CourseApiTest(BaseAPITestCase):
                     )
 
         with self.assertNumQueries(11):
-            response = self.client.get(f"/api/courses/{course.code}/")
+            response = self.client.get(f"/api/v1.0/courses/{course.code}/")
 
         content = json.loads(response.content)
         expected = {
@@ -177,7 +177,7 @@ class CourseApiTest(BaseAPITestCase):
         # - An other request should get the cached response
         with self.assertNumQueries(1):
             self.client.get(
-                f"/api/courses/{course.code}/",
+                f"/api/v1.0/courses/{course.code}/",
             )
 
         # - But cache should rely on the current language
@@ -189,7 +189,7 @@ class CourseApiTest(BaseAPITestCase):
         expected_num_queries = 19 if product_purchased else 20
         with self.assertNumQueries(expected_num_queries):
             self.client.get(
-                f"/api/courses/{course.code}/",
+                f"/api/v1.0/courses/{course.code}/",
                 HTTP_ACCEPT_LANGUAGE="fr-fr",
             )
 
@@ -314,7 +314,7 @@ class CourseApiTest(BaseAPITestCase):
 
         with self.assertNumQueries(36):
             response = self.client.get(
-                f"/api/courses/{course.code}/",
+                f"/api/v1.0/courses/{course.code}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
@@ -458,7 +458,7 @@ class CourseApiTest(BaseAPITestCase):
         # Course information should have been cached, but orders not.
         with self.assertNumQueries(16):
             self.client.get(
-                f"/api/courses/{course.code}/",
+                f"/api/v1.0/courses/{course.code}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
@@ -504,7 +504,7 @@ class CourseApiTest(BaseAPITestCase):
         # - Retrieve course information
         with self.assertNumQueries(16):
             response = self.client.get(
-                f"/api/courses/{course.code}/",
+                f"/api/v1.0/courses/{course.code}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
@@ -563,7 +563,7 @@ class CourseApiTest(BaseAPITestCase):
         )
 
         response = self.client.get(
-            f"/api/courses/{course.code}/",
+            f"/api/v1.0/courses/{course.code}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -588,7 +588,7 @@ class CourseApiTest(BaseAPITestCase):
             "title": "mathématiques",
             "products": [p.id for p in products],
         }
-        response = self.client.post("/api/courses/", data=data)
+        response = self.client.post("/api/v1.0/courses/", data=data)
 
         self.assertContains(
             response,
@@ -609,7 +609,7 @@ class CourseApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/courses/",
+            "/api/v1.0/courses/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -625,7 +625,7 @@ class CourseApiTest(BaseAPITestCase):
         """Anonymous users should not be able to delete a course."""
         course = factories.CourseFactory()
 
-        response = self.client.delete(f"/api/courses/{course.id}/")
+        response = self.client.delete(f"/api/v1.0/courses/{course.id}/")
 
         self.assertEqual(response.status_code, 405)
         self.assertEqual(models.Course.objects.count(), 1)
@@ -636,7 +636,7 @@ class CourseApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.delete(
-            f"/api/courses/{course.id}/",
+            f"/api/v1.0/courses/{course.id}/",
             fHTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 405)
@@ -647,14 +647,14 @@ class CourseApiTest(BaseAPITestCase):
         course = factories.CourseFactory(code="initial_code")
 
         response = self.client.get(
-            f"/api/courses/{course.code}/",
+            f"/api/v1.0/courses/{course.code}/",
         )
         data = json.loads(response.content)
         data["code"] = "modified_code"
 
         # With POST method
         response = self.client.post(
-            f"/api/courses/{course.code}/",
+            f"/api/v1.0/courses/{course.code}/",
             content_type="application/json",
             data=data,
         )
@@ -665,7 +665,7 @@ class CourseApiTest(BaseAPITestCase):
 
         # With PUT method
         response = self.client.put(
-            f"/api/courses/{course.code}/",
+            f"/api/v1.0/courses/{course.code}/",
             content_type="application/json",
             data=data,
         )
@@ -684,14 +684,14 @@ class CourseApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.get(
-            f"/api/courses/{course.code}/",
+            f"/api/v1.0/courses/{course.code}/",
         )
         data = json.loads(response.content)
         data["code"] = "modified_code"
 
         # With POST method
         response = self.client.post(
-            f"/api/courses/{course.code}/",
+            f"/api/v1.0/courses/{course.code}/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -703,7 +703,7 @@ class CourseApiTest(BaseAPITestCase):
 
         # With PUT method
         response = self.client.put(
-            f"/api/courses/{course.code}/",
+            f"/api/v1.0/courses/{course.code}/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_course_run.py
+++ b/src/backend/joanie/tests/core/test_api_course_run.py
@@ -13,7 +13,7 @@ class CourseRunApiTest(BaseAPITestCase):
         """
         factories.CourseRunFactory()
 
-        response = self.client.get("/api/course-runs/")
+        response = self.client.get("/api/v1.0/course-runs/")
 
         self.assertContains(
             response,
@@ -31,7 +31,7 @@ class CourseRunApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.get(
-            "/api/course-runs/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/course-runs/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertContains(
@@ -47,7 +47,7 @@ class CourseRunApiTest(BaseAPITestCase):
         course_run = factories.CourseRunFactory()
 
         with self.assertNumQueries(1):
-            response = self.client.get(f"/api/course-runs/{course_run.id}/")
+            response = self.client.get(f"/api/v1.0/course-runs/{course_run.id}/")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -83,7 +83,7 @@ class CourseRunApiTest(BaseAPITestCase):
         """
         course_run = factories.CourseRunFactory(is_listed=False)
 
-        response = self.client.get(f"/api/course-runs/{course_run.id}/")
+        response = self.client.get(f"/api/v1.0/course-runs/{course_run.id}/")
 
         self.assertContains(
             response,
@@ -100,7 +100,8 @@ class CourseRunApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.get(
-            f"/api/course-runs/{course_run.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/course-runs/{course_run.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
         self.assertContains(
@@ -117,7 +118,7 @@ class CourseRunApiTest(BaseAPITestCase):
             "course": course.id,
         }
 
-        response = self.client.post("/api/course-runs/", data=data)
+        response = self.client.post("/api/v1.0/course-runs/", data=data)
 
         self.assertContains(
             response,
@@ -138,7 +139,7 @@ class CourseRunApiTest(BaseAPITestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs/", data=data, HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/course-runs/", data=data, HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertContains(
@@ -165,7 +166,7 @@ class CourseRunApiTest(BaseAPITestCase):
             "enrollment_end": "2020-12-24T09:31:59.417972Z",
         }
 
-        response = self.client.put(f"/api/course-runs/{course_run.id}/", data=data)
+        response = self.client.put(f"/api/v1.0/course-runs/{course_run.id}/", data=data)
 
         self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
         course_run.refresh_from_db()
@@ -194,7 +195,7 @@ class CourseRunApiTest(BaseAPITestCase):
         }
 
         response = self.client.put(
-            f"/api/course-runs/{course_run.id}/",
+            f"/api/v1.0/course-runs/{course_run.id}/",
             data=data,
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -216,7 +217,9 @@ class CourseRunApiTest(BaseAPITestCase):
             "resource_link": "https://perdu.com",
         }
 
-        response = self.client.patch(f"/api/course-runs/{course_run.id}/", data=data)
+        response = self.client.patch(
+            f"/api/v1.0/course-runs/{course_run.id}/", data=data
+        )
 
         self.assertContains(
             response, 'Method \\"PATCH\\" not allowed.', status_code=405
@@ -240,7 +243,7 @@ class CourseRunApiTest(BaseAPITestCase):
         }
 
         response = self.client.patch(
-            f"/api/course-runs/{course_run.id}/",
+            f"/api/v1.0/course-runs/{course_run.id}/",
             data=data,
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -258,7 +261,7 @@ class CourseRunApiTest(BaseAPITestCase):
         """Anonymous users should not be allowed to delete a course run."""
         course_run = factories.CourseRunFactory()
 
-        response = self.client.delete(f"/api/course-runs/{course_run.id}/")
+        response = self.client.delete(f"/api/v1.0/course-runs/{course_run.id}/")
 
         self.assertContains(
             response, 'Method \\"DELETE\\" not allowed.', status_code=405
@@ -272,7 +275,8 @@ class CourseRunApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.delete(
-            f"/api/course-runs/{course_run.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/course-runs/{course_run.id}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
         self.assertContains(

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -77,7 +77,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         factories.EnrollmentFactory(course_run=self.create_opened_course_run())
 
         response = self.client.get(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
         )
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
@@ -96,7 +96,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(enrollment.user.username)
 
         response = self.client.get(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -149,7 +149,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(other_enrollment.user.username)
 
         response = self.client.get(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -208,7 +208,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             course_run=self.create_opened_course_run(),
         )
 
-        response = self.client.get(f"/api/enrollments/{enrollment.id}/")
+        response = self.client.get(f"/api/v1.0/enrollments/{enrollment.id}/")
         self.assertEqual(response.status_code, 401)
 
         content = json.loads(response.content)
@@ -233,7 +233,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.get(
-            f"/api/enrollments/{enrollment.id}/",
+            f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -279,7 +279,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.get(
-            f"/api/enrollments/{enrollment.id}/",
+            f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 404)
@@ -294,7 +294,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             "course_run": course_run.resource_link,
         }
         response = self.client.post(
-            "/api/enrollments/", data=data, content_type="application/json"
+            "/api/v1.0/enrollments/", data=data, content_type="application/json"
         )
         self.assertEqual(response.status_code, 401)
 
@@ -317,7 +317,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -389,7 +389,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -421,7 +421,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -488,7 +488,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -543,7 +543,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -583,7 +583,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(order.owner.username)
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -642,7 +642,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("another-username")
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -680,7 +680,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(order.owner.username)
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -707,7 +707,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -743,7 +743,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data=data,
@@ -801,7 +801,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         data = {"course_run": course_run.resource_link, "is_active": True}
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -825,7 +825,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         data = {"course_run": "this-course-run-does-not-exist", "is_active": True}
 
         response = self.client.post(
-            "/api/enrollments/",
+            "/api/v1.0/enrollments/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -851,7 +851,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             course_run=self.create_opened_course_run()
         )
 
-        response = self.client.delete(f"/api/enrollments/{enrollment.id}/")
+        response = self.client.delete(f"/api/v1.0/enrollments/{enrollment.id}/")
 
         self.assertEqual(response.status_code, 401)
 
@@ -878,7 +878,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.delete(
-            f"/api/enrollments/{enrollment.id}/",
+            f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 405)
@@ -892,7 +892,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(enrollment.user.username)
 
         response = self.client.delete(
-            f"/api/enrollments/{enrollment.id}/",
+            f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 405)
@@ -919,7 +919,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             )
 
             response = self.client.patch(
-                f"/api/enrollments/{enrollment.id}/",
+                f"/api/v1.0/enrollments/{enrollment.id}/",
                 data={"state": new_state[0]},
                 content_type="application/json",
             )
@@ -957,7 +957,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             )
 
             response = self.client.patch(
-                f"/api/enrollments/{enrollment.id}/",
+                f"/api/v1.0/enrollments/{enrollment.id}/",
                 data={"is_active": is_active_new},
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -988,7 +988,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             token = self.get_user_token(enrollment.user.username)
 
             response = self.client.patch(
-                f"/api/enrollments/{enrollment.id}/",
+                f"/api/v1.0/enrollments/{enrollment.id}/",
                 data={"is_active": is_active_new},
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -1038,7 +1038,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         user_token = self.get_user_token(enrollment.user.username)
 
         response = self.client.get(
-            f"/api/enrollments/{enrollment.id}/",
+            f"/api/v1.0/enrollments/{enrollment.id}/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {user_token}",
         )
@@ -1068,7 +1068,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         response = self.client.patch(
-            f"/api/enrollments/{enrollment.id}/",
+            f"/api/v1.0/enrollments/{enrollment.id}/",
             data=new_data,
             content_type="application/json",
             **headers,
@@ -1078,7 +1078,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         # Check that nothing was modified
         self.assertEqual(models.Enrollment.objects.count(), 1)
         response = self.client.get(
-            f"/api/enrollments/{enrollment.id}/",
+            f"/api/v1.0/enrollments/{enrollment.id}/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {user_token}",
         )

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -35,7 +35,7 @@ class OrderApiTest(BaseAPITestCase):
         factories.OrderFactory(product=product)
 
         response = self.client.get(
-            "/api/orders/",
+            "/api/v1.0/orders/",
         )
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
@@ -54,7 +54,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(order.owner.username)
 
         response = self.client.get(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -91,7 +91,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(other_order.owner.username)
 
         response = self.client.get(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -129,7 +129,7 @@ class OrderApiTest(BaseAPITestCase):
         product = factories.ProductFactory()
         order = factories.OrderFactory(product=product)
 
-        response = self.client.get(f"/api/orders/{order.id}/")
+        response = self.client.get(f"/api/v1.0/orders/{order.id}/")
         self.assertEqual(response.status_code, 401)
 
         content = json.loads(response.content)
@@ -147,7 +147,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.generate_token_from_user(owner)
 
         response = self.client.get(
-            f"/api/orders/{order.id}/",
+            f"/api/v1.0/orders/{order.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
@@ -180,7 +180,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.get(
-            f"/api/orders/{order.id}/",
+            f"/api/v1.0/orders/{order.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 404)
@@ -196,7 +196,7 @@ class OrderApiTest(BaseAPITestCase):
             "product": str(product.id),
         }
         response = self.client.post(
-            "/api/orders/", data=data, content_type="application/json"
+            "/api/v1.0/orders/", data=data, content_type="application/json"
         )
         self.assertEqual(response.status_code, 401)
 
@@ -222,7 +222,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -283,7 +283,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -334,7 +334,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -355,7 +355,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token("panoramix")
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -386,7 +386,7 @@ class OrderApiTest(BaseAPITestCase):
         data = {"product": str(product.id), "course": course.code}
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -405,7 +405,7 @@ class OrderApiTest(BaseAPITestCase):
         order.cancel()
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -427,7 +427,7 @@ class OrderApiTest(BaseAPITestCase):
         data = {"product": str(product.id), "course": course.code}
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -462,7 +462,7 @@ class OrderApiTest(BaseAPITestCase):
         }
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -493,7 +493,7 @@ class OrderApiTest(BaseAPITestCase):
                 "payment_info": {
                     "payment_id": f"pay_{order.id}",
                     "provider": "dummy",
-                    "url": "http://testserver/api/payments/notifications",
+                    "url": "http://testserver/api/v1.0/payments/notifications",
                 },
             },
         )
@@ -526,7 +526,7 @@ class OrderApiTest(BaseAPITestCase):
         }
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -558,7 +558,7 @@ class OrderApiTest(BaseAPITestCase):
                 "payment_info": {
                     "payment_id": f"pay_{order.id}",
                     "provider": "dummy",
-                    "url": "http://testserver/api/payments/notifications",
+                    "url": "http://testserver/api/v1.0/payments/notifications",
                     "is_paid": True,
                 },
             },
@@ -583,7 +583,7 @@ class OrderApiTest(BaseAPITestCase):
         }
 
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -600,7 +600,7 @@ class OrderApiTest(BaseAPITestCase):
         product = factories.ProductFactory()
         order = factories.OrderFactory(product=product)
 
-        response = self.client.delete(f"/api/orders/{order.id}/")
+        response = self.client.delete(f"/api/v1.0/orders/{order.id}/")
 
         self.assertEqual(response.status_code, 401)
 
@@ -626,7 +626,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.generate_token_from_user(user)
 
         response = self.client.delete(
-            f"/api/orders/{order.id}/",
+            f"/api/v1.0/orders/{order.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 405)
@@ -639,7 +639,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(order.owner.username)
 
         response = self.client.delete(
-            f"/api/orders/{order.id}/",
+            f"/api/v1.0/orders/{order.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 405)
@@ -651,7 +651,7 @@ class OrderApiTest(BaseAPITestCase):
         owner_token = self.generate_token_from_user(order.owner)
 
         response = self.client.get(
-            f"/api/orders/{order.id}/",
+            f"/api/v1.0/orders/{order.id}/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {owner_token}",
         )
@@ -666,7 +666,7 @@ class OrderApiTest(BaseAPITestCase):
         other_owner_token = self.get_user_token(other_owner.username)
 
         other_response = self.client.get(
-            f"/api/orders/{other_order.id}/",
+            f"/api/v1.0/orders/{other_order.id}/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {other_owner_token}",
         )
@@ -702,7 +702,7 @@ class OrderApiTest(BaseAPITestCase):
             # With full object
             data[field] = other_data[field]
             response = self.client.put(
-                f"/api/orders/{order.id}/",
+                f"/api/v1.0/orders/{order.id}/",
                 data=data,
                 content_type="application/json",
                 **headers,
@@ -711,7 +711,7 @@ class OrderApiTest(BaseAPITestCase):
 
             # With partial object
             response = self.client.patch(
-                f"/api/orders/{order.id}/",
+                f"/api/v1.0/orders/{order.id}/",
                 data={field: other_data[field]},
                 content_type="application/json",
                 **headers,
@@ -721,7 +721,7 @@ class OrderApiTest(BaseAPITestCase):
             # Check that nothing was modified
             self.assertEqual(models.Order.objects.count(), 2)
             response = self.client.get(
-                f"/api/orders/{order.id}/",
+                f"/api/v1.0/orders/{order.id}/",
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {owner_token}",
             )
@@ -757,7 +757,7 @@ class OrderApiTest(BaseAPITestCase):
 
         response = self.client.get(
             (
-                f"/api/orders/{proforma_invoice.order.id}/proforma_invoice/"
+                f"/api/v1.0/orders/{proforma_invoice.order.id}/proforma_invoice/"
                 f"?reference={proforma_invoice.reference}"
             ),
         )
@@ -778,7 +778,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(proforma_invoice.order.owner.username)
 
         response = self.client.get(
-            f"/api/orders/{proforma_invoice.order.id}/proforma_invoice/",
+            f"/api/v1.0/orders/{proforma_invoice.order.id}/proforma_invoice/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -797,7 +797,10 @@ class OrderApiTest(BaseAPITestCase):
         token = self.generate_token_from_user(user)
 
         response = self.client.get(
-            f"/api/orders/{order.id}/proforma_invoice/?reference={proforma_invoice.reference}",
+            (
+                f"/api/v1.0/orders/{order.id}/proforma_invoice/"
+                f"?reference={proforma_invoice.reference}"
+            ),
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -822,7 +825,7 @@ class OrderApiTest(BaseAPITestCase):
 
         response = self.client.get(
             (
-                f"/api/orders/{proforma_invoice.order.id}/proforma_invoice/"
+                f"/api/v1.0/orders/{proforma_invoice.order.id}/proforma_invoice/"
                 f"?reference={proforma_invoice.reference}"
             ),
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -848,7 +851,7 @@ class OrderApiTest(BaseAPITestCase):
 
         response = self.client.get(
             (
-                f"/api/orders/{proforma_invoice.order.id}/proforma_invoice/"
+                f"/api/v1.0/orders/{proforma_invoice.order.id}/proforma_invoice/"
                 f"?reference={proforma_invoice.reference}"
             ),
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -868,7 +871,7 @@ class OrderApiTest(BaseAPITestCase):
         """An anonymous user should not be allowed to abort an order"""
         order = factories.OrderFactory()
 
-        response = self.client.post(f"/api/orders/{order.id}/abort/")
+        response = self.client.post(f"/api/v1.0/orders/{order.id}/abort/")
 
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 401)
@@ -886,7 +889,7 @@ class OrderApiTest(BaseAPITestCase):
 
         token = self.generate_token_from_user(user)
         response = self.client.post(
-            f"/api/orders/{order.id}/abort/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/orders/{order.id}/abort/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         content = json.loads(response.content)
@@ -906,7 +909,7 @@ class OrderApiTest(BaseAPITestCase):
 
         token = self.generate_token_from_user(user)
         response = self.client.post(
-            f"/api/orders/{order.id}/abort/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/orders/{order.id}/abort/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         content = json.loads(response.content)
@@ -937,7 +940,7 @@ class OrderApiTest(BaseAPITestCase):
             "billing_address": billing_address,
         }
         response = self.client.post(
-            "/api/orders/",
+            "/api/v1.0/orders/",
             data=data,
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -956,7 +959,7 @@ class OrderApiTest(BaseAPITestCase):
 
         # - User asks to abort the order
         response = self.client.post(
-            f"/api/orders/{order.id}/abort/",
+            f"/api/v1.0/orders/{order.id}/abort/",
             data={"payment_id": payment_id},
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_products.py
+++ b/src/backend/joanie/tests/core/test_api_products.py
@@ -12,7 +12,7 @@ class ProductApiTest(BaseAPITestCase):
         """
         factories.ProductFactory()
 
-        response = self.client.get("/api/products/")
+        response = self.client.get("/api/v1.0/products/")
 
         self.assertContains(
             response,
@@ -29,7 +29,7 @@ class ProductApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.get(
-            "/api/products/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/products/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertContains(
@@ -45,7 +45,7 @@ class ProductApiTest(BaseAPITestCase):
         product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CREDENTIAL)
 
         with self.assertNumQueries(2):
-            response = self.client.get(f"/api/products/{product.id}/")
+            response = self.client.get(f"/api/v1.0/products/{product.id}/")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -121,7 +121,7 @@ class ProductApiTest(BaseAPITestCase):
         An anonymous user should not be allowed to retrieve a product linked to any course.
         """
         product = factories.ProductFactory(courses=[])
-        response = self.client.get(f"/api/products/{product.id}/")
+        response = self.client.get(f"/api/v1.0/products/{product.id}/")
 
         self.assertContains(response, "Not found.", status_code=404)
 
@@ -134,7 +134,7 @@ class ProductApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.get(
-            f"/api/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertContains(response, "Not found.", status_code=404)
@@ -149,7 +149,7 @@ class ProductApiTest(BaseAPITestCase):
             "call_to_action": "Purchase now!",
         }
 
-        response = self.client.post("/api/products/", data=data)
+        response = self.client.post("/api/v1.0/products/", data=data)
 
         self.assertContains(
             response,
@@ -172,7 +172,7 @@ class ProductApiTest(BaseAPITestCase):
         }
 
         response = self.client.post(
-            "/api/products/", data=data, HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/products/", data=data, HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertContains(
@@ -194,7 +194,7 @@ class ProductApiTest(BaseAPITestCase):
             "call_to_action": "Purchase now!",
         }
 
-        response = self.client.put(f"/api/products/{product.id}/", data=data)
+        response = self.client.put(f"/api/v1.0/products/{product.id}/", data=data)
 
         self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
         product.refresh_from_db()
@@ -215,7 +215,7 @@ class ProductApiTest(BaseAPITestCase):
         }
 
         response = self.client.put(
-            f"/api/products/{product.id}/",
+            f"/api/v1.0/products/{product.id}/",
             data=data,
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -230,7 +230,7 @@ class ProductApiTest(BaseAPITestCase):
 
         data = {"price": 1337.00}
 
-        response = self.client.patch(f"/api/products/{product.id}/", data=data)
+        response = self.client.patch(f"/api/v1.0/products/{product.id}/", data=data)
 
         self.assertContains(
             response, 'Method \\"PATCH\\" not allowed.', status_code=405
@@ -249,7 +249,7 @@ class ProductApiTest(BaseAPITestCase):
         }
 
         response = self.client.patch(
-            f"/api/products/{product.id}/",
+            f"/api/v1.0/products/{product.id}/",
             data=data,
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -264,7 +264,7 @@ class ProductApiTest(BaseAPITestCase):
         """Anonymous users should not be allowed to delete a product."""
         product = factories.ProductFactory()
 
-        response = self.client.delete(f"/api/products/{product.id}/")
+        response = self.client.delete(f"/api/v1.0/products/{product.id}/")
 
         self.assertContains(
             response, 'Method \\"DELETE\\" not allowed.', status_code=405
@@ -278,7 +278,7 @@ class ProductApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         response = self.client.delete(
-            f"/api/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertContains(

--- a/src/backend/joanie/tests/lms_handler/test_api_course_run_sync_edx.py
+++ b/src/backend/joanie/tests/lms_handler/test_api_course_run_sync_edx.py
@@ -39,7 +39,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync", data, content_type="application/json"
+            "/api/v1.0/course-runs-sync", data, content_type="application/json"
         )
 
         self.assertEqual(response.status_code, 403)
@@ -59,7 +59,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=("invalid authorization"),
@@ -84,7 +84,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -115,7 +115,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -153,7 +153,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -184,7 +184,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -214,7 +214,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -242,7 +242,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -278,7 +278,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -309,7 +309,7 @@ class SyncCourseRunApiTestCase(TestCase):
         data = {"resource_link": link, "end": "2021-03-14T09:31:59.417895Z"}
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(
@@ -363,7 +363,7 @@ class SyncCourseRunApiTestCase(TestCase):
         }
 
         response = self.client.post(
-            "/api/course-runs-sync",
+            "/api/v1.0/course-runs-sync",
             data,
             content_type="application/json",
             HTTP_AUTHORIZATION=(

--- a/src/backend/joanie/tests/payment/test_api_credit_card.py
+++ b/src/backend/joanie/tests/payment/test_api_credit_card.py
@@ -17,7 +17,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
 
     def test_api_credit_card_get_credit_cards_without_authorization(self):
         """Retrieve credit cards without authorization header is forbidden."""
-        response = self.client.get("/api/credit-cards/")
+        response = self.client.get("/api/v1.0/credit-cards/")
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
             response.data, {"detail": "Authentication credentials were not provided."}
@@ -26,7 +26,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_get_credit_cards_with_bad_token(self):
         """Retrieve credit cards with bad token is forbidden."""
         response = self.client.get(
-            "/api/credit-cards/", HTTP_AUTHORIZATION="Bearer invalid_token"
+            "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION="Bearer invalid_token"
         )
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data["code"], "token_not_valid")
@@ -38,7 +38,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             expires_at=arrow.utcnow().shift(days=-1).datetime,
         )
         response = self.client.get(
-            "/api/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.data["code"], "token_not_valid")
@@ -52,7 +52,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         self.assertFalse(User.objects.filter(username=username).exists())
         token = self.get_user_token(username)
         response = self.client.get(
-            "/api/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
@@ -65,7 +65,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         CreditCardFactory.create_batch(2, owner=user)
 
         response = self.client.get(
-            "/api/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
@@ -77,7 +77,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         card = CreditCardFactory(owner=user)
 
         response = self.client.get(
-            f"/api/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 200)
 
@@ -102,7 +102,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         card = CreditCardFactory.build(owner=user)
 
         response = self.client.get(
-            f"/api/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 404)
 
@@ -116,7 +116,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         card = CreditCardFactory()
 
         response = self.client.get(
-            f"/api/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            f"/api/v1.0/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
         self.assertEqual(response.status_code, 404)
 
@@ -124,7 +124,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         """Create a credit card is not allowed."""
         token = self.get_user_token("johndoe")
         response = self.client.post(
-            "/api/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
         self.assertEqual(response.status_code, 405)
@@ -133,7 +133,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         """Update a credit card without authorization header is forbidden."""
         card = CreditCardFactory()
         response = self.client.put(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             content_type="application/json",
             data={"title": "Card title updated"},
         )
@@ -149,7 +149,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         )
         card = CreditCardFactory(owner=user)
         response = self.client.put(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data={"title": "Card title updated"},
@@ -165,7 +165,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         token = self.get_user_token(username=user.username)
         card = CreditCardFactory(owner=user)
         response = self.client.put(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data=[],
@@ -187,7 +187,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         token = self.get_user_token(username=user.username)
         card = CreditCardFactory()
         response = self.client.put(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data={"title": "Credit card title updated!"},
@@ -201,7 +201,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         token = self.get_user_token(username=user.username)
         card = CreditCardFactory(owner=user)
         response = self.client.put(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data={"is_main": False},
@@ -220,7 +220,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         token = self.get_user_token(username=user.username)
         main_card, card = CreditCardFactory.create_batch(2, owner=user)
         response = self.client.put(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data={"is_main": True},
@@ -248,7 +248,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         token = self.get_user_token(username=user.username)
         card = CreditCardFactory(owner=user)
         response = self.client.put(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             content_type="application/json",
             data={
@@ -274,7 +274,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_delete_without_authorization(self):
         """Delete credit card without authorization header is forbidden."""
         card = CreditCardFactory()
-        response = self.client.delete(f"/api/credit-cards/{card.id}/")
+        response = self.client.delete(f"/api/v1.0/credit-cards/{card.id}/")
 
         self.assertEqual(response.status_code, 401)
 
@@ -282,7 +282,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         """Delete credit card with invalid authorization header is forbidden."""
         card = CreditCardFactory()
         response = self.client.delete(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION="Bearer invalid-token",
         )
 
@@ -296,7 +296,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         )
         card = CreditCardFactory()
         response = self.client.delete(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -307,7 +307,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         token = self.get_user_token("johndoe")
         card = CreditCardFactory()
         response = self.client.delete(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -325,7 +325,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         token = self.get_user_token(user.username)
         card = CreditCardFactory(owner=user)
         response = self.client.delete(
-            f"/api/credit-cards/{card.id}/",
+            f"/api/v1.0/credit-cards/{card.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 

--- a/src/backend/joanie/tests/payment/test_api_payment.py
+++ b/src/backend/joanie/tests/payment/test_api_payment.py
@@ -27,7 +27,7 @@ class PaymentApiTestCase(BaseAPITestCase):
         )
 
         response = self.client.post(
-            "/api/payments/notifications",
+            "/api/v1.0/payments/notifications",
             content_type="application/json",
             data={"id": "pay_0000"},
         )
@@ -44,7 +44,7 @@ class PaymentApiTestCase(BaseAPITestCase):
         """
 
         response = self.client.post(
-            "/api/payments/notifications",
+            "/api/v1.0/payments/notifications",
             content_type="application/json",
             data={"id": "pay_0000"},
         )

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -230,7 +230,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         request = APIRequestFactory().post(path="/")
         self.assertEqual(
             backend.get_notification_url(request),
-            "http://testserver/api/payments/notifications",
+            "http://testserver/api/v1.0/payments/notifications",
         )
 
     @mock.patch(

--- a/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
+++ b/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
@@ -64,7 +64,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):
             {
                 "provider": "dummy",
                 "payment_id": payment_id,
-                "url": "http://testserver/api/payments/notifications",
+                "url": "http://testserver/api/v1.0/payments/notifications",
             },
         )
 
@@ -75,7 +75,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):
                 "id": payment_id,
                 "amount": int(order.total.amount * 100),
                 "billing_address": billing_address,
-                "notification_url": "http://testserver/api/payments/notifications",
+                "notification_url": "http://testserver/api/v1.0/payments/notifications",
                 "metadata": {"order_id": str(order.id)},
             },
         )
@@ -119,7 +119,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):
             {
                 "provider": "dummy",
                 "payment_id": payment_id,
-                "url": "http://testserver/api/payments/notifications",
+                "url": "http://testserver/api/v1.0/payments/notifications",
                 "is_paid": True,
             },
         )
@@ -132,7 +132,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):
                 "id": payment_id,
                 "amount": int(order.total.amount * 100),
                 "billing_address": billing_address,
-                "notification_url": "http://testserver/api/payments/notifications",
+                "notification_url": "http://testserver/api/v1.0/payments/notifications",
                 "metadata": {"order_id": str(order.id)},
             },
         )

--- a/src/backend/joanie/tests/payment/test_backend_payplug.py
+++ b/src/backend/joanie/tests/payment/test_backend_payplug.py
@@ -86,7 +86,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
                     "country": billing_address["country"],
                 },
                 "shipping": {"delivery_type": "DIGITAL_GOODS"},
-                "notification_url": "http://testserver/api/payments/notifications",
+                "notification_url": "http://testserver/api/v1.0/payments/notifications",
                 "metadata": {"order_id": str(order.id)},
             },
         )
@@ -141,7 +141,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
                     "country": billing_address["country"],
                 },
                 "shipping": {"delivery_type": "DIGITAL_GOODS"},
-                "notification_url": "http://testserver/api/payments/notifications",
+                "notification_url": "http://testserver/api/v1.0/payments/notifications",
                 "metadata": {"order_id": str(order.id)},
             }
         )
@@ -197,7 +197,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
                     "country": billing_address["country"],
                 },
                 "shipping": {"delivery_type": "DIGITAL_GOODS"},
-                "notification_url": "http://testserver/api/payments/notifications",
+                "notification_url": "http://testserver/api/v1.0/payments/notifications",
                 "metadata": {"order_id": str(order.id)},
             }
         )
@@ -257,7 +257,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
                     "country": billing_address["country"],
                 },
                 "shipping": {"delivery_type": "DIGITAL_GOODS"},
-                "notification_url": "http://testserver/api/payments/notifications",
+                "notification_url": "http://testserver/api/v1.0/payments/notifications",
                 "metadata": {"order_id": str(order.id)},
             }
         )
@@ -309,7 +309,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
                     "country": billing_address["country"],
                 },
                 "shipping": {"delivery_type": "DIGITAL_GOODS"},
-                "notification_url": "http://testserver/api/payments/notifications",
+                "notification_url": "http://testserver/api/v1.0/payments/notifications",
                 "metadata": {"order_id": str(order.id)},
             }
         )

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -39,9 +39,14 @@ router.register("orders", api.OrderViewSet, basename="orders")
 router.register("course-runs", api.CourseRunViewSet, basename="course-runs")
 router.register("products", api.ProductViewSet, basename="products")
 
+API_VERSION = "v1.0"
+
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/", include([*router.urls, *lms_urlpatterns, *payment_urlpatterns])),
+    path(
+        f"api/{API_VERSION}/",
+        include([*router.urls, *lms_urlpatterns, *payment_urlpatterns]),
+    ),
 ]
 
 if settings.DEBUG:
@@ -73,7 +78,7 @@ if settings.DEBUG:
         SchemaView = views.get_schema_view(
             openapi.Info(
                 title="Joanie API",
-                default_version="v1",
+                default_version=API_VERSION,
                 description="This is the Joanie API schema.",
             ),
             public=True,
@@ -82,17 +87,17 @@ if settings.DEBUG:
 
         urlpatterns += [
             re_path(
-                r"^swagger(?P<format>\.json|\.yaml)$",
+                rf"^{API_VERSION}/swagger(?P<format>\.json|\.yaml)$",
                 SchemaView.without_ui(cache_timeout=0),
                 name="api-schema",
             ),
             re_path(
-                r"^swagger/$",
+                rf"^{API_VERSION}/swagger/$",
                 SchemaView.with_ui("swagger", cache_timeout=0),
                 name="swagger-ui-schema",
             ),
             re_path(
-                r"^redoc/$",
+                rf"^{API_VERSION}/redoc/$",
                 SchemaView.with_ui("redoc", cache_timeout=0),
                 name="redoc-schema",
             ),


### PR DESCRIPTION
## Purpose

As Roy Fielding said : "Versioning an interface is just a "polite" way to kill deployed clients.". We are polite.
Now all api routes are prefixed by `/api/v1.0/`

## Proposal

- [x] Enable DRF Versioning by using URLPathVersioning
