### PR TITLE
🐛(core) prevent to enroll on several course runs for the same course

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Fixed
 
+- Prevent to enroll on several opened course runs of the same course
 - Prevent internal server error when certificate document is unprocessable
 - Fix a bug that raise an error when user is automatically enrolled to
   a course run on which they have already an inactive enrollment

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -737,12 +737,14 @@ class Enrollment(BaseModel):
 
         # The user should not be enrolled in another opened course run of the same course.
         if (
-            self.created_on is None
-            and self.user.enrollments.filter(
+            self.is_active
+            and self.user.enrollments.exclude(id=self.id)
+            .filter(
                 course_run__course=self.course_run.course,
                 course_run__end__gte=timezone.now(),
                 is_active=True,
-            ).exists()
+            )
+            .exists()
         ):
             message = _(
                 "You are already enrolled to an opened course run "

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -557,7 +557,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         self.assertTrue(models.Enrollment.objects.filter(is_active=True).exists())
         data = {
             "course_run": course_run2.id,
-            "is_active": random.choice([True, False]),
+            "is_active": True,
             "was_created_by_order": True,
         }
         token = self.get_user_token(user.username)
@@ -1575,8 +1575,8 @@ class EnrollmentApiTest(BaseAPITestCase):
         self.assertEqual(enrollment.is_active, True)
         self.assertEqual(enrollment.was_created_by_order, True)
 
-        # User unrolls and tried to update the was_created_by_order field but it should
-        # not be updated because enrollment is active.
+        # User unenrolls and tried to update the was_created_by_order field, but it
+        # should not be updated because enrollment is active.
         response = self.client.put(
             f"/api/v1.0/enrollments/{enrollment.id}/",
             data={

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -196,7 +196,7 @@ class OrderModelsTestCase(TestCase):
         InvoiceFactory(order=order, total=order.total)
 
         # - Validate the order should automatically enroll user to course run
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(24):
             order.validate()
 
         enrollment.refresh_from_db()


### PR DESCRIPTION
## Purpose

We do not want a user is able to enroll on several opened course runs of the same course. Currently, we execute the check only on enrollment creation so one case was not covered by this check. Indeed if the user enrolls to a first course
 run then unenroll to this course run, it is able to enroll a second course run
 then re-enroll to the first one.


## Proposal

- [x] Check if user is not already enrolled on opened course run of the same course as soon as `is_active` attribute to the related enrollment is True.
