### PR TITLE
🔧(Dockerfile) copy mail templates during

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,8 @@ data
 .circleci
 .git
 .vscode
+.iml
+.idea
 db.sqlite3
 .mypy_cache
 .pylint.d


### PR DESCRIPTION
## Purpose

Currently, mail templates are not included into the docker image for two reasons.

First, there is a mistake about the path to copy mail templates after generation.
Second mail templates are built at collectstatic stage but app files are copied again after this stage so mail files are overriden here. In order to fix that, we copy app files during collectstatic stage, generate mail templates then copy all app files from this stage.


## Proposal

- [x] Fix docker production build
- [x] Take opportunity to fix a flaky test
