### PR TITLE
🚨(tray) avoid using punctuation with password lookup

### DIFF
--- a/src/tray/vars/vault/main.yml.j2
+++ b/src/tray/vars/vault/main.yml.j2
@@ -7,9 +7,9 @@ DB_USER: {{ postgresql_credentials.user }}
 DB_PASSWORD: {{ postgresql_credentials.password }}
 
 # joanie environment
-DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=50') }}
+DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=50') }}
 # FIXME uncomment this variable and replace with your sentry's credentials
 # DJANGO_SENTRY_DSN: https://super:django@sentry.io/foo
 
 # JWT Token
-DJANGO_JWT_PRIVATE_SIGNING_KEY: {{ lookup('password', '/dev/null length=50') }}
+DJANGO_JWT_PRIVATE_SIGNING_KEY: {{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=50') }}


### PR DESCRIPTION
## Purpose

The tray job is failing time to time with a syntax error reading the vault file. We want to remove punctuation in the generated password to not have this syntax error

Ref: https://github.com/openfun/marsha/pull/2081

