### PR TITLE
✨(admin) display password field into user change view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 - Allow on-demand page size on the order and enrollment endpoints
 - Add yarn cli to generate joanie api client in TypeScript
 - Display course runs into the admin course change view
+- Display password field into admin user change view
 
 ### Removed
 

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -199,7 +199,7 @@ class UserAdmin(auth_admin.UserAdmin):
         "language",
     )
     fieldsets = (
-        (None, {"fields": ("username",)}),
+        (None, {"fields": ("username", "password")}),
         (_("Personal info"), {"fields": ("email", "language")}),
         (
             _("Permissions"),


### PR DESCRIPTION
## Purpose

Support members needs to access to admin interface, so a superuser should be able to set a password to new support user to allow them to login to the Joanie admin interface.

<img width="982" alt="image" src="https://user-images.githubusercontent.com/9265241/229141440-9ea7941f-7480-4248-a1a3-917e213c6bd1.png">


## Proposal

- [x] Display password field into admin user change view
