### PR TITLE
Feature/store initial enrollment context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Allow to filter enrollment resource by `was_created_by_order`
 - Add a flag `was_created_by_order` to the Enrollment model
 - Allow to filter enrollment resource by course run id
 - Allow linking organizations to a course (who created it?) to a product

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add a flag `was_created_by_order` to the Enrollment model
 - Allow to filter enrollment resource by course run id
 - Allow linking organizations to a course (who created it?) to a product
   (who is advertising it?) and to an order (who sold it?)

--- a/src/backend/joanie/core/filters.py
+++ b/src/backend/joanie/core/filters.py
@@ -72,6 +72,7 @@ class EnrollmentViewSetFilter(filters.FilterSet):
     """
 
     course_run = filters.UUIDFilter(field_name="course_run__id")
+    was_created_by_order = filters.BooleanFilter(field_name="was_created_by_order")
 
     class Meta:
         model = models.Enrollment

--- a/src/backend/joanie/core/migrations/0001_initial.py
+++ b/src/backend/joanie/core/migrations/0001_initial.py
@@ -948,6 +948,14 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 (
+                    "was_created_by_order",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Ticked if the enrollment has been initially created in the scope of an order.",
+                        verbose_name="was created by order",
+                    ),
+                ),
+                (
                     "course_run",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.RESTRICT,

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -402,16 +402,14 @@ class EnrollmentSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         """
-        Retrieve the course run ressource through the provided resource_link
-        then try to create the enrollment ressource.
+        Retrieve the course run resource through the provided id
+        then try to create the enrollment resource.
         """
-        resource_link = self.initial_data["course_run"]
+        course_run_id = self.initial_data["course_run"]
         try:
-            course_run = models.CourseRun.objects.get(resource_link=resource_link)
+            course_run = models.CourseRun.objects.get(id=course_run_id)
         except models.CourseRun.DoesNotExist as exception:
-            message = (
-                f'A course run with resource link "{resource_link}" does not exist.'
-            )
+            message = f'A course run with id "{course_run_id}" does not exist.'
             raise serializers.ValidationError({"__all__": [message]}) from exception
 
         validated_data["course_run"] = course_run

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -459,6 +459,7 @@ class CourseApiTest(BaseAPITestCase):
                             "id": str(enrollment.id),
                             "is_active": enrollment.is_active,
                             "state": enrollment.state,
+                            "was_created_by_order": enrollment.was_created_by_order,
                             "course_run": {
                                 "id": str(enrollment.course_run.id),
                                 "resource_link": enrollment.course_run.resource_link,

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -147,7 +147,7 @@ class OrderModelsTestCase(TestCase):
         self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
 
         # - Validate the order should automatically enroll user to course run
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             order.validate()
 
         self.assertEqual(Enrollment.objects.count(), 1)
@@ -179,7 +179,9 @@ class OrderModelsTestCase(TestCase):
         self.assertEqual(Enrollment.objects.count(), 0)
 
         # - User enroll to the cr1
-        factories.EnrollmentFactory(course_run=cr1, user=owner, is_active=True)
+        factories.EnrollmentFactory(
+            course_run=cr1, user=owner, is_active=True, was_created_by_order=True
+        )
         self.assertEqual(Enrollment.objects.count(), 1)
         self.assertEqual(Enrollment.objects.filter(is_active=True).count(), 1)
 
@@ -221,7 +223,9 @@ class OrderModelsTestCase(TestCase):
         self.assertEqual(Enrollment.objects.count(), 0)
 
         # - User enroll to the cr1
-        factories.EnrollmentFactory(course_run=cr1, user=owner, is_active=True)
+        factories.EnrollmentFactory(
+            course_run=cr1, user=owner, is_active=True, was_created_by_order=True
+        )
         self.assertEqual(Enrollment.objects.count(), 1)
         self.assertEqual(Enrollment.objects.filter(is_active=True).count(), 1)
 


### PR DESCRIPTION
## Purpose

Some course run can be available for free and in the same time included in a product. In case the user has first freely enroll to the course run then purchase a product including it, we need to know if the user is initially enrolled freely. So on enrollment creation, client can provide an order id. If one is provided, the flag `was_created_by_order` will be set to True.



## Proposal

- [x] Add a BooleanField `was_created_by_order` to Enrollment model
- [x] Allow to filter enrollment by this new flag
