### PR TITLE
Allow on demand page size for orders and enrollments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- Activate pagination by default on all endpoints (20 items per page)
 - Use user fullname instead of username in order confirmation email
 
 ## Added
@@ -51,6 +52,6 @@ and this project adheres to
 - First working version serving sellable micro-credentials for multiple
   organizations synchronized to a remote catalog
 
-[unreleased]: https://github.com/openfun/joanie/compare/v1.1.0...master
+[unreleased]: https://github.com/openfun/joanie/compare/v1.1.0...main
 [1.1.0]: https://github.com/openfun/joanie/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/openfun/joanie/compare/695965575b80d45c2600a1bcaf84d78bebaec1e7...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 
 ## Added
 
+- Allow on-demand page size on the order and enrollment endpoints
 - Add yarn cli to generate joanie api client in TypeScript
 
 ### Removed

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -47,7 +47,8 @@ class Pagination(pagination.PageNumberPagination):
     """Pagination to display no more than 100 objects per page sorted by creation date."""
 
     ordering = "-created_on"
-    page_size = 100
+    max_page_size = 100
+    page_size_query_param = "page_size"
 
 
 class CourseRunViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -241,6 +241,8 @@ class Base(Configuration):
             "django_filters.rest_framework.DjangoFilterBackend"
         ],
         "EXCEPTION_HANDLER": "joanie.core.api.exception_handler",
+        "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+        "PAGE_SIZE": 20,
         "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
     }
 


### PR DESCRIPTION
## Purpose

The order and enrollment endpoints are used by the frontend to build a view mixing both objects. For this, the frontend needs to be able to customize the number of items returned by page.

## Proposal

This pull request proposes to activate on-demand page size on the order and enrollment endpoints. We fix the max size of the page to 100 items for security reasons.

While working on this, we realized that pagination should be activated by default on all endpoints. We set it to 20 items per page by default, not modifiable via the querystring (this can be activated on a case-by-case basis like we do here for orders and enrollments.
