### PR TITLE
🐛(settings) use values.Value formats as JSON to set COURSE_WEB_HOOKS

### DIFF
--- a/src/backend/joanie/core/utils.py
+++ b/src/backend/joanie/core/utils.py
@@ -3,10 +3,12 @@ Utils that can be useful throughout Joanie's core app
 """
 import base64
 import collections.abc
+import json
 
 from django.utils.text import slugify
 from django.utils.translation import get_language
 
+from configurations import values
 from PIL import ImageFile as PillowImageFile
 
 
@@ -85,3 +87,16 @@ def get_resource_cache_key(
         cache_key = f"{cache_key}-{current_language}"
 
     return cache_key
+
+
+class JSONValue(values.Value):
+    """
+    A custom value class based on django-configurations Value class that
+    allows to load a JSON string and use it as a value.
+    """
+
+    def to_python(self, value):
+        """
+        Return the python representation of the JSON string.
+        """
+        return json.loads(value)

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -18,6 +18,8 @@ import sentry_sdk
 from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
 
+from .core.utils import JSONValue
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DATA_DIR = os.path.join("/", "data")
@@ -323,20 +325,11 @@ class Base(Configuration):
     SENTRY_DSN = values.Value(None, environ_name="SENTRY_DSN")
 
     # Richie synchronization
-    COURSE_WEB_HOOK_URL = values.Value()
-    COURSE_WEB_HOOK_SECRET = values.Value()
-    COURSE_WEB_HOOK_VERIFY = values.BooleanValue(True)
-    COURSE_WEB_HOOKS = (
-        [
-            {
-                "secret": COURSE_WEB_HOOK_SECRET,
-                "url": COURSE_WEB_HOOK_URL,
-                "verify": COURSE_WEB_HOOK_VERIFY,
-            }
-        ]
-        if COURSE_WEB_HOOK_URL
-        else []
-    )
+    # COURSE_WEB_HOOKS environment variable should be a stringified JSON array of
+    # objects with the following structure:
+    # e.g:
+    # DJANGO_COURSE_WEB_HOOKS=[{"url": "http://example.com", "secret": "secret", "verify": true}]
+    COURSE_WEB_HOOKS = JSONValue([])
 
     # pylint: disable=invalid-name
     @property


### PR DESCRIPTION
## Purpose
Currently, we defined through environment variables the COURSE_WEB_HOOK_URL,
COURSE_WEB_HOOK_SECRET and COURSE_WEB_HOOK_VERIFY then if COURSE_WEB_HOOK_URL
was defined, we tried to set COURSE_WEB_HOOKS settings. But unfortunately this
was not work as when this code was interpreted, COURSE_WEB_HOOK_URL was always
none. In order to fix that, we create a custom JSONValue class which takes a
JSON string as raw value then returns the python representation.

In this way we are now able to define `COURSE_WEB_HOOKS` through environment variable as following : 
```
DJANGO_COURSE_WEB_HOOKS=[{"url":"http://www.example.com", "secret": "a-secret", "verify": false}]
```

## Proposal

- [x] Sets `COURSE_WEB_HOOKS` setting through `values.Value` with `json.loads` as formatter.
