### PR TITLE
👨‍💻(settings) use specific cookie name in dev mode

### DIFF
--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -401,6 +401,8 @@ class Development(Base):
     DEBUG = True
     NGROK_ENDPOINT = values.Value(None, "NGROK_ENDPOINT", environ_prefix=None)
 
+    SESSION_COOKIE_NAME = "joanie_sessionid"
+
     LOGIN_URL = "/admin/login/"
     LOGOUT_URL = "/admin/logout/"
 


### PR DESCRIPTION
## Purpose

During development, we can run several django applications on local hostname. So all those applications are using the same session cookie name so they can be overridden that pretty weird. So we decide to rename joanie cookie session name in development to prevent this behaviour.

## Proposal

- [x] Rename session cookie in development

### Question 
I wonder if it was not better to set the session cookie name for all environment ? 🤔 
