### PR TITLE
🩹(api schema): add course query param to product retrieve route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to
 
 - Allow on-demand page size on the order and enrollment endpoints
 - Add yarn cli to generate joanie api client in TypeScript
+- Add course query param to openapi schema on route products.retrieve
 
 ### Removed
 

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -186,6 +186,10 @@ class OrderViewSet(
         owner = User.update_or_create_from_request_user(request_user=self.request.user)
         serializer.save(owner=owner)
 
+    @swagger_auto_schema(
+        request_body=serializers.OrderCreateBodySerializer,
+        responses={200: serializers.OrderCreateResponseSerializer()},
+    )
     @transaction.atomic
     def create(self, request, *args, **kwargs):
         """Try to create an order and a related payment if the payment is fee."""
@@ -257,7 +261,10 @@ class OrderViewSet(
 
             # Return the fresh new order with payment_info
             return Response(
-                {**serializer.data, "payment_info": payment_info}, status=201
+                serializers.OrderCreateResponseSerializer(
+                    {**serializer.data, "payment_info": payment_info}
+                ),
+                status=201,
             )
 
         # Else return the fresh new order

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -6,6 +6,8 @@ from django.db import IntegrityError, transaction
 from django.http import HttpResponse
 from django.utils.translation import gettext_lazy as _
 
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, pagination, permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError as DRFValidationError
@@ -110,6 +112,14 @@ class ProductViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
             context.update({"course_code": course})
 
         return context
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter("course", in_=openapi.IN_QUERY, type=openapi.TYPE_STRING)
+        ],
+    )
+    def retrieve(self, *args, **kwargs):
+        return super().retrieve(*args, **kwargs)
 
 
 # pylint: disable=too-many-ancestors

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -545,3 +545,27 @@ class CertificateSerializer(serializers.ModelSerializer):
         model = models.Certificate
         fields = ["id"]
         read_only_fields = ["id"]
+
+
+class OrderCreateBodySerializer(OrderSerializer):
+    billing_address = AddressSerializer(required=False)
+
+    class Meta(OrderSerializer.Meta):
+        fields = OrderSerializer.Meta.fields + ["billing_address"]
+        read_only_fields = OrderSerializer.Meta.fields + ["billing_address"]
+
+
+class PaymentSerializer(serializers.Serializer):
+    payment_id = serializers.CharField(required=True)
+    provider = serializers.CharField(required=True)
+    url = serializers.CharField(required=True)
+    is_paid = serializers.BooleanField(required=False)
+
+
+class OrderCreateResponseSerializer(OrderSerializer):
+    id = serializers.CharField(required=True)
+    payment_info = PaymentSerializer(required=False)
+
+    class Meta(OrderSerializer.Meta):
+        fields = OrderSerializer.Meta.fields + ["payment_info"]
+        read_only_fields = OrderSerializer.Meta.fields + ["payment_info"]


### PR DESCRIPTION
## Purpose

course is a mandatory query param for product.retrieve. we need it in order to correctly generate javascript api client.
