### PR TITLE
✨(accounts) store user.fullname into firstname field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Changed
 
+- Store full name in user profile through firstname field
 - Set CourseRun `is_listed` to False by default
 - Improve order confirmation email template
 - Include course information into course runs representation

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -37,8 +37,6 @@ class UserFactory(factory.django.DjangoModelFactory):
     email = factory.Faker("email")
     language = factory.fuzzy.FuzzyChoice([lang[0] for lang in settings.LANGUAGES])
     password = make_password("password")
-    first_name = factory.Faker("first_name")
-    last_name = factory.Faker("last_name")
 
 
 class CertificateDefinitionFactory(factory.django.DjangoModelFactory):

--- a/src/backend/joanie/core/models/accounts.py
+++ b/src/backend/joanie/core/models/accounts.py
@@ -51,7 +51,13 @@ class User(BaseModel, auth_models.AbstractUser):
 
         user = User.objects.update_or_create(
             username=request_user.username,
-            defaults={"email": request_user.email, "language": language},
+            defaults={
+                # Currently, the authentication backend only provide full_name,
+                # so we save it in the first_name field
+                "first_name": getattr(request_user, "full_name", None) or "",
+                "email": request_user.email,
+                "language": language,
+            },
         )[0]
 
         return user

--- a/src/backend/joanie/tests/base.py
+++ b/src/backend/joanie/tests/base.py
@@ -67,6 +67,7 @@ class BaseAPITestCase(TestCase):
                 "iat": issued_at,
                 "language": user.language,
                 "username": user.username,
+                "fullname": user.get_full_name(),
             }
         )
         return token

--- a/src/backend/joanie/tests/core/test_models_user.py
+++ b/src/backend/joanie/tests/core/test_models_user.py
@@ -70,7 +70,7 @@ class UserModelTestCase(TestCase):
     def test_models_create_or_update_from_request(self):
         """
         Check using the method create_or_update_from_request, a user
-        is created if non existing or else updated
+        is created if non-existing or else updated
         """
         user = UserFactory(username="Sam", email="mail@fun-test.fr")
 
@@ -78,6 +78,7 @@ class UserModelTestCase(TestCase):
         request.username = "Sam"
         request.email = "sam@fun-test.fr"
         request.language = "fr"
+        request.full_name = "Samy Fonzarelli"
 
         User.update_or_create_from_request_user(request)
         user.refresh_from_db()
@@ -85,6 +86,8 @@ class UserModelTestCase(TestCase):
         # email has been updated
         self.assertEqual(user.email, "sam@fun-test.fr")
         self.assertEqual(user.language, "fr-fr")
+        self.assertEqual(user.first_name, "Samy Fonzarelli")
+        self.assertEqual(user.get_full_name(), "Samy Fonzarelli")
         # no new object has been created
         self.assertEqual(User.objects.count(), 1)
 
@@ -100,7 +103,7 @@ class UserModelTestCase(TestCase):
     def test_models_create_or_update_from_request_language(self):
         """
         Check using the method create_or_update_from_request, the language
-        is set depending of the values of the language available in the
+        is set depending on the values of the language available in the
         settings and understood in different ways
         """
         request = RequestFactory()


### PR DESCRIPTION
## Purpose

Currently, the jwt token used to authenticate user contains only a fullname property. As there are too much edge cases to split fullname into first and last
 names, we prefer to store this property into the firstname field. It allows us
 later to switch gracefully to another authentication.

## Proposal

- [x] Store fullname jwt token property into firstname field. 
