### PR TITLE
🐛(certificate) prevent server error when certificate is unprocessable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,16 @@ and this project adheres to
 
 - Set CourseRun `is_listed` to False by default
 - Improve order confirmation email template
+- Include course information into course runs representation
 
 ### Added
 
 - Add synchronization for course runs
 - Add make dbshell cmd to access database in cli
 
-### Changed
-
-- Include course information into course runs representation
-
 ### Fixed
 
+- Prevent internal server error when certificate document is unprocessable
 - Fix a bug that raise an error when user is automatically enrolled to
   a course run on which they have already an inactive enrollment
 

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -404,9 +404,14 @@ class CertificateViewSet(
                 {"detail": f"No certificate found with id {pk}."}, status=404
             )
 
-        response = HttpResponse(
-            certificate.document, content_type="application/pdf", status=200
-        )
+        document = certificate.document
+
+        if not document:
+            return Response(
+                {"detail": f"Unable to generate certificate {pk}."}, status=422
+            )
+
+        response = HttpResponse(document, content_type="application/pdf", status=200)
 
         response["Content-Disposition"] = f"attachment; filename={pk}.pdf;"
 


### PR DESCRIPTION
## Purpose

Currently, organization logo and signature are not required to create an organization. But to create a certificate document we need this information so
 when this information are missing, a ValueError is raised then an internal
 server error is returned. In order to fix that we properly manage this case by
 returning a 422 error.


## Proposal

- [x] Certificate `document` property returns None when certificate cannot be created
- [x] Download api endpoint returns a 422 error when certificate document cannot be created
