### PR TITLE
🗃️(CourseRun) set `is_listed` field to False by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- Set CourseRun `is_listed` to False by default
 - Improve order confirmation email template
 
 ### Added

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -299,7 +299,7 @@ class CourseRun(parler_models.TranslatableModel, BaseModel):
     is_gradable = models.BooleanField(_("is gradable"), default=False)
     is_listed = models.BooleanField(
         _("is listed"),
-        default=True,
+        default=False,
         help_text=_(
             "If checked the course run will be included in the list of course runs "
             "available for enrollment on the related course page."

--- a/src/backend/joanie/tests/core/test_api_course_run.py
+++ b/src/backend/joanie/tests/core/test_api_course_run.py
@@ -42,9 +42,9 @@ class CourseRunApiTest(BaseAPITestCase):
 
     def test_api_course_run_read_detail(self):
         """
-        Any users should be allowed to retrieve a course run with minimal db access.
+        Any users should be allowed to retrieve a listed course run with minimal db access.
         """
-        course_run = factories.CourseRunFactory()
+        course_run = factories.CourseRunFactory(is_listed=True)
 
         with self.assertNumQueries(1):
             response = self.client.get(f"/api/v1.0/course-runs/{course_run.id}/")

--- a/src/backend/joanie/tests/core/test_models_enrollment.py
+++ b/src/backend/joanie/tests/core/test_models_enrollment.py
@@ -45,6 +45,7 @@ class EnrollmentModelsTestCase(TestCase):
             enrollment_end=self.now + timedelta(hours=1),
             title="my run",
             resource_link=resource_link,
+            is_listed=True,
         )
 
         enrollment = factories.EnrollmentFactory(
@@ -92,6 +93,7 @@ class EnrollmentModelsTestCase(TestCase):
             start=self.now - timedelta(hours=1),
             end=self.now + timedelta(hours=2),
             enrollment_end=self.now + timedelta(hours=1),
+            is_listed=True,
         )
         enrollment = factories.EnrollmentFactory(course_run=course_run, is_active=False)
 
@@ -115,6 +117,7 @@ class EnrollmentModelsTestCase(TestCase):
             end=self.now + timedelta(hours=2),
             enrollment_end=self.now + timedelta(hours=1),
             course=factories.CourseFactory(),
+            is_listed=True,
         )
         enrollment = factories.EnrollmentFactory(course_run=cr1, is_active=True)
 
@@ -271,6 +274,7 @@ class EnrollmentModelsTestCase(TestCase):
             end=self.now + timedelta(hours=2),
             enrollment_end=self.now + timedelta(hours=1),
             resource_link=resource_link,
+            is_listed=True,
         )
         enrollment = factories.EnrollmentFactory(course_run=course_run)
 
@@ -303,6 +307,7 @@ class EnrollmentModelsTestCase(TestCase):
             end=self.now + timedelta(hours=2),
             enrollment_end=self.now + timedelta(hours=1),
             resource_link=resource_link,
+            is_listed=True,
         )
         enrollment = factories.EnrollmentFactory(course_run=course_run)
 

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -153,7 +153,7 @@ class OrderModelsTestCase(TestCase):
         InvoiceFactory(order=order, total=order.total)
 
         # - Validate the order should automatically enroll user to course run
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(17):
             order.validate()
 
         self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
@@ -175,6 +175,7 @@ class OrderModelsTestCase(TestCase):
             start=timezone.now() - timedelta(hours=1),
             end=timezone.now() + timedelta(hours=2),
             enrollment_end=timezone.now() + timedelta(hours=1),
+            is_listed=True,
         )
 
         product = factories.ProductFactory(
@@ -302,6 +303,7 @@ class OrderModelsTestCase(TestCase):
             start=timezone.now() - timedelta(hours=1),
             end=timezone.now() + timedelta(hours=2),
             enrollment_end=timezone.now() + timedelta(hours=1),
+            is_listed=True,
         )[0]
 
         # - Create one product which relies on the same course

--- a/src/backend/joanie/tests/core/test_signals.py
+++ b/src/backend/joanie/tests/core/test_signals.py
@@ -24,7 +24,8 @@ class SignalsTestCase(TestCase):
         the equivalent course run of related products and the course run itself.
         """
         course_run = factories.CourseRunFactory(
-            start=datetime(2022, 7, 7, 7, 0, tzinfo=ZoneInfo("UTC"))
+            start=datetime(2022, 7, 7, 7, 0, tzinfo=ZoneInfo("UTC")),
+            is_listed=True,
         )
         products = factories.ProductFactory.create_batch(
             2, target_courses=[course_run.course]
@@ -64,8 +65,10 @@ class SignalsTestCase(TestCase):
         When a course run restriction is in place, synchronize_course_runs should
         only be triggered for course runs declared in the restriction list.
         """
-        course_run = factories.CourseRunFactory()
-        course_run_excluded = factories.CourseRunFactory(course=course_run.course)
+        course_run = factories.CourseRunFactory(is_listed=True)
+        course_run_excluded = factories.CourseRunFactory(
+            course=course_run.course, is_listed=True
+        )
         product = factories.ProductFactory()
         factories.ProductTargetCourseRelationFactory(
             product=product, course=course_run.course, course_runs=[course_run]


### PR DESCRIPTION
## Purpose

Now that Joanie is able to synchronize its course runs with Richie, we prefer that a CourseRun is not listed by default. In this way, we prevent to involuntary display a CourseRun on a catalog. Furthermore, it prevents that a course run is available for free enrollment by mistake!


## Proposal

Description...

- [x] Set `is_listed` field of `CourseRun` model to False by default
