### PR TITLE
Add abilities to courses, organizations and their accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add abilities to courses/organizations and their accesses
 - Add ID field to the course serializer
 - Add course and organization accesses with roles
 - CRUD admin API for organizations, products, course runs,
@@ -24,6 +25,7 @@ and this project adheres to
 
 ### Changed
 
+- Refactor how the user is authenticated and passed throughout the request
 - Normalize the organization code field
 - Activate pagination by default on all endpoints (20 items per page)
 - Use user fullname instead of username in order confirmation email

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add ID field to the course serializer
 - Add course and organization accesses with roles
 - CRUD admin API for organizations, products, course runs,
   certificate definitions, courses and retrieve enabled languages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 
 ### Changed
 
+- Normalize the organization code field
 - Activate pagination by default on all endpoints (20 items per page)
 - Use user fullname instead of username in order confirmation email
 - Rename certificate field into certificate_definition for the ProductSerializer

--- a/src/backend/joanie/core/authentication.py
+++ b/src/backend/joanie/core/authentication.py
@@ -1,0 +1,52 @@
+"""Authentication for joanie's core app."""
+from django.conf import settings
+from django.utils.functional import SimpleLazyObject
+from django.utils.translation import get_supported_language_variant
+from django.utils.translation import gettext_lazy as _
+
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken
+from rest_framework_simplejwt.settings import api_settings
+
+
+def get_user_dict(token):
+    """Get user field values from token."""
+    values = {
+        field: token[token_field]
+        for field, token_field in settings.JWT_USER_FIELDS_SYNC.items()
+        if token_field in token
+    }
+
+    try:
+        values["language"] = get_supported_language_variant(
+            values["language"].replace("_", "-")
+        )
+    except LookupError:
+        values["language"] = settings.LANGUAGE_CODE
+
+    return values
+
+
+class DelegatedJWTAuthentication(JWTAuthentication):
+    """Override JWTAuthentication to create missing users on the fly."""
+
+    def get_user(self, validated_token):
+        """
+        Return the user related to the given validated token, creating it if necessary.
+        """
+        try:
+            user_id = validated_token[api_settings.USER_ID_CLAIM]
+        except KeyError as exc:
+            raise InvalidToken(
+                _("Token contained no recognizable user identification")
+            ) from exc
+
+        def get_or_create_and_update_user():
+            user, _created = self.user_model.objects.get_or_create(
+                **{api_settings.USER_ID_FIELD: user_id},
+                defaults=get_user_dict(validated_token)
+            )
+            user.update_from_token(validated_token)
+            return user
+
+        return SimpleLazyObject(get_or_create_and_update_user)

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -160,6 +160,14 @@ class Organization(parler_models.TranslatableModel, BaseModel):
             f"[{self.code}] {self.safe_translation_getter('title', any_language=True)}"
         )
 
+    def clean(self):
+        """
+        We normalize the code with slugify for better uniqueness
+        """
+        # Normalize the code by slugifying and capitalizing it
+        self.code = utils.normalize_code(self.code)
+        return super().clean()
+
 
 class OrganizationAccess(BaseModel):
     """Link table between organizations and users"""

--- a/src/backend/joanie/core/permissions.py
+++ b/src/backend/joanie/core/permissions.py
@@ -1,50 +1,23 @@
 """Permission handlers for joanie's core app."""
-from abc import abstractmethod
-
 from rest_framework import permissions
 
-from .enums import ADMIN, OWNER
 
-
-class BaseAccessPermission(permissions.BasePermission):
-    """Base permission class for accesses."""
-
-    @abstractmethod
-    def get_resource(self, obj):
-        """Retun the resource instance to which accesses are attached."""
+class IsAuthenticated(permissions.BasePermission):
+    """
+    Allows access only to authenticated users. Alternative method checking the presence
+    of the auth token to avoid hitting the database.
+    """
 
     def has_permission(self, request, view):
-        """Only allow authenticated users."""
-        return request.user.is_authenticated
+        return bool(request.auth) if request.auth else request.user.is_authenticated
+
+
+class AccessPermission(IsAuthenticated):
+    """Permission class for access objects."""
 
     def has_object_permission(self, request, view, obj):
-        """
-        Check that the logged-in user is administrator of the linked resource.
-        """
-        if request.method == "DELETE" and obj.role == OWNER:
-            return obj.user.username == request.user.username
-
-        return (
-            self.get_resource(obj)
-            .accesses.filter(
-                user__username=request.user.username,
-                role__in=[ADMIN, OWNER],
-            )
-            .exists()
+        """Check permission for a given object."""
+        abilities = obj.get_abilities(
+            user=request.user, auth=getattr(request, "auth", None)
         )
-
-
-class CourseAccessPermission(BaseAccessPermission):
-    """Permissions for course accesses."""
-
-    def get_resource(self, obj):
-        """Retun the course instance to which accesses are attached."""
-        return obj.course
-
-
-class OrganizationAccessPermission(BaseAccessPermission):
-    """Permissions for organization accesses."""
-
-    def get_resource(self, obj):
-        """Retun the organization instance to which accesses are attached."""
-        return obj.organization
+        return abilities.get(request.method.lower(), False)

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -44,8 +44,8 @@ class CourseSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Course
-        fields = ("code", "title")
-        read_only_fields = ("code", "title")
+        fields = ("id", "code", "title")
+        read_only_fields = ("id", "code", "title")
 
 
 class CourseAccessSerializer(serializers.ModelSerializer):
@@ -53,7 +53,7 @@ class CourseAccessSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.CourseAccess
-        fields = ["id", "user", "role"]
+        fields = ["id", "role", "user"]
         read_only_fields = ["id"]
 
     def update(self, instance, validated_data):
@@ -126,7 +126,7 @@ class OrganizationAccessSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.OrganizationAccess
-        fields = ["id", "user", "role"]
+        fields = ["id", "role", "user"]
         read_only_fields = ["id"]
 
     def update(self, instance, validated_data):

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -88,50 +88,56 @@ class CourseAccessSerializer(AbilitiesModelSerializer):
         """
         Check access rights specific to writing (create/update)
         """
-        request = self.context["request"]
+        request = self.context.get("request")
+        auth = getattr(request, "auth", None)
+        user = getattr(request, "user", None)
         role = attrs.get("role")
 
         # Update
         if self.instance:
-            can_set_role_to = self.instance.get_abilities(
-                user=request.user, auth=request.auth
-            )["set_role_to"]
+            can_set_role_to = self.instance.get_abilities(user=user, auth=auth)[
+                "set_role_to"
+            ]
 
             if role and role not in can_set_role_to:
                 message = (
                     _(
-                        "You must be administrator or owner of a course to manage its accesses."
-                    )
-                    if can_set_role_to
-                    else _(
                         f"You are only allowed to set role to {', '.join(can_set_role_to)}"
                     )
+                    if can_set_role_to
+                    else _("You are not allowed to set this role for this course.")
                 )
                 raise exceptions.PermissionDenied(message)
 
         # Create
         else:
             username = (
-                request.auth["username"]
-                if request.auth
-                else (request.user.username if request.user.is_authenticated else None)
+                auth["username"]
+                if auth
+                else (user.username if user and user.is_authenticated else None)
             )
+            try:
+                course_id = self.context["course_id"]
+            except KeyError as exc:
+                raise exceptions.ValidationError(
+                    _(
+                        "You must set a course ID in context to create a new course access."
+                    )
+                ) from exc
 
             if not models.CourseAccess.objects.filter(
-                course=self.context["course_id"],
+                course=course_id,
                 user__username=username,
                 role__in=[enums.OWNER, enums.ADMIN],
             ).exists():
                 raise exceptions.PermissionDenied(
-                    _(
-                        "You must be administrator or owner of a course to manage its accesses."
-                    )
+                    _("You are not allowed to manage accesses for this course.")
                 )
 
             if (
                 role == enums.OWNER
                 and not models.CourseAccess.objects.filter(
-                    course=self.context["course_id"],
+                    course=course_id,
                     user__username=username,
                     role=enums.OWNER,
                 ).exists()
@@ -175,52 +181,57 @@ class OrganizationAccessSerializer(AbilitiesModelSerializer):
         """
         Check access rights specific to writing (create/update)
         """
-        request = self.context["request"]
+        request = self.context.get("request")
+        auth = getattr(request, "auth", None)
+        user = getattr(request, "user", None)
         role = attrs.get("role")
 
         # Update
         if self.instance:
-            can_set_role_to = self.instance.get_abilities(
-                user=request.user, auth=request.auth
-            )["set_role_to"]
+            can_set_role_to = self.instance.get_abilities(user=user, auth=auth)[
+                "set_role_to"
+            ]
 
             if role and role not in can_set_role_to:
                 message = (
                     _(
-                        "You must be administrator or owner of a organization "
-                        "to manage its accesses."
-                    )
-                    if can_set_role_to
-                    else _(
                         f"You are only allowed to set role to {', '.join(can_set_role_to)}"
                     )
+                    if can_set_role_to
+                    else _("You are not allowed to set this role for this course.")
                 )
                 raise exceptions.PermissionDenied(message)
 
         # Create
         else:
             username = (
-                request.auth["username"]
-                if request.auth
-                else (request.user.username if request.user.is_authenticated else None)
+                auth["username"]
+                if auth
+                else (user.username if user and user.is_authenticated else None)
             )
+            try:
+                organization_id = self.context["organization_id"]
+            except KeyError as exc:
+                raise exceptions.ValidationError(
+                    _(
+                        "You must set a organization ID in context to create a new "
+                        "organization access."
+                    )
+                ) from exc
 
             if not models.OrganizationAccess.objects.filter(
-                organization=self.context["organization_id"],
+                organization=organization_id,
                 user__username=username,
                 role__in=[enums.OWNER, enums.ADMIN],
             ).exists():
                 raise exceptions.PermissionDenied(
-                    _(
-                        "You must be administrator or owner of an organization "
-                        "to manage its accesses."
-                    )
+                    _("You are not allowed to manage accesses for this organization.")
                 )
 
             if (
                 role == enums.OWNER
                 and not models.OrganizationAccess.objects.filter(
-                    organization=self.context["organization_id"],
+                    organization=organization_id,
                     user__username=username,
                     role=enums.OWNER,
                 ).exists()

--- a/src/backend/joanie/payment/api.py
+++ b/src/backend/joanie/payment/api.py
@@ -9,9 +9,7 @@ from rest_framework import mixins, permissions, viewsets
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from joanie.core.models import User
-
-from . import exceptions, get_payment_backend, serializers
+from . import exceptions, get_payment_backend, models, serializers
 
 logger = logging.getLogger(__name__)
 
@@ -62,5 +60,9 @@ class CreditCardViewSet(
 
     def get_queryset(self):
         """Custom queryset to get user's credit cards"""
-        user = User.update_or_create_from_request_user(request_user=self.request.user)
-        return user.credit_cards.all()
+        username = (
+            self.request.auth["username"]
+            if self.request.auth
+            else self.request.user.username
+        )
+        return models.CreditCard.objects.filter(owner__username=username)

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -159,8 +159,6 @@ class Base(Configuration):
         "django.middleware.csrf.CsrfViewMiddleware",
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
-        "django.contrib.sites.middleware.CurrentSiteMiddleware",
-        "dockerflow.django.middleware.DockerflowMiddleware",
     ]
 
     AUTHENTICATION_BACKENDS = [
@@ -235,7 +233,7 @@ class Base(Configuration):
 
     REST_FRAMEWORK = {
         "DEFAULT_AUTHENTICATION_CLASSES": (
-            "rest_framework_simplejwt.authentication.JWTTokenUserAuthentication",
+            "joanie.core.authentication.DelegatedJWTAuthentication",
         ),
         "DEFAULT_FILTER_BACKENDS": [
             "django_filters.rest_framework.DjangoFilterBackend"
@@ -257,6 +255,15 @@ class Base(Configuration):
         "USER_ID_CLAIM": "username",
         "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
     }
+    JWT_USER_FIELDS_SYNC = values.DictValue(
+        {
+            "email": "email",
+            "first_name": "full_name",
+            "language": "language",
+        },
+        environ_name="JOANIE_JWT_USER_FIELDS_SYNC",
+        environ_prefix=None,
+    )
 
     # Mail
     EMAIL_BACKEND = values.Value("django.core.mail.backends.smtp.EmailBackend")

--- a/src/backend/joanie/tests/base.py
+++ b/src/backend/joanie/tests/base.py
@@ -67,7 +67,7 @@ class BaseAPITestCase(TestCase):
                 "iat": issued_at,
                 "language": user.language,
                 "username": user.username,
-                "fullname": user.get_full_name(),
+                "full_name": user.get_full_name(),
             }
         )
         return token

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -76,6 +76,7 @@ class CertificateApiTest(BaseAPITestCase):
                         "order": {
                             "id": str(order.id),
                             "course": {
+                                "id": str(order.course.id),
                                 "code": order.course.code,
                                 "title": order.course.title,
                             },
@@ -207,6 +208,7 @@ class CertificateApiTest(BaseAPITestCase):
                 "order": {
                     "id": str(certificate.order.id),
                     "course": {
+                        "id": str(certificate.order.course.id),
                         "code": certificate.order.course.code,
                         "title": certificate.order.course.title,
                     },

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -49,12 +49,12 @@ class CertificateApiTest(BaseAPITestCase):
 
         token = self.get_user_token(user.username)
 
-        response = self.client.get(
-            "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
-        )
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            )
 
         self.assertEqual(response.status_code, 200)
-
         order = certificate.order
         self.assertEqual(
             response.json(),

--- a/src/backend/joanie/tests/core/test_api_course_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_course_accesses.py
@@ -520,11 +520,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
-            {
-                "detail": (
-                    "You must be administrator or owner of a course to manage its accesses."
-                )
-            },
+            {"detail": ("You are not allowed to manage accesses for this course.")},
         )
         self.assertFalse(CourseAccess.objects.filter(user=other_user).exists())
 
@@ -552,11 +548,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
-            {
-                "detail": (
-                    "You must be administrator or owner of a course to manage its accesses."
-                )
-            },
+            {"detail": ("You are not allowed to manage accesses for this course.")},
         )
         self.assertFalse(CourseAccess.objects.filter(user=other_user).exists())
 
@@ -584,11 +576,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(
             response.json(),
-            {
-                "detail": (
-                    "You must be administrator or owner of a course to manage its accesses."
-                )
-            },
+            {"detail": ("You are not allowed to manage accesses for this course.")},
         )
         self.assertFalse(CourseAccess.objects.filter(user=other_user).exists())
 

--- a/src/backend/joanie/tests/core/test_api_course_run.py
+++ b/src/backend/joanie/tests/core/test_api_course_run.py
@@ -56,6 +56,7 @@ class CourseRunApiTest(BaseAPITestCase):
                 "id": str(course_run.id),
                 "resource_link": course_run.resource_link,
                 "course": {
+                    "id": str(course_run.course.id),
                     "code": str(course_run.course.code),
                     "title": str(course_run.course.title),
                 },

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -116,6 +116,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                         "course_run": {
                             "id": str(enrollment.course_run.id),
                             "course": {
+                                "id": str(enrollment.course_run.course.id),
                                 "code": str(enrollment.course_run.course.code),
                                 "title": str(enrollment.course_run.course.title),
                             },
@@ -177,6 +178,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                         "course_run": {
                             "id": str(other_enrollment.course_run.id),
                             "course": {
+                                "id": str(enrollment.course_run.course.id),
                                 "code": str(other_enrollment.course_run.course.code),
                                 "title": str(other_enrollment.course_run.course.title),
                             },
@@ -306,6 +308,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                             "id": str(course_run_1.id),
                             "resource_link": course_run_1.resource_link,
                             "course": {
+                                "id": str(course_run_1.course.id),
                                 "code": str(course_run_1.course.code),
                                 "title": str(course_run_1.course.title),
                             },
@@ -452,6 +455,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(enrollment.course_run.id),
                     "course": {
+                        "id": str(enrollment.course_run.course.id),
                         "code": str(enrollment.course_run.course.code),
                         "title": str(enrollment.course_run.course.title),
                     },
@@ -552,6 +556,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -670,6 +675,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -750,6 +756,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -990,6 +997,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -1240,6 +1248,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                     "course_run": {
                         "id": str(enrollment.course_run.id),
                         "course": {
+                            "id": str(enrollment.course_run.course.id),
                             "code": str(enrollment.course_run.course.code),
                             "title": str(enrollment.course_run.course.title),
                         },
@@ -1443,6 +1452,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -1512,6 +1522,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -1568,6 +1579,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -1646,6 +1658,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },
@@ -1702,6 +1715,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
+                        "id": str(course_run.course.id),
                         "code": str(course_run.course.code),
                         "title": str(course_run.course.title),
                     },

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -97,10 +97,12 @@ class EnrollmentApiTest(BaseAPITestCase):
         # The user can see his/her enrollment
         token = self.get_user_token(enrollment.user.username)
 
-        response = self.client.get(
-            "/api/v1.0/enrollments/",
-            HTTP_AUTHORIZATION=f"Bearer {token}",
-        )
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                "/api/v1.0/enrollments/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
 
@@ -159,10 +161,12 @@ class EnrollmentApiTest(BaseAPITestCase):
         # The user linked to the other enrollment can only see his/her enrollment
         token = self.get_user_token(other_enrollment.user.username)
 
-        response = self.client.get(
-            "/api/v1.0/enrollments/",
-            HTTP_AUTHORIZATION=f"Bearer {token}",
-        )
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                "/api/v1.0/enrollments/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content)
 
@@ -288,11 +292,10 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         # Retrieve user's enrollment related to the first course_run
-        with self.assertNumQueries(8):
-            response = self.client.get(
-                f"/api/v1.0/enrollments/?course_run={str(course_run_1.id)}",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            )
+        response = self.client.get(
+            f"/api/v1.0/enrollments/?course_run={str(course_run_1.id)}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -352,11 +355,10 @@ class EnrollmentApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         # Retrieve user's enrollment related to the first course_run
-        with self.assertNumQueries(6):
-            response = self.client.get(
-                "/api/v1.0/enrollments/?course_run=invalid_course_run_id",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            )
+        response = self.client.get(
+            "/api/v1.0/enrollments/?course_run=invalid_course_run_id",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"course_run": ["Enter a valid UUID."]})
@@ -386,7 +388,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             user=user, course_run=cr3, was_created_by_order=True
         )
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 "/api/v1.0/enrollments/?was_created_by_order=false",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -396,7 +398,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         content = response.json()
         self.assertEqual(content["count"], 2)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 "/api/v1.0/enrollments/?was_created_by_order=true",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -54,7 +54,7 @@ class OrderApiTest(BaseAPITestCase):
         # The owner can see his/her order
         token = self.get_user_token(order.owner.username)
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(7):
             response = self.client.get(
                 "/api/v1.0/orders/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -92,11 +92,10 @@ class OrderApiTest(BaseAPITestCase):
         # The owner of the other order can only see his/her order
         token = self.get_user_token(other_order.owner.username)
 
-        with self.assertNumQueries(12):
-            response = self.client.get(
-                "/api/v1.0/orders/",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            )
+        response = self.client.get(
+            "/api/v1.0/orders/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -185,11 +184,10 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         # Retrieve user's order related to the product 1
-        with self.assertNumQueries(13):
-            response = self.client.get(
-                f"/api/v1.0/orders/?product={product_1.id}",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            )
+        response = self.client.get(
+            f"/api/v1.0/orders/?product={product_1.id}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -230,7 +228,7 @@ class OrderApiTest(BaseAPITestCase):
 
         # Try to retrieve user's order related with an invalid product id
         # should return a 400 error
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(0):
             response = self.client.get(
                 "/api/v1.0/orders/?product=invalid_product_id",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -253,7 +251,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         # Retrieve user's order related to the first course linked to the product 1
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(8):
             response = self.client.get(
                 f"/api/v1.0/orders/?course={product_1.courses.first().code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -304,10 +302,9 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         # Retrieve user's order related to the product 1
-        with self.assertNumQueries(13):
-            response = self.client.get(
-                "/api/v1.0/orders/?state=pending", HTTP_AUTHORIZATION=f"Bearer {token}"
-            )
+        response = self.client.get(
+            "/api/v1.0/orders/?state=pending", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -354,10 +351,9 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         # Retrieve user's order related to the product 1
-        with self.assertNumQueries(13):
-            response = self.client.get(
-                "/api/v1.0/orders/?state=canceled", HTTP_AUTHORIZATION=f"Bearer {token}"
-            )
+        response = self.client.get(
+            "/api/v1.0/orders/?state=canceled", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -407,11 +403,10 @@ class OrderApiTest(BaseAPITestCase):
         token = self.get_user_token(user.username)
 
         # Retrieve user's order related to the product 1
-        with self.assertNumQueries(13):
-            response = self.client.get(
-                "/api/v1.0/orders/?state=validated",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            )
+        response = self.client.get(
+            "/api/v1.0/orders/?state=validated",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -452,7 +447,7 @@ class OrderApiTest(BaseAPITestCase):
 
         # Try to retrieve user's order related with an invalid product id
         # should return a 400 error
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(0):
             response = self.client.get(
                 "/api/v1.0/orders/?state=invalid_state",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -490,7 +485,7 @@ class OrderApiTest(BaseAPITestCase):
         order = factories.OrderFactory(product=product, owner=owner)
         token = self.generate_token_from_user(owner)
 
-        with self.assertNumQueries(19):
+        with self.assertNumQueries(14):
             response = self.client.get(
                 f"/api/v1.0/orders/{order.id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -1150,7 +1145,7 @@ class OrderApiTest(BaseAPITestCase):
             "billing_address": billing_address,
         }
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(19):
             response = self.client.post(
                 "/api/v1.0/orders/",
                 data=data,

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -830,7 +830,7 @@ class OrderApiTest(BaseAPITestCase):
         )
         course = product.courses.first()
         organization = product.course_relations.first().organizations.first()
-        self.assertEqual(
+        self.assertCountEqual(
             list(product.target_courses.order_by("product_relations")), target_courses
         )
 
@@ -856,7 +856,7 @@ class OrderApiTest(BaseAPITestCase):
         self.assertEqual(models.Order.objects.count(), 1)
         order = models.Order.objects.get()
 
-        self.assertEqual(
+        self.assertCountEqual(
             list(order.target_courses.order_by("product_relations")), target_courses
         )
 

--- a/src/backend/joanie/tests/core/test_api_organization_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_organization_accesses.py
@@ -486,7 +486,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             response.json(),
             {
                 "detail": (
-                    "You must be administrator or owner of an organization to manage its accesses."
+                    "You are not allowed to manage accesses for this organization."
                 )
             },
         )
@@ -516,7 +516,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             response.json(),
             {
                 "detail": (
-                    "You must be administrator or owner of an organization to manage its accesses."
+                    "You are not allowed to manage accesses for this organization."
                 )
             },
         )

--- a/src/backend/joanie/tests/core/test_api_products.py
+++ b/src/backend/joanie/tests/core/test_api_products.py
@@ -50,7 +50,7 @@ class ProductApiTest(BaseAPITestCase):
             course=course, product=product, organizations=[]
         )
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             response = self.client.get(
                 f"/api/v1.0/products/{product.id}/?course={course.code}"
             )
@@ -69,7 +69,7 @@ class ProductApiTest(BaseAPITestCase):
             course=course, product=product, organizations=[organization]
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             response = self.client.get(f"/api/v1.0/products/{product.id}/")
 
         self.assertEqual(response.status_code, 400)
@@ -89,7 +89,7 @@ class ProductApiTest(BaseAPITestCase):
             course=course, product=product, organizations=[organization]
         )
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.get(
                 f"/api/v1.0/products/{product.id}/?course={course.code}"
             )
@@ -173,7 +173,7 @@ class ProductApiTest(BaseAPITestCase):
                 ],
                 "title": product.title,
                 "type": product.type,
-                "orders": None,
+                "orders": [],
             },
         )
 
@@ -210,7 +210,7 @@ class ProductApiTest(BaseAPITestCase):
 
         self.assertEqual(order.state, "pending")
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/v1.0/products/{product.id}/?course={course.code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -237,7 +237,7 @@ class ProductApiTest(BaseAPITestCase):
 
         self.assertEqual(order.state, "validated")
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/v1.0/products/{product.id}/?course={course.code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -266,7 +266,7 @@ class ProductApiTest(BaseAPITestCase):
 
         self.assertEqual(order.state, "canceled")
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/v1.0/products/{product.id}/?course={course.code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -286,7 +286,7 @@ class ProductApiTest(BaseAPITestCase):
             type=enums.PRODUCT_TYPE_CREDENTIAL, courses=[course1]
         )
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             response = self.client.get(
                 f"/api/v1.0/products/{product.id}/?course={course2.code}"
             )
@@ -345,7 +345,7 @@ class ProductApiTest(BaseAPITestCase):
 
         # If user request product only and filter to the first course,
         # it should get only one order into orders property
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/v1.0/products/{product.id}/?course={courses[0].code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_authentication_delegated_jwt_authentication.py
+++ b/src/backend/joanie/tests/core/test_authentication_delegated_jwt_authentication.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for the DelegatedJWTAuthentication backend.
+"""
+from joanie.core import factories, models
+from joanie.core.authentication import DelegatedJWTAuthentication
+from joanie.tests.base import BaseAPITestCase
+
+
+class DelegatedJWTAuthenticationTestCase(BaseAPITestCase):
+    """
+    Unit test suite to validate the behavior of the DelegatedJWTAuthentication backend.
+    """
+
+    def test_authentication_delegated_user_unknown(self):
+        """If the user is unknown, it should be created on the fly."""
+        token = self.get_user_token("dave")
+        token.payload.update(
+            {
+                "full_name": "David",
+                "email": "david.bowman@hal.com",
+                "language": "fr-fr",
+            }
+        )
+
+        auth_user = DelegatedJWTAuthentication().get_user(token)
+
+        # The user should not be created yet
+        self.assertFalse(models.User.objects.exists())
+
+        # Now trigger the lazy wrapper evaluation
+        str(auth_user)
+
+        # The user should now have been created
+        user = models.User.objects.get()
+        self.assertEqual(user.email, "david.bowman@hal.com")
+        self.assertEqual(user.username, "dave")
+        self.assertEqual(user.first_name, "David")
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+
+    def test_authentication_delegated_user_existing(self):
+        """
+        If the user is existing, it should get synchronized but only when
+        the user is accessed from the request.
+        """
+        user = factories.UserFactory(first_name="Rodolphe")
+        other_user = factories.UserFactory(first_name="Rudiger")
+
+        token = self.generate_token_from_user(user)
+        token["full_name"] = "Thomas"
+
+        auth_user = DelegatedJWTAuthentication().get_user(token)
+
+        self.assertEqual(models.User.objects.count(), 2)
+
+        # The user should not have been synchronized yet
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, "Rodolphe")
+
+        # Now trigger the lazy wrapper evaluation
+        str(auth_user)
+
+        # The user should not have been synchronized
+        user.refresh_from_db()
+        self.assertEqual(user.first_name, "Thomas")
+
+        # The other user was left unchanged
+        other_user.refresh_from_db()
+        self.assertEqual(other_user.first_name, "Rudiger")

--- a/src/backend/joanie/tests/core/test_models_course_access.py
+++ b/src/backend/joanie/tests/core/test_models_course_access.py
@@ -1,0 +1,460 @@
+"""
+Test suite for course access models
+"""
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ValidationError
+
+from joanie.core import factories, models
+from joanie.tests.base import BaseAPITestCase
+
+
+# pylint: disable=too-many-public-methods
+class CourseAccessModelsTestCase(BaseAPITestCase):
+    """Test suite for the CourseAccess model."""
+
+    def test_models_course_access_course_user_pair_unique(self):
+        """Only one course access object is allowed per course/user pair."""
+        access = factories.UserCourseAccessFactory()
+
+        # Creating a second course access for the same course/user pair should raise an error...
+        with self.assertRaises(ValidationError) as context:
+            factories.UserCourseAccessFactory(course=access.course, user=access.user)
+
+        self.assertEqual(
+            context.exception.messages[0],
+            "Course access with this Course and User already exists.",
+        )
+        self.assertEqual(models.CourseAccess.objects.count(), 1)
+
+    # get_abilities
+
+    def test_models_course_access_get_abilities_anonymous(self):
+        """Check abilities returned for an anonymous user."""
+        access = factories.UserCourseAccessFactory()
+        abilities = access.get_abilities(user=AnonymousUser())
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": False,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_authenticated(self):
+        """Check abilities returned for an authenticated user."""
+        access = factories.UserCourseAccessFactory()
+        abilities = access.get_abilities(user=factories.UserFactory())
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": False,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    # - for owner
+
+    def test_models_course_access_get_abilities_for_owner_of_self_allowed(self):
+        """
+        Check abilities of self access for the owner of a course when there is more
+        than one user left.
+        """
+        access = factories.UserCourseAccessFactory(role="owner")
+        factories.UserCourseAccessFactory(
+            course=access.course, role="owner"
+        )  # another one
+        abilities = access.get_abilities(user=access.user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["administrator", "instructor", "manager"],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_owner_of_self_last(self):
+        """
+        Check abilities of self access for the owner of a course when there is
+        only one owner left.
+        """
+        access = factories.UserCourseAccessFactory(role="owner")
+        abilities = access.get_abilities(user=access.user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_owner_of_owner(self):
+        """Check abilities of owner access for the owner of a course."""
+        access = factories.UserCourseAccessFactory(role="owner")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="owner"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_owner_of_administrator(self):
+        """Check abilities of administrator access for the owner of a course."""
+        access = factories.UserCourseAccessFactory(role="administrator")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="owner"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["owner", "instructor", "manager"],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_owner_of_instructor(self):
+        """Check abilities of instructor access for the owner of a course."""
+        access = factories.UserCourseAccessFactory(role="instructor")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="owner"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["owner", "administrator", "manager"],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_owner_of_manager(self):
+        """Check abilities of manager access for the owner of a course."""
+        access = factories.UserCourseAccessFactory(role="manager")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="owner"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["owner", "administrator", "instructor"],
+            },
+        )
+
+    # - for administrator
+
+    def test_models_course_access_get_abilities_for_administrator_of_owner(self):
+        """Check abilities of owner access for the administator of a course."""
+        access = factories.UserCourseAccessFactory(role="owner")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="administrator"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_administrator_of_administrator(
+        self,
+    ):
+        """Check abilities of administrator access for the administrator of a course."""
+        access = factories.UserCourseAccessFactory(role="administrator")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="administrator"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["instructor", "manager"],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_administrator_of_instructor(self):
+        """Check abilities of instructor access for the administrator of a course."""
+        access = factories.UserCourseAccessFactory(role="instructor")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="administrator"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["administrator", "manager"],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_administrator_of_manager(self):
+        """Check abilities of manager access for the administrator of a course."""
+        access = factories.UserCourseAccessFactory(role="manager")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="administrator"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["administrator", "instructor"],
+            },
+        )
+
+    # - for instructor
+
+    def test_models_course_access_get_abilities_for_instructor_of_owner(self):
+        """Check abilities of owner access for the instructor of a course."""
+        access = factories.UserCourseAccessFactory(role="owner")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="instructor"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_instructor_of_administrator(self):
+        """Check abilities of administrator access for the instructor of a course."""
+        access = factories.UserCourseAccessFactory(role="administrator")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="instructor"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_instructor_of_instructor(self):
+        """Check abilities of instructor access for the instructor of a course."""
+        access = factories.UserCourseAccessFactory(role="instructor")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="instructor"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_instructor_of_manager(self):
+        """Check abilities of manager access for the instructor of a course."""
+        access = factories.UserCourseAccessFactory(role="manager")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="instructor"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    # - for manager
+
+    def test_models_course_access_get_abilities_for_manager_of_owner(self):
+        """Check abilities of owner access for the manager of a course."""
+        access = factories.UserCourseAccessFactory(role="owner")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="manager"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_manager_of_administrator(self):
+        """Check abilities of administrator access for the manager of a course."""
+        access = factories.UserCourseAccessFactory(role="administrator")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="manager"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_manager_of_instructor(self):
+        """Check abilities of instructor access for the manager of a course."""
+        access = factories.UserCourseAccessFactory(role="instructor")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="manager"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_for_manager_of_manager(self):
+        """Check abilities of manager access for the manager of a course."""
+        access = factories.UserCourseAccessFactory(role="manager")
+        factories.UserCourseAccessFactory(course=access.course)  # another one
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="manager"
+        ).user
+
+        with self.assertNumQueries(1):
+            abilities = access.get_abilities(user=user)
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_auth(self):
+        """Check abilities returned when passing a token instead of a user."""
+        access = factories.UserCourseAccessFactory(role="manager")
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="manager"
+        ).user
+        token = self.get_user_token(user.username)
+
+        with self.assertNumQueries(1):
+            abilities = access.get_abilities(auth=token)
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_course_access_get_abilities_preset_role(self):
+        """No query is done if the role is preset e.g. with query annotation."""
+        access = factories.UserCourseAccessFactory(role="manager")
+        user = factories.UserCourseAccessFactory(
+            course=access.course, role="manager"
+        ).user
+        access.user_role = "manager"
+
+        with self.assertNumQueries(0):
+            abilities = access.get_abilities(user=user)
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -52,6 +52,23 @@ class OrderModelsTestCase(TestCase):
 
         factories.OrderFactory(owner=order.owner, product=product, course=order.course)
 
+    def test_models_order_course_runs_relation_sorted_by_position(self):
+        """The product/course relation should be sorted by position."""
+        courses = factories.CourseFactory.create_batch(5)
+        product = factories.ProductFactory(target_courses=courses)
+
+        # Create an order link to the product
+        order = factories.OrderFactory(product=product)
+
+        target_courses = order.target_courses.order_by("product_target_relations")
+        self.assertCountEqual(target_courses, courses)
+
+        position = 0
+        for target_course in target_courses:
+            course_position = target_course.product_target_relations.get().position
+            self.assertGreaterEqual(course_position, position)
+            position = course_position
+
     def test_models_order_course_in_product_new(self):
         """
         An order's course should be included in the target courses of its related product at

--- a/src/backend/joanie/tests/core/test_models_organization.py
+++ b/src/backend/joanie/tests/core/test_models_organization.py
@@ -1,0 +1,34 @@
+"""
+Test suite for organization models
+"""
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from joanie.core import factories, models
+
+
+class OrganizationModelsTestCase(TestCase):
+    """Test suite for the Organization model."""
+
+    def test_models_organization_fields_code_normalize(self):
+        """The `code` field should be normalized to an ascii slug on save."""
+        organization = factories.OrganizationFactory()
+
+        organization.code = "Là&ça boô"
+        organization.save()
+        self.assertEqual(organization.code, "LACA-BOO")
+
+    def test_models_organization_fields_code_unique(self):
+        """The `code` field should be unique among organizations."""
+        factories.OrganizationFactory(code="the-unique-code")
+
+        # Creating a second organization with the same code should raise an error...
+        with self.assertRaises(ValidationError) as context:
+            factories.OrganizationFactory(code="the-unique-code")
+
+        self.assertEqual(
+            context.exception.messages[0], "Organization with this Code already exists."
+        )
+        self.assertEqual(
+            models.Organization.objects.filter(code="THE-UNIQUE-CODE").count(), 1
+        )

--- a/src/backend/joanie/tests/core/test_models_organization_access.py
+++ b/src/backend/joanie/tests/core/test_models_organization_access.py
@@ -1,0 +1,346 @@
+"""
+Test suite for organization access models
+"""
+from django.contrib.auth.models import AnonymousUser
+from django.core.exceptions import ValidationError
+
+from joanie.core import factories, models
+from joanie.tests.base import BaseAPITestCase
+
+
+# pylint: disable=too-many-public-methods
+class OrganizationAccessModelsTestCase(BaseAPITestCase):
+    """Test suite for the OrganizationAccess model."""
+
+    def test_models_organization_access_organization_user_pair_unique(self):
+        """Only one organization access object is allowed per organization/user pair."""
+        access = factories.UserOrganizationAccessFactory()
+
+        # Creating a second organization access for the same organization/user pair
+        # should raise an error...
+        with self.assertRaises(ValidationError) as context:
+            factories.UserOrganizationAccessFactory(
+                organization=access.organization, user=access.user
+            )
+
+        self.assertEqual(
+            context.exception.messages[0],
+            "Organization access with this Organization and User already exists.",
+        )
+        self.assertEqual(models.OrganizationAccess.objects.count(), 1)
+
+    # get_abilities
+
+    def test_models_organization_access_get_abilities_anonymous(self):
+        """Check abilities returned for an anonymous user."""
+        access = factories.UserOrganizationAccessFactory()
+        abilities = access.get_abilities(user=AnonymousUser())
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": False,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_authenticated(self):
+        """Check abilities returned for an authenticated user."""
+        access = factories.UserOrganizationAccessFactory()
+        abilities = access.get_abilities(user=factories.UserFactory())
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": False,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    # - for owner
+
+    def test_models_organization_access_get_abilities_for_owner_of_self_allowed(self):
+        """
+        Check abilities of self access for the owner of a organization when there is more
+        than one user left.
+        """
+        access = factories.UserOrganizationAccessFactory(role="owner")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="owner"
+        )  # another one
+        abilities = access.get_abilities(user=access.user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["administrator", "member"],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_owner_of_self_last(self):
+        """
+        Check abilities of self access for the owner of a organization when there is
+        only one owner left.
+        """
+        access = factories.UserOrganizationAccessFactory(role="owner")
+        abilities = access.get_abilities(user=access.user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_owner_of_owner(self):
+        """Check abilities of owner access for the owner of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="owner")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="owner"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_owner_of_administrator(self):
+        """Check abilities of administrator access for the owner of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="administrator")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="owner"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["owner", "member"],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_owner_of_member(self):
+        """Check abilities of member access for the owner of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="member")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="owner"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["owner", "administrator"],
+            },
+        )
+
+    # - for administrator
+
+    def test_models_organization_access_get_abilities_for_administrator_of_owner(self):
+        """Check abilities of owner access for the administator of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="owner")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="administrator"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_administrator_of_administrator(
+        self,
+    ):
+        """Check abilities of administrator access for the administrator of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="administrator")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="administrator"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["member"],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_administrator_of_member(self):
+        """Check abilities of member access for the administrator of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="member")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="administrator"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": True,
+                "get": True,
+                "patch": True,
+                "put": True,
+                "set_role_to": ["administrator"],
+            },
+        )
+
+    # - for member
+
+    def test_models_organization_access_get_abilities_for_member_of_owner(self):
+        """Check abilities of owner access for the member of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="owner")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="member"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_member_of_administrator(self):
+        """Check abilities of administrator access for the member of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="administrator")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="member"
+        ).user
+        abilities = access.get_abilities(user=user)
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_for_member_of_member_user(self):
+        """Check abilities of member access for the member of a organization."""
+        access = factories.UserOrganizationAccessFactory(role="member")
+        factories.UserOrganizationAccessFactory(
+            organization=access.organization
+        )  # another one
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="member"
+        ).user
+
+        with self.assertNumQueries(1):
+            abilities = access.get_abilities(user=user)
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_member_auth(self):
+        """Check abilities returned when passing a token instead of a user."""
+        access = factories.UserOrganizationAccessFactory(role="member")
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="member"
+        ).user
+        token = self.get_user_token(user.username)
+
+        with self.assertNumQueries(1):
+            abilities = access.get_abilities(auth=token)
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )
+
+    def test_models_organization_access_get_abilities_preset_role(self):
+        """No query is done if the role is preset e.g. with query annotation."""
+        access = factories.UserOrganizationAccessFactory(role="member")
+        user = factories.UserOrganizationAccessFactory(
+            organization=access.organization, role="member"
+        ).user
+        access.user_role = "member"
+
+        with self.assertNumQueries(0):
+            abilities = access.get_abilities(user=user)
+
+        self.assertEqual(
+            abilities,
+            {
+                "delete": False,
+                "get": True,
+                "patch": False,
+                "put": False,
+                "set_role_to": [],
+            },
+        )

--- a/src/backend/joanie/tests/core/test_models_product.py
+++ b/src/backend/joanie/tests/core/test_models_product.py
@@ -12,7 +12,7 @@ from django.test import TestCase
 from djmoney.money import Money
 from moneyed import EUR
 
-from joanie.core import enums, factories, models
+from joanie.core import enums, factories
 
 
 class ProductModelsTestCase(TestCase):

--- a/src/backend/joanie/tests/core/test_models_product.py
+++ b/src/backend/joanie/tests/core/test_models_product.py
@@ -58,15 +58,11 @@ class ProductModelsTestCase(TestCase):
         product = factories.ProductFactory()
         factories.ProductTargetCourseRelationFactory.create_batch(5, product=product)
 
-        expected_courses = list(
-            p.course
-            for p in models.ProductTargetCourseRelation.objects.order_by("position")
-        )
-
-        ordered_courses = list(
-            product.target_courses.order_by("product_target_relations")
-        )
-        self.assertEqual(ordered_courses, expected_courses)
+        position = 0
+        for course in product.target_courses.order_by("product_target_relations"):
+            course_position = course.product_target_relations.get().position
+            self.assertGreaterEqual(course_position, position)
+            position = course_position
 
     def test_models_product_course_runs_relation_course_runs(self):
         """

--- a/src/backend/joanie/tests/core/test_serializers_course_access.py
+++ b/src/backend/joanie/tests/core/test_serializers_course_access.py
@@ -1,0 +1,53 @@
+"""Test suite for the course access serializer"""
+import random
+
+from django.test import TestCase
+
+from rest_framework import exceptions
+
+from joanie.core import factories, models, serializers
+
+
+class CourseAccessSerializerTestCase(TestCase):
+    """Course access serializer test case"""
+
+    def test_serializers_course_access_no_request_no_course(self):
+        """
+        The course access serializer should return a 400 if "course_id" is not passed in context.
+        """
+        user = factories.UserFactory()
+
+        data = {
+            "user": str(user.id),
+            "role": random.choice(models.CourseAccess.ROLE_CHOICES)[0],
+        }
+        serializer = serializers.CourseAccessSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "non_field_errors": [
+                    "You must set a course ID in context to create a new course access."
+                ]
+            },
+        )
+
+    def test_serializers_course_access_no_request_with_course(self):
+        """
+        The course access serializer should raise a permission error even if a "course_id"
+        is passed if there is no request, so no authorized user.
+        """
+        user = factories.UserFactory()
+        course = factories.CourseFactory()
+
+        data = {
+            "user": str(user.id),
+            "role": random.choice(models.CourseAccess.ROLE_CHOICES)[0],
+        }
+        serializer = serializers.CourseAccessSerializer(
+            data=data, context={"course_id": str(course.id)}
+        )
+
+        with self.assertRaises(exceptions.PermissionDenied):
+            self.assertTrue(serializer.is_valid())

--- a/src/backend/joanie/tests/core/test_serializers_organization_access.py
+++ b/src/backend/joanie/tests/core/test_serializers_organization_access.py
@@ -1,0 +1,51 @@
+"""Test suite for the organization access serializer"""
+import random
+
+from django.test import TestCase
+
+from rest_framework import exceptions
+
+from joanie.core import factories, models, serializers
+
+
+class OrganizationAccessSerializerTestCase(TestCase):
+    """Organization access serializer test case"""
+
+    def test_serializers_organization_access_no_request_no_organization(self):
+        """
+        The organization access serializer should return a 400 if "organization_id"
+        is not passed in context.
+        """
+        user = factories.UserFactory()
+
+        data = {
+            "user": str(user.id),
+            "role": random.choice(models.OrganizationAccess.ROLE_CHOICES)[0],
+        }
+        serializer = serializers.OrganizationAccessSerializer(data=data)
+
+        self.assertFalse(serializer.is_valid())
+        message = "You must set a organization ID in context to create a new organization access."
+        self.assertEqual(
+            serializer.errors,
+            {"non_field_errors": [message]},
+        )
+
+    def test_serializers_organization_access_no_request_with_organization(self):
+        """
+        The organization access serializer should raise a permission error even if a
+        "organization_id" is passed if there is no request, so no authorized user.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+
+        data = {
+            "user": str(user.id),
+            "role": random.choice(models.OrganizationAccess.ROLE_CHOICES)[0],
+        }
+        serializer = serializers.OrganizationAccessSerializer(
+            data=data, context={"organization_id": str(organization.id)}
+        )
+
+        with self.assertRaises(exceptions.PermissionDenied):
+            self.assertTrue(serializer.is_valid())

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -136,9 +136,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         payment information provided then mark order as validated.
         """
         backend = TestBasePaymentBackend()
-        owner = UserFactory(
-            email="sam@fun-test.fr", language="en-us", username="Samantha"
-        )
+        owner = UserFactory(email="sam@fun-test.fr", language="en-us")
         order = OrderFactory(owner=owner)
         billing_address = BillingAddressDictFactory()
         payment = {
@@ -162,7 +160,9 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         self.assertEqual(order.state, "validated")
 
         # - Email has been sent
-        self._check_order_validated_email_sent("sam@fun-test.fr", "Samantha", order)
+        self._check_order_validated_email_sent(
+            "sam@fun-test.fr", owner.get_full_name(), order
+        )
 
     def test_payment_backend_base_do_on_payment_failure(self):
         """
@@ -325,7 +325,10 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
 
         backend = TestBasePaymentBackend()
         owner = UserFactory(
-            email="sam@fun-test.fr", language="fr-fr", username="Samantha"
+            email="sam@fun-test.fr",
+            language="fr-fr",
+            first_name="Dave",
+            last_name="Bowman",
         )
         order = OrderFactory(owner=owner)
         billing_address = BillingAddressDictFactory()
@@ -352,7 +355,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         # - Email has been sent
         email_content = " ".join(mail.outbox[0].body.split())
         self.assertIn("Votre commande a été confirmée.", email_content)
-        self.assertIn("Bonjour Samantha", email_content)
+        self.assertIn("Bonjour Dave Bowman", email_content)
         self.assertNotIn("Your order has been confirmed.", email_content)
 
         # - Check it's the right object

--- a/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
+++ b/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
@@ -104,7 +104,11 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):
 
         backend = DummyPaymentBackend()
         owner = UserFactory(
-            email="sam@fun-test.fr", language="en-us", username="Samantha"
+            email="sam@fun-test.fr",
+            language="en-us",
+            username="Samantha",
+            first_name="",
+            last_name="",
         )
         order = OrderFactory(owner=owner)
         billing_address = BillingAddressDictFactory()

--- a/src/backend/joanie/tests/payment/test_backend_payplug.py
+++ b/src/backend/joanie/tests/payment/test_backend_payplug.py
@@ -466,7 +466,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
 
         # Email has been sent
         self._check_order_validated_email_sent(
-            order.owner.email, order.owner.username, order
+            order.owner.email, order.owner.get_full_name(), order
         )
 
     @mock.patch.object(BasePaymentBackend, "_do_on_payment_success")


### PR DESCRIPTION
## Purpose

We want to transmit to the frontend what a user is allowed to do or not on a given object. This is derived from the state of the object and the role that the logged-in user has on this object.

## Proposal

- [x] Add a method `get_abilities` on the models
- [x] Add a field `abilities` on the API endpoints
- [x] Refactor how authentication is handled and the user is passed thourghout the request

 
While working on this PR I had the opportunity to make minor improvements:
- [x] Add `ID` field to the course serialiser
- [x] Normalize the organization `code` field
- [x] Fix randomly failing tests
