### PR TITLE
🔨(makefile) fix bootstrap command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,11 @@ bootstrap: \
 	build \
 	run \
 	migrate \
+	front-admin-install \
+	front-admin-build \
 	i18n-compile \
 	install-mails \
-	build-mails \
-	front-admin-install \
-	front-admin-build
+	build-mails
 .PHONY: bootstrap
 
 # -- Docker/compose


### PR DESCRIPTION
## Purpose

The bootstrap command does not work properly since we added the front admin install and build steps. Indeed `i18n-compile` extract now translation from front admin project. It requires formatjs to be installed so at the first bootstrap, if developper does not have installed front admin dependencies itself
 the `i18n-compile` command failed.
