### PR TITLE
🐛(core) fix string representation of CourseRun model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Fixed
 
+- Prevent server error when CourseRun instance has no start and end dates.
 - Prevent to enroll on several opened course runs of the same course
 - Prevent internal server error when certificate document is unprocessable
 - Fix a bug that raise an error when user is automatically enrolled to

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -314,7 +314,7 @@ class CourseRun(parler_models.TranslatableModel, BaseModel):
     def __str__(self):
         return (
             f"{self.safe_translation_getter('title', any_language=True)} "
-            f"[{self.start:%Y-%m-%d} to {self.end:%Y-%m-%d}]"
+            f"[{self.state.get('text')}]"
         )
 
     def get_serialized(self, visibility=None):

--- a/src/backend/joanie/tests/core/test_models_course_run.py
+++ b/src/backend/joanie/tests/core/test_models_course_run.py
@@ -23,6 +23,15 @@ class CourseRunModelsTestCase(TestCase):
         super().setUp()
         self.now = django_timezone.now()
 
+    def test_models_course_run_string_representation(self):
+        """
+        The string representation of a course run should be built with its title
+        and its state text.
+        """
+
+        course_run = factories.CourseRunFactory()
+        self.assertEqual(str(course_run), f"{course_run.title} [{course_run.state}]")
+
     def test_models_course_run_normalized(self):
         """
         The resource_link field should be normalized on save.

--- a/src/backend/joanie/tests/core/test_models_enrollment.py
+++ b/src/backend/joanie/tests/core/test_models_enrollment.py
@@ -171,7 +171,9 @@ class EnrollmentModelsTestCase(TestCase):
                 is_active=True,
                 course_run=factories.CourseRunFactory(
                     course=course,
+                    start=timezone.now() - timedelta(hours=1),
                     end=timezone.now() + timedelta(hours=2),
+                    enrollment_start=timezone.now() - timedelta(hours=2),
                     enrollment_end=timezone.now() + timedelta(hours=1),
                     is_listed=True,
                 ),
@@ -182,6 +184,7 @@ class EnrollmentModelsTestCase(TestCase):
             course=course,
             start=self.now - timedelta(hours=1),
             end=self.now + timedelta(hours=2),
+            enrollment_start=self.now - timedelta(hours=2),
             enrollment_end=self.now + timedelta(hours=1),
             is_listed=True,
         )

--- a/src/backend/joanie/tests/core/test_models_enrollment.py
+++ b/src/backend/joanie/tests/core/test_models_enrollment.py
@@ -56,10 +56,7 @@ class EnrollmentModelsTestCase(TestCase):
 
         self.assertEqual(
             str(enrollment),
-            (
-                "[active][set] Françoise for my run "
-                f"[{course_run.start:%Y-%m-%d} to {course_run.end:%Y-%m-%d}]"
-            ),
+            ("[active][set] Françoise for my run " f"[{course_run.state['text']}]"),
         )
 
     def test_models_enrollment_str_inactive(self):
@@ -81,7 +78,7 @@ class EnrollmentModelsTestCase(TestCase):
             str(enrollment),
             (
                 "[inactive][failed] Françoise for my run "
-                f"[{course_run.start:%Y-%m-%d} to {course_run.end:%Y-%m-%d}]"
+                f"[{course_run.state['text']}]"
             ),
         )
 


### PR DESCRIPTION
## Purpose

The CourseRun string representation was based on a title and the start end end date of the CourseRun instance. But start and end date fields can be null so in this case, the string representation raises a `NoneType.__format__` error. So instead to use those dates, we could use the state.


## Proposal

- [x] Use title and state for CourseRun string representation. 
