### PR TITLE
Fix/admin editable username on creation

### DIFF
--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -107,6 +107,27 @@ class CourseRunAdmin(TranslatableAdmin):
     """Admin class for the CourseRun model"""
 
     list_display = ("title", "resource_link", "start", "end", "state", "is_gradable")
+    readonly_fields = ("id",)
+    fieldsets = (
+        (
+            _("Main information"),
+            {
+                "fields": (
+                    "id",
+                    "course",
+                    "title",
+                    "resource_link",
+                    "is_gradable",
+                    "is_listed",
+                    "languages",
+                    "enrollment_start",
+                    "enrollment_end",
+                    "start",
+                    "end",
+                )
+            },
+        ),
+    )
     actions = ("mark_as_gradable",)
 
     @admin.action(description=_("Mark course run as gradable"))

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -148,10 +148,17 @@ class UserAdmin(auth_admin.UserAdmin):
         ),
         (_("Important dates"), {"fields": ("last_login", "date_joined")}),
     )
-    readonly_fields = (
-        "username",
-        "language",
-    )
+    readonly_fields = ("language",)
+    readonly_update_fields = ("username",)
+
+    def get_readonly_fields(self, request, obj=None):
+        """
+        Make some fields readonly on update to avoid changing them by mistake
+        """
+        if obj is None:
+            return self.readonly_fields
+
+        return self.readonly_fields + self.readonly_update_fields
 
 
 class ProductTargetCourseRelationInline(SortableInlineAdminMixin, admin.TabularInline):

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -205,6 +205,7 @@ class ProductAdmin(
             _("Main information"),
             {
                 "fields": (
+                    "id",
                     "type",
                     "title",
                     "description",
@@ -218,7 +219,10 @@ class ProductAdmin(
     )
 
     inlines = (ProductTargetCourseRelationInline,)
-    readonly_fields = ("related_courses",)
+    readonly_fields = (
+        "id",
+        "related_courses",
+    )
     actions = (ACTION_NAME_GENERATE_CERTIFICATES,)
     change_actions = (ACTION_NAME_GENERATE_CERTIFICATES,)
 


### PR DESCRIPTION
## Purpose

Currently an administrator is not able to create a new account for other staff member as username field of User model is readonly. In order to fix that, we make the username field readonly only for existing resource.

Furthermore, we take opportunity to improve a little bit the user experience for Product and Course Model.
About both models, editor needs to retrieve the id of the resource so we display it on admin change view.

Then about CourseRun models it appears that fields are now well ordered, so we use the `fieldsets` property of the Admin view to reorder fields.

<img width="574" alt="image" src="https://user-images.githubusercontent.com/9265241/215061696-a20f6c23-1fef-43a4-8f96-3a19a6c7c1c0.png">

<img width="391" alt="image" src="https://user-images.githubusercontent.com/9265241/215061733-7a23e6a3-0195-4210-b92c-463243afcede.png">


## Proposal

- [x] Make username readonly only for update
- [x] Display CourseRun & Product id in admin change view
- [x] Improve fields order for CourseRun
