### PR TITLE
🔖(release) bump to version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,83 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.0.0] - 2023-01-31
+
 ### Added
 
-- Add a fsm to handle state of Order model
-- Allow to filter enrollment resource by `was_created_by_order`
-- Add a flag `was_created_by_order` to the Enrollment model
-- Allow to filter enrollment resource by course run id
-- Allow linking organizations to a course (who created it?) to a product
-  (who is advertising it?) and to an order (who sold it?)
-- Bind full target_courses object into order serializer representation
-- Allow to filter order resource by product id, course code and state 
-- Add api versioning
-- Add CourseRun & Product API endpoints
-- Configure language through environment variables
-- Send email when the payment is successful
-- Transform `mjml` files (email's template files) to html and plaintext
-- Add email settings and configure `mailcatcher` in docker-compose stack
-- Add Open Badge Factory badge provider
-- Add language in the user token
-- Set and update user's email sent from the token
-- Add `certification_definition` field to `Certificate` model
-- Add Arnold tray to facilitate deploying Joanie to Kubernetes
-- Add the `badges` application
-- Add `is_listed` boolean field to course run model
-- Add custom actions into admin to generate certificates
-- Add a management command to generate certificate for eligible orders
-- Add `is_passed` cached property to enrollment model
-- Add an api endpoint to retrieve and download certificates
-- Add a `get_grades` method to LMSHandler
-- Add a computed "state" to Course and CourseRun models
-- Add Payplug payment backend and related API routes
-- Add Invoice and Transaction models for accounting purposes
-- Add credit card model and related api to retrieve, update, delete it
-- Serve static files with `whitenoise` third party app
-- Add collected static files to the production Docker image
-- Install django-money to manage currencies
-- Improve course and product admin change views
-- Add ngrok to serve Joanie on a public address for development purpose
-- Add unique constraint to owner address field to allow only one main address
-  per user
-- Add fullname field to address model
-- Add a web hook endpoint to synchronize course runs from a LMS
-- Add a "languages" field to the course run model
-- Add stub dependencies required by mypy
-- Add .gitlint configuration file
-- Use marion and howard to generate certificate for an order
-- Use marion and howard to generate invoice for an order
-- Implement Address model for billing and add routes API to get, create,
-  update and delete address.
-- Install security updates in project Docker images
-- Enable CORS Headers
-- Add routes API to get all products available for a course
-  and get or set orders.
-- Implement first models to manage courses, products, orders,
-  enrollments to course runs and certifications.
-- Add a LMSHandler class to select the right LMS Backend to use according to
-  the course run's `resource_link` provided
-- Add a OpenEdX LMS Backend to manage enrollments
+- First working version serving sellable micro-credentials for multiple
+  organizations synchronized to a remote catalog
 
-### Changed
-
-- Transforms id into UUID on all models
-- The field `password` from user's model has a default value
-- Configure language field of the user's model
-- Update codebase to remove the use of deprecated pytz and USE_L10N
-  with Django 4.0
-- Refactor links between enrollment and order models
-- Update Order serializers to bind certificate
-- Order `state` is now a computed property
-- Split address fullname field into first_name and last_name fields
-- Update CourseSerializer to bind order and enrollment related to the user
-- Use a ViewSet to create address api
-- Rename the "name" field to "title" (avoid confusion with new "fullname" field)
-- Rename "main" field to "is_main" as our naming convention for boolean fields
-- Pin base Docker image to `python8-slim-bullseye`
-- Make course run dates not required
-- Make the "resource_link" field unique and required for course runs
-- Normalize course codes and ensure their uniqueness
-- Refactor models to allow enrollment without order
-
-[unreleased]: https://github.com/openfun/joanie
+[unreleased]: https://github.com/openfun/joanie/compare/v1.0.0...master
+[1.0.0]: https://github.com/openfun/joanie/compare/695965575b80d45c2600a1bcaf84d78bebaec1e7...v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Joanie – Power up Richie catalog 👛
 
-Joanie aims to power up [Richie](https://github.com/openfun/richie) catalog
-functionalities by delivering an API able to manage course
-enrollment/subscription, payment and certificates delivery.
+Joanie is a headless ERP for education to manage course enrollment/subscription,
+payment and certificates delivery.
 
 Joanie is built on top of [Django Rest
 Framework](https://www.django-rest-framework.org/).

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -3,24 +3,24 @@
 ;;
 [metadata]
 name = joanie
-version = 0.0.1
-description = Power up Richie with course enrollment, subscription, payment and certificates delivery
+version = 1.0.0
+description = A headless ERP for education to manage course enrollment/subscription, payment and certificates delivery.
 long_description = file:README.md
 long_description_content_type = text/markdown
 author = Open FUN (France Université Numérique)
 author_email = fun.dev@fun-mooc.fr
 url = https://github.com/openfun/joanie
 license = MIT
-keywords = Django, OpenEdX, Richie, dashboard
+keywords = Django, ERP, education, dashboard
 classifiers =
-    Development Status :: 4 - Beta
+    Development Status :: 5 - Production/Stable
     Framework :: Django
-    Framework :: Django :: 3.1.5
+    Framework :: Django :: 4
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.10
 
 [options]
 install_requires =


### PR DESCRIPTION
### Added

- First working version serving sellable micro-credentials for multiple organizations synchronized to a remote catalog
