### PR TITLE
Api/order target courses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Bind full target_courses object into order serializer representation
 - Allow to filter order resource by product id, course code and state 
 - Add api versioning
 - Add CourseRun & Product API endpoints

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -164,11 +164,7 @@ class OrderViewSet(
     def get_queryset(self):
         """Custom queryset to limit to orders owned by the logged-in user."""
         user = User.update_or_create_from_request_user(request_user=self.request.user)
-        return (
-            user.orders.all()
-            .select_related("owner", "product")
-            .prefetch_related("target_courses__course_runs")
-        )
+        return user.orders.all().select_related("owner", "product", "certificate")
 
     def perform_create(self, serializer):
         """Force the order's "owner" field to the logged-in user."""


### PR DESCRIPTION
## Purpose

Like we did for product serializer, we now bind order's target courses into the
OrderSerializer representation. This information are useful for frontend so to
avoid numerous requests to the api, we can assume to bind directly this
information within order.


## Proposal

- [x] Bind full target courses object to OrderSerializer reprensetation
- [x] Update tests
