### PR TITLE
Api/certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 ### Removed
 
 - Badge providers now live in the obc python package
+- Remove unused `OrderLiteSerializer`
 
 ## [1.1.0] - 2023-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Activate pagination by default on all endpoints (20 items per page)
 - Use user fullname instead of username in order confirmation email
+- Rename certificate field into certificate_definition for the ProductSerializer
 
 ## Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Activate pagination by default on all endpoints (20 items per page)
 - Use user fullname instead of username in order confirmation email
 - Rename certificate field into certificate_definition for the ProductSerializer
+- Improve certificate serializer
 
 ## Added
 

--- a/src/backend/joanie/core/api.py
+++ b/src/backend/joanie/core/api.py
@@ -380,6 +380,7 @@ class CertificateViewSet(
     """
 
     lookup_field = "pk"
+    pagination_class = Pagination
     serializer_class = serializers.CertificateSerializer
     permission_classes = [permissions.IsAuthenticated]
 

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -138,7 +138,7 @@ class ProductSerializer(serializers.ModelSerializer):
     """
 
     id = serializers.CharField(read_only=True)
-    certificate = CertificationDefinitionSerializer(
+    certificate_definition = CertificationDefinitionSerializer(
         read_only=True, source="certificate_definition"
     )
     organizations = serializers.SerializerMethodField("get_organizations")
@@ -155,7 +155,7 @@ class ProductSerializer(serializers.ModelSerializer):
         model = models.Product
         fields = [
             "call_to_action",
-            "certificate",
+            "certificate_definition",
             "id",
             "organizations",
             "price",
@@ -166,7 +166,7 @@ class ProductSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = [
             "call_to_action",
-            "certificate",
+            "certificate_definition",
             "id",
             "organizations",
             "price",

--- a/src/backend/joanie/core/serializers.py
+++ b/src/backend/joanie/core/serializers.py
@@ -255,63 +255,6 @@ class ProductSerializer(serializers.ModelSerializer):
         return representation
 
 
-class OrderLiteSerializer(serializers.ModelSerializer):
-    """
-    Minimal Order model serializer
-    """
-
-    id = serializers.CharField(read_only=True)
-    total = MoneyField(
-        coerce_to_string=False,
-        decimal_places=2,
-        max_digits=9,
-        min_value=0,
-        read_only=True,
-    )
-    enrollments = serializers.SerializerMethodField(read_only=True)
-    organization = serializers.SlugRelatedField(read_only=True, slug_field="id")
-    product = serializers.SlugRelatedField(read_only=True, slug_field="id")
-    main_invoice = serializers.SlugRelatedField(read_only=True, slug_field="reference")
-    certificate = serializers.SlugRelatedField(read_only=True, slug_field="id")
-
-    class Meta:
-        model = models.Order
-        fields = [
-            "id",
-            "certificate",
-            "created_on",
-            "main_invoice",
-            "organization",
-            "total",
-            "total_currency",
-            "enrollments",
-            "product",
-            "state",
-        ]
-        read_only_fields = [
-            "id",
-            "certificate",
-            "created_on",
-            "main_invoice",
-            "organization",
-            "total",
-            "total_currency",
-            "enrollments",
-            "product",
-            "state",
-        ]
-
-    def get_enrollments(self, order):
-        """
-        For the current order, retrieve its related enrollments.
-        """
-        return EnrollmentSerializer(
-            instance=order.get_enrollments(),
-            many=True,
-            context=self.context,
-        ).data
-
-
 class CourseSerializer(serializers.ModelSerializer):
     """
     Serialize all information about a course.

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -61,7 +61,31 @@ class CertificateApiTest(BaseAPITestCase):
                 "count": 1,
                 "next": None,
                 "previous": None,
-                "results": [{"id": str(certificate.id)}],
+                "results": [
+                    {
+                        "id": str(certificate.id),
+                        "certificate_definition": {
+                            "description": certificate.certificate_definition.description,
+                            "name": certificate.certificate_definition.name,
+                            "title": certificate.certificate_definition.title,
+                        },
+                        "issued_on": certificate.issued_on.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "order": {
+                            "id": str(certificate.order.id),
+                            "course": {
+                                "code": certificate.order.course.code,
+                                "title": certificate.order.course.title,
+                            },
+                            "organization": {
+                                "id": str(certificate.order.organization.id),
+                                "code": certificate.order.organization.code,
+                                "title": certificate.order.organization.title,
+                            },
+                        },
+                    },
+                ],
             },
         )
 
@@ -163,7 +187,30 @@ class CertificateApiTest(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
 
         content = json.loads(response.content)
-        self.assertEqual(content, {"id": str(certificate.id)})
+        self.assertEqual(
+            content,
+            {
+                "id": str(certificate.id),
+                "certificate_definition": {
+                    "description": certificate.certificate_definition.description,
+                    "name": certificate.certificate_definition.name,
+                    "title": certificate.certificate_definition.title,
+                },
+                "issued_on": certificate.issued_on.isoformat().replace("+00:00", "Z"),
+                "order": {
+                    "id": str(certificate.order.id),
+                    "course": {
+                        "code": certificate.order.course.code,
+                        "title": certificate.order.course.title,
+                    },
+                    "organization": {
+                        "id": str(certificate.order.organization.id),
+                        "code": certificate.order.organization.code,
+                        "title": certificate.order.organization.title,
+                    },
+                },
+            },
+        )
 
     def test_api_certificate_download_anonymous(self):
         """

--- a/src/backend/joanie/tests/core/test_api_products.py
+++ b/src/backend/joanie/tests/core/test_api_products.py
@@ -99,7 +99,7 @@ class ProductApiTest(BaseAPITestCase):
             response.json(),
             {
                 "call_to_action": product.call_to_action,
-                "certificate": {
+                "certificate_definition": {
                     "description": product.certificate_definition.description,
                     "name": product.certificate_definition.name,
                     "title": product.certificate_definition.title,


### PR DESCRIPTION
## Purpose

Api consumer should be able to retrieve certificates earned by the authenticated user. Currently, the CertificateSerializer was minimal by serializing only its id, now we need to return certificate_definition and related order information.

Response example : 
```json
{
  "count": 1,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": "b2566f77-7cbd-4788-bdd8-bffd5c397664",
      "certificate_definition": {
        "description": "",
        "name": "certificate-definition-0",
        "title": "Botanist Certification"
      },
      "issued_on": "2023-03-09T14:42:23.967075Z",
      "order": {
        "id": "3dfe778d-7de1-46bb-b4cc-a3ce26597069",
        "course": {
          "code": "00009",
          "title": "Course 3"
        },
        "organization": {
          "id": "00bc3582-8bfc-483f-bd8a-9f345c73791b",
          "code": "94490848",
          "title": "Organization 0"
        }
      }
    }
  ]
}
```

## Proposal

- [x] Update CertificateSerializer
- [x] Update tests
