### PR TITLE
✨(api) allow to filter enrollments by course run id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Allow to filter enrollment resource by course run id
 - Allow linking organizations to a course (who created it?) to a product
   (who is advertising it?) and to an order (who sold it?)
 - Bind full target_courses object into order serializer representation

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -122,6 +122,7 @@ class EnrollmentViewSet(
     pagination_class = Pagination
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = serializers.EnrollmentSerializer
+    filterset_class = filters.EnrollmentViewSetFilter
 
     def get_queryset(self):
         """Custom queryset to limit to orders owned by the logged-in user."""

--- a/src/backend/joanie/core/filters.py
+++ b/src/backend/joanie/core/filters.py
@@ -64,3 +64,15 @@ class ProductViewSetFilter(filters.FilterSet):
     class Meta:
         model = models.Product
         fields: List[str] = []
+
+
+class EnrollmentViewSetFilter(filters.FilterSet):
+    """
+    EnrollmentViewSetFilter allows to filter this resource with a course run id.
+    """
+
+    course_run = filters.UUIDFilter(field_name="course_run__id")
+
+    class Meta:
+        model = models.Enrollment
+        fields: List[str] = []


### PR DESCRIPTION
## Purpose

In order to manage standalone course runs, frontend needs to know if the authenticated user is enrolled to a given course run. To address this need we allow to filter user's enrollment through a course run id.


## Proposal

- [x] Create `EnrollmentViewSetFilter` which allows to filter this resource only by couse run id.
