### PR TITLE
♻️(certificates) refactor certificate generation

### DIFF
--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -5,8 +5,8 @@ from typing import List
 
 from django_filters import rest_framework as filters
 
+from .. import models
 from ..enums import ORDER_STATE_CHOICES
-from . import models
 
 
 class OrderViewSetFilter(filters.FilterSet):

--- a/src/backend/joanie/core/helpers.py
+++ b/src/backend/joanie/core/helpers.py
@@ -1,61 +1,7 @@
 """
 Helpers that can be useful throughout Joanie's core app
 """
-from django.core.exceptions import ValidationError
-from django.utils import timezone
-
-from joanie.core import enums, models
-
-
-def generate_certificate_for_order(order):
-    """
-    Check if order is eligible for certification then generate certificate if it is.
-
-    Eligibility means that order contains
-    one passed enrollment per graded courses.
-
-    Return:
-        0: if the order is not eligible for certification
-        1: if a certificate has been generated for the current order
-    """
-    graded_courses = (
-        order.target_courses.filter(order_relations__is_graded=True)
-        .order_by("order_relations__position")
-        .prefetch_related("course_runs")
-    )
-    graded_courses_count = len(graded_courses)
-
-    if graded_courses_count == 0:
-        return 0
-
-    # Retrieve all enrollments in one query. Since these enrollments rely on
-    # order course runs, the count will always be pretty small.
-    course_enrollments = models.Enrollment.objects.filter(
-        course_run__course__in=graded_courses,
-        course_run__is_gradable=True,
-        course_run__start__lte=timezone.now(),
-        is_active=True,
-        user=order.owner,
-    ).select_related("user", "course_run")
-
-    # If we do not have one enrollment per graded course, there is no need to
-    # continue, we are sure that order is not eligible for certification.
-    if len(course_enrollments) != graded_courses_count:
-        return 0
-
-    # Otherwise, we now need to know if each enrollment has been passed
-    for enrollment in course_enrollments:
-        if enrollment.is_passed is False:
-            # If one enrollment has not been passed, no need to continue,
-            # We are sure that order is not eligible for certification.
-            return 0
-
-    try:
-        order.create_certificate()
-    except ValidationError:
-        return 0
-
-    return 1
+from joanie.core import enums
 
 
 def generate_certificates_for_orders(orders):
@@ -64,13 +10,19 @@ def generate_certificates_for_orders(orders):
     then return the count of generated certificates.
     """
     total = 0
-    orders_filtered = orders.filter(
-        state=enums.ORDER_STATE_VALIDATED,
-        certificate__isnull=True,
-        product__type__in=enums.PRODUCT_TYPE_CERTIFICATE_ALLOWED,
-    ).iterator()
+    orders_filtered = (
+        orders.filter(
+            state=enums.ORDER_STATE_VALIDATED,
+            certificate__isnull=True,
+            product__type__in=enums.PRODUCT_TYPE_CERTIFICATE_ALLOWED,
+        )
+        .select_related("product")
+        .iterator()
+    )
 
     for order in orders_filtered:
-        total += generate_certificate_for_order(order)
+        _certificate, created = order.get_or_generate_certificate()
+        if created is True:
+            total += 1
 
     return total

--- a/src/backend/joanie/tests/core/test_commands_generate_certificates.py
+++ b/src/backend/joanie/tests/core/test_commands_generate_certificates.py
@@ -161,13 +161,13 @@ class CreateCertificatesTestCase(TestCase):
         self.assertEqual(certificate_qs.count(), 0)
 
         # A certificate should be generated for the 1st product
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             call_command("generate_certificates", product=product_1.id)
         self.assertEqual(certificate_qs.filter(order=orders[0]).count(), 1)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 0)
 
         # Then a certificate should be generated for the 2nd product
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             call_command("generate_certificates", product=product_2.id)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 1)
 
@@ -264,12 +264,12 @@ class CreateCertificatesTestCase(TestCase):
         self.assertEqual(certificate_qs.count(), 0)
 
         # A certificate should be generated for the 1st product
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             call_command("generate_certificates", product=product_1.id)
         self.assertEqual(certificate_qs.filter(order=orders[0]).count(), 1)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 0)
 
         # Then a certificate should be generated for the 2nd product
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             call_command("generate_certificates", product=product_2.id)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 1)

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -3,6 +3,7 @@ Test suite for order models
 """
 import random
 from datetime import timedelta
+from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
@@ -13,10 +14,11 @@ from django_fsm import TransitionNotAllowed
 from moneyed import Money
 
 from joanie.core import enums, factories
-from joanie.core.models import Enrollment
+from joanie.core.models import Certificate, Enrollment
 from joanie.payment.factories import InvoiceFactory
 
 
+# pylint: disable=too-many-public-methods
 class OrderModelsTestCase(TestCase):
     """Test suite for the Order model."""
 
@@ -453,3 +455,224 @@ class OrderModelsTestCase(TestCase):
         )
         order.cancel()
         self.assertEqual(order.state, enums.ORDER_STATE_CANCELED)
+
+    # get_or_generate_certificate
+
+    def test_models_order_get_or_generate_certificate(self):
+        """Generate a certificate for a product order"""
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - timedelta(hours=1),
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type=random.choice(["certificate", "credential"]),
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            target_courses=[course_run.course],
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertTrue(created)
+        self.assertEqual(Certificate.objects.count(), 1)
+        self.assertEqual(new_certificate, Certificate.objects.first())
+
+        # getting the certificate when it already exists
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertEqual(Certificate.objects.count(), 1)
+        self.assertEqual(new_certificate, Certificate.objects.first())
+
+        document_context = new_certificate.get_document_context()
+        blue_square_base64 = (
+            "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgY"
+            "PgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
+        )
+        self.assertEqual(
+            document_context["organization"]["logo"],
+            blue_square_base64,
+        )
+        self.assertEqual(
+            document_context["organization"]["signature"],
+            blue_square_base64,
+        )
+
+    def test_models_order_get_or_generate_certificate_no_definition(self):
+        """
+        No certificate should be generated in the absence of a certificate definition
+        on the product
+        """
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - timedelta(hours=1),
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type=random.choice(["certificate", "credential"]),
+            certificate_definition=None,  # No certificate definition defined
+            target_courses=[course_run.course],
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertFalse(Certificate.objects.exists())
+        self.assertIsNone(new_certificate)
+
+    def test_models_order_get_or_generate_certificate_type_enrollment(self):
+        """A product of the type "enrollment" should not generate any certificate."""
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - timedelta(hours=1),
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type="enrollment",
+            target_courses=[course_run.course],
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertFalse(Certificate.objects.exists())
+        self.assertIsNone(new_certificate)
+
+    def test_models_order_get_or_generate_certificate_no_graded_course(self):
+        """
+        No certificate should be generated if the product does not have at least one
+        graded course.
+        """
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - timedelta(hours=1),
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type=random.choice(["certificate", "credential"]),
+            certificate_definition=factories.CertificateDefinitionFactory(),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course_run.course,
+            is_graded=False,  # course is not graded
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertFalse(Certificate.objects.exists())
+        self.assertIsNone(new_certificate)
+
+    def test_models_order_get_or_generate_certificate_course_run_is_not_gradable(self):
+        """No certificate should be generated if there is no gradable course runs."""
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=False,  # course run is not gradable
+            start=timezone.now() - timedelta(hours=1),
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type=random.choice(["certificate", "credential"]),
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            target_courses=[course_run.course],
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertFalse(Certificate.objects.exists())
+        self.assertIsNone(new_certificate)
+
+    def test_models_order_get_or_generate_certificate_course_run_in_the_future(self):
+        """No certificate should be generated if the course runs are in the future."""
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now()
+            + timedelta(hours=1),  # course run starts in the future
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type=random.choice(["certificate", "credential"]),
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            target_courses=[course_run.course],
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertFalse(Certificate.objects.exists())
+        self.assertIsNone(new_certificate)
+
+    def test_models_order_get_or_generate_certificate_enrollment_inactive(self):
+        """No certificate should be generated if the user's enrollment is inactive."""
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - timedelta(hours=1),
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type=random.choice(["certificate", "credential"]),
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            target_courses=[course_run.course],
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+        enrollment = Enrollment.objects.get()
+        enrollment.is_active = False
+        enrollment.save()
+
+        new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertFalse(Certificate.objects.exists())
+        self.assertIsNone(new_certificate)
+
+    def test_models_order_get_or_generate_certificate_enrollment_not_passed(self):
+        """No certificate should be generated if the user's enrollment is not passed."""
+        course_run = factories.CourseRunFactory(
+            enrollment_end=timezone.now() + timedelta(hours=1),
+            enrollment_start=timezone.now() - timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - timedelta(hours=1),
+        )
+        product = factories.ProductFactory(
+            price="0.00",
+            type=random.choice(["certificate", "credential"]),
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            target_courses=[course_run.course],
+        )
+        factories.CourseFactory(products=[product])
+        order = factories.OrderFactory(product=product)
+
+        with mock.patch.object(Enrollment, "get_grade", return_value={"passed": False}):
+            new_certificate, created = order.get_or_generate_certificate()
+
+        self.assertFalse(created)
+        self.assertFalse(Certificate.objects.exists())
+        self.assertIsNone(new_certificate)


### PR DESCRIPTION
## Purpose

Some checks were done in the helper and others in the model which lead to unwanted behaviors when I tried adding some missing tests.

## Proposal

Move all checks to the method on the model which is responsible for generating the certificate and rename it to `get_or_generate_certificate` so it works the same as the `get_or_create` method on Django models.