### PR TITLE
Fix/max retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Fixed
 
+- Catch error if the max retries synchronization webhook gets reached 
 - Prevent server error when CourseRun instance has no start and end dates.
 - Prevent to enroll on several opened course runs of the same course
 - Prevent internal server error when certificate document is unprocessable

--- a/src/backend/joanie/tests/core/test_utils_webhooks_synchronize_course_runs.py
+++ b/src/backend/joanie/tests/core/test_utils_webhooks_synchronize_course_runs.py
@@ -145,7 +145,7 @@ class SynchronizeCourseRunsUtilsTestCase(TestCase):
             rsp = rsps.post(
                 re.compile("http://richie.education/webhook"),
                 body="{}",
-                status=random.choice(["404", "500", "301"]),
+                status=random.choice([404, 301]),
                 content_type="application/json",
             )
 


### PR DESCRIPTION
## Purpose

So far, internal server error occurs if a course web
hook returns a 500 error. To prevent this, we simply
catch the error.

## Proposal


- fix string in status code
- try catch max retries
