### PR TITLE
🔧(settings) remove custom env variable name for language settings

### DIFF
--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -107,7 +107,7 @@ class Base(Configuration):
     # https://docs.djangoproject.com/en/3.1/topics/i18n/
 
     # Languages
-    LANGUAGE_CODE = values.Value("en-us", environ_name="LANGUAGE_CODE")
+    LANGUAGE_CODE = values.Value("en-us")
 
     # Careful! Languages should be ordered by priority, as this tuple is used to get
     # fallback/default languages throughout the app.
@@ -115,19 +115,11 @@ class Base(Configuration):
         (
             ("en-us", _("English")),
             ("fr-fr", _("French")),
-        ),
-        environ_name="LANGUAGES",
+        )
     )
 
     LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 
-    PARLER_LANGUAGES = {
-        SITE_ID: (tuple(dict(code=code) for code, _name in LANGUAGES)),
-        "default": {
-            "fallbacks": [LANGUAGE_CODE],
-            "hide_untranslated": False,
-        },
-    }
     TIME_ZONE = "UTC"
     USE_I18N = True
     USE_TZ = True
@@ -346,6 +338,20 @@ class Base(Configuration):
         Delegate to the module function to enable easier testing.
         """
         return get_release()
+
+    # pylint: disable=invalid-name
+    @property
+    def PARLER_LANGUAGES(self):
+        """
+        Return languages for Parler computed from the LANGUAGES and LANGUAGE_CODE settings.
+        """
+        return {
+            self.SITE_ID: tuple(dict(code=code) for code, _name in self.LANGUAGES),
+            "default": {
+                "fallbacks": [self.LANGUAGE_CODE],
+                "hide_untranslated": False,
+            },
+        }
 
     @classmethod
     def post_setup(cls):

--- a/src/tray/templates/services/app/_env.yml.j2
+++ b/src/tray/templates/services/app/_env.yml.j2
@@ -1,3 +1,0 @@
-DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004
-DJANGO_LANGUAGE_CODE: 'fr-fr'
-DJANGO_LANGUAGES: 'fr-fr,French;en-us,English'


### PR DESCRIPTION
## Purpose

We can consider language settings as Django settings and keep the `DJANGO_` prefix in the expected variable name that configures them, which is what the tray is doing.

## Proposal

- [x] Remove custom environ name for `LANGUAGE_CODE` and `LANGUAGES` settings.
- [x] Remove language overrides in the Arnold tray as we already have defaults for these settings (and anything the `_env.yml` file is being overriden by a configmap in deployments)
