### PR TITLE
💬(mail) use user fullname instead of username when exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Use user fullname instead of username in order confirmation email
+
 ## Added
 
 - Add yarn cli to generate joanie api client in TypeScript

--- a/src/backend/joanie/core/views.py
+++ b/src/backend/joanie/core/views.py
@@ -15,7 +15,7 @@ class DebugMailSuccessPayment(TemplateView):
         context = super().get_context_data(**kwargs)
         context["title"] = "👨‍💻Development email preview"
         context["email"] = order.owner.email
-        context["username"] = order.owner.username
+        context["fullname"] = order.owner.get_full_name() or order.owner.username
         context["product"] = order.product
         context["site"] = {
             "name": site.name,

--- a/src/backend/joanie/payment/backends/base.py
+++ b/src/backend/joanie/payment/backends/base.py
@@ -76,7 +76,7 @@ class BasePaymentBackend:
                 template_vars = {
                     "title": _("Purchase order confirmed!"),
                     "email": order.owner.email,
-                    "username": order.owner.username,
+                    "fullname": order.owner.get_full_name() or order.owner.username,
                     "product": order.product,
                     "site": {
                         "name": site.name,

--- a/src/mail/mjml/order_validated.mjml
+++ b/src/mail/mjml/order_validated.mjml
@@ -11,8 +11,8 @@
         <mj-column>
           <mj-text padding="0">
             <p>
-              {%if username%}
-                {% blocktranslate with name=username %}Hello {{ name }}{% endblocktranslate %}
+              {%if fullname%}
+                {% blocktranslate with name=fullname %}Hello {{ name }}{% endblocktranslate %}
               {% else %}
                 {%trans "Hello" %}
               {% endif %}<br/>


### PR DESCRIPTION
## Purpose

When user has a full name define we should use it within our mails instead of its username.


## Proposal

- [x] Bind user fullname in mail context when exists
