### PR TITLE
🐛(core) fix a bug about auto enrollment on order validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a bug that raise an error when user is automatically enrolled to
+  a course run on which they have already an inactive enrollment
+
 ## [1.0.0] - 2023-01-31
 
 ### Added

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -526,9 +526,9 @@ class Order(BaseModel):
         for course in courses_with_one_course_run:
             course_run = course.course_runs.first()
             try:
-                enrollment = Enrollment.objects.get(
+                enrollment = Enrollment.objects.only("is_active").get(
                     course_run=course_run, user=self.owner
-                ).only("is_active")
+                )
             except Enrollment.DoesNotExist:
                 Enrollment.objects.create(
                     course_run=course_run,


### PR DESCRIPTION
## Purpose

When an order is validated, if the related product has a target course with a single course run, the user is automatically enrolled to this one. In the case where there is an existing inactive enrolled for the couple user / course run, the statement to retrieve enrollment contains a syntax error.


## Proposal

- [x] Fix bug and add a test
