### PR TITLE
🚸(core) display course runs into admin course change view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 - Allow on-demand page size on the order and enrollment endpoints
 - Add yarn cli to generate joanie api client in TypeScript
+- Display course runs into the admin course change view
 
 ### Removed
 

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -60,11 +60,40 @@ class CertificateAdmin(admin.ModelAdmin):
         return obj.order.owner
 
 
-class CourseProductRelationInline(admin.TabularInline):
+class CourseProductRelationInline(admin.StackedInline):
     """Admin class for the CourseProductRelation model"""
 
     form = forms.CourseProductRelationAdminForm
     model = models.Course.products.through
+    extra = 0
+
+
+class CourseCourseRunsInline(admin.TabularInline):
+    """Admin class for the CourseCourseRunsInline"""
+
+    model = models.CourseRun
+    show_change_link = True
+
+    readonly_fields = (
+        "title",
+        "resource_link",
+        "enrollment_start",
+        "enrollment_end",
+        "start",
+        "end",
+        "is_listed",
+        "is_gradable",
+    )
+    fields = (
+        "title",
+        "resource_link",
+        "enrollment_start",
+        "enrollment_end",
+        "start",
+        "end",
+        "is_listed",
+        "is_gradable",
+    )
     extra = 0
 
 
@@ -76,10 +105,19 @@ class CourseAdmin(DjangoObjectActions, TranslatableAdmin):
     change_actions = (ACTION_NAME_GENERATE_CERTIFICATES,)
     change_form_template = "joanie/admin/translatable_change_form_with_actions.html"
     list_display = ("code", "title", "state")
+    readonly_fields = ("course_runs",)
     filter_horizontal = ("products",)
-    inlines = (CourseProductRelationInline,)
+    inlines = (CourseCourseRunsInline, CourseProductRelationInline)
     fieldsets = (
-        (_("Main information"), {"fields": ("code", "title")}),
+        (
+            _("Main information"),
+            {
+                "fields": (
+                    "code",
+                    "title",
+                )
+            },
+        ),
         (
             _("Organizations"),
             {
@@ -106,7 +144,15 @@ class CourseAdmin(DjangoObjectActions, TranslatableAdmin):
 class CourseRunAdmin(TranslatableAdmin):
     """Admin class for the CourseRun model"""
 
-    list_display = ("title", "resource_link", "start", "end", "state", "is_gradable")
+    list_display = (
+        "title",
+        "resource_link",
+        "start",
+        "end",
+        "state",
+        "is_gradable",
+        "is_listed",
+    )
     readonly_fields = ("id",)
     fieldsets = (
         (


### PR DESCRIPTION
## Purpose

On course admin change view, we decided to display related course runs with a modification link to ease content administration.

<img width="1652" alt="image" src="https://user-images.githubusercontent.com/9265241/224261337-a6110477-88b6-409d-a5aa-10cae99c2d79.png">


## Proposal

- [x] Display Course Runs into Course Admin page as readonly with through a TabularInline class
