### PR TITLE
Refactor `get_abilities` method and add user abilities

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -73,8 +73,7 @@ class ProductViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
 
     def get_serializer_context(self):
         """
-        Provide username to the authenticated user (if one is authenticated)
-        and course code to the `ProductSerializer`
+        Provide course code to the `ProductSerializer`
         """
         context = super().get_serializer_context()
 
@@ -546,17 +545,12 @@ class OrganizationAccessViewSet(
             # Limit to accesses that are linked to an organization THAT has an access
             # for the logged-in user (not filtering the only access linked to the
             # logged-in user)
-            username = (
-                self.request.auth["username"]
-                if self.request.auth
-                else self.request.user.username
-            )
             user_role_query = models.OrganizationAccess.objects.filter(
-                organization__accesses__user__username=username
+                organization__accesses__user=self.request.user
             ).values("role")[:1]
             queryset = (
                 queryset.filter(
-                    organization__accesses__user__username=username,
+                    organization__accesses__user=self.request.user,
                 )
                 .annotate(user_role=Subquery(user_role_query))
                 .distinct()
@@ -626,17 +620,12 @@ class CourseAccessViewSet(
             # Limit to accesses that are linked to a course THAT has an access
             # for the logged-in user (not filtering the only access linked to the
             # logged-in user)
-            username = (
-                self.request.auth["username"]
-                if self.request.auth
-                else self.request.user.username
-            )
             user_role_query = models.CourseAccess.objects.filter(
-                course__accesses__user__username=username
+                course__accesses__user=self.request.user
             ).values("role")[:1]
             queryset = (
                 queryset.filter(
-                    course__accesses__user__username=username,
+                    course__accesses__user=self.request.user,
                 )
                 .annotate(user_role=Subquery(user_role_query))
                 .distinct()

--- a/src/backend/joanie/core/models/accounts.py
+++ b/src/backend/joanie/core/models/accounts.py
@@ -9,6 +9,7 @@ from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 
 from django_countries.fields import CountryField
+from rest_framework_simplejwt.settings import api_settings
 
 from ..authentication import get_user_dict
 from .base import BaseModel
@@ -44,7 +45,13 @@ class User(BaseModel, auth_models.AbstractUser):
         values = get_user_dict(token)
         for key, value in values.items():
             if value != getattr(self, key):
-                User.objects.filter(username=self.username).update(**values)
+                User.objects.filter(
+                    **{
+                        api_settings.USER_ID_FIELD: getattr(
+                            self, api_settings.USER_ID_FIELD
+                        )
+                    }
+                ).update(**values)
                 break
 
     def get_abilities(self, user):

--- a/src/backend/joanie/core/permissions.py
+++ b/src/backend/joanie/core/permissions.py
@@ -17,7 +17,5 @@ class AccessPermission(IsAuthenticated):
 
     def has_object_permission(self, request, view, obj):
         """Check permission for a given object."""
-        abilities = obj.get_abilities(
-            user=request.user, auth=getattr(request, "auth", None)
-        )
+        abilities = obj.get_abilities(request.user)
         return abilities.get(request.method.lower(), False)

--- a/src/backend/joanie/tests/core/test_api_address.py
+++ b/src/backend/joanie/tests/core/test_api_address.py
@@ -95,7 +95,7 @@ class AddressAPITestCase(BaseAPITestCase):
     def test_api_address_get_addresses(self):
         """Get addresses for a user in db with two addresses linked to him"""
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         address1 = factories.AddressFactory.create(owner=user, title="Office")
         address2 = factories.AddressFactory.create(owner=user, title="Home")
 
@@ -132,7 +132,7 @@ class AddressAPITestCase(BaseAPITestCase):
     def test_api_address_list_pagination(self, _mock_page_size):
         """Pagination should work as expected."""
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         addresses = factories.AddressFactory.create_batch(3, owner=user)
         address_ids = [str(address.id) for address in addresses]
@@ -243,8 +243,8 @@ class AddressAPITestCase(BaseAPITestCase):
         """Create user addresses not allowed with user token expired"""
         # Try to create addresses with expired token
         user = factories.UserFactory()
-        token = self.get_user_token(
-            user.username,
+        token = self.generate_token_from_user(
+            user,
             expires_at=arrow.utcnow().shift(days=-1).datetime,
         )
         address = factories.AddressFactory.build()
@@ -264,8 +264,8 @@ class AddressAPITestCase(BaseAPITestCase):
         """Update user addresses not allowed with user token expired"""
         # Try to update addresses with expired token
         user = factories.UserFactory()
-        token = self.get_user_token(
-            user.username,
+        token = self.generate_token_from_user(
+            user,
             expires_at=arrow.utcnow().shift(days=-1).datetime,
         )
         address = factories.AddressFactory.create(owner=user)
@@ -317,7 +317,7 @@ class AddressAPITestCase(BaseAPITestCase):
     def test_api_address_update_with_bad_payload(self):
         """Update user addresses with valid token but bad data"""
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         address = factories.AddressFactory.create(owner=user)
         new_address = factories.AddressFactory.build()
         payload = get_payload(new_address)
@@ -379,7 +379,7 @@ class AddressAPITestCase(BaseAPITestCase):
         User should not be able to demote its main address
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         address = factories.AddressFactory(owner=user, is_main=True)
 
         payload = get_payload(address)
@@ -444,7 +444,7 @@ class AddressAPITestCase(BaseAPITestCase):
         it should not be allowed to set the "id" field
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         address = factories.AddressFactory.build()
         # - Add an id field to the request body
         payload = get_payload(address)
@@ -501,8 +501,8 @@ class AddressAPITestCase(BaseAPITestCase):
     def test_api_address_delete_with_expired_token(self):
         """Delete address is not allowed with expired token"""
         user = factories.UserFactory()
-        token = self.get_user_token(
-            user.username,
+        token = self.generate_token_from_user(
+            user,
             expires_at=arrow.utcnow().shift(days=-1).datetime,
         )
         address = factories.AddressFactory.create(owner=user)
@@ -527,7 +527,7 @@ class AddressAPITestCase(BaseAPITestCase):
     def test_api_address_delete(self):
         """Delete address is allowed with valid token"""
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         address = factories.AddressFactory.create(owner=user)
         response = self.client.delete(
             f"/api/v1.0/addresses/{address.id}/",

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -53,7 +53,7 @@ class CertificateApiTest(BaseAPITestCase):
         )
         certificate = CertificateFactory(order=order)
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         with self.assertNumQueries(2):
             response = self.client.get(
@@ -103,7 +103,7 @@ class CertificateApiTest(BaseAPITestCase):
     def test_api_certificate_read_list_pagination(self, _mock_page_size):
         """Pagination should work as expected."""
         user = UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         orders = [
             OrderFactory(
@@ -180,7 +180,7 @@ class CertificateApiTest(BaseAPITestCase):
         )
         certificate = CertificateFactory(order=order)
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # - Try to retrieve a not owned certificate should return a 404
         response = self.client.get(
@@ -263,7 +263,7 @@ class CertificateApiTest(BaseAPITestCase):
         )
         certificate = CertificateFactory(order=order)
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # - Try to retrieve a not owned certificate should return a 404
         response = self.client.get(
@@ -315,7 +315,7 @@ class CertificateApiTest(BaseAPITestCase):
         order = OrderFactory(product=product, organization=organization, owner=user)
         certificate = CertificateFactory(order=order)
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             f"/api/v1.0/certificates/{certificate.id}/download/",
@@ -333,7 +333,7 @@ class CertificateApiTest(BaseAPITestCase):
         Create a certificate should not be allowed even if user is admin
         """
         user = UserFactory(is_staff=True, is_superuser=True)
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         response = self.client.post(
             "/api/v1.0/certificates/",
             {"id": uuid.uuid4()},
@@ -349,7 +349,7 @@ class CertificateApiTest(BaseAPITestCase):
         Update a certificate should not be allowed even if user is admin
         """
         user = UserFactory(is_staff=True, is_superuser=True)
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         certificate = CertificateFactory()
         response = self.client.put(
             f"/api/v1.0/certificates/{certificate.id}/",
@@ -366,7 +366,7 @@ class CertificateApiTest(BaseAPITestCase):
         Delete a certificate should not be allowed even if user is admin
         """
         user = UserFactory(is_staff=True, is_superuser=True)
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         certificate = CertificateFactory()
         response = self.client.delete(
             f"/api/v1.0/certificates/{certificate.id}/",

--- a/src/backend/joanie/tests/core/test_api_course_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_course_accesses.py
@@ -36,7 +36,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         course to which they are not related.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         factories.UserCourseAccessFactory(course=course)
@@ -45,7 +45,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         factories.UserCourseAccessFactory(course=course, role="manager")
         factories.UserCourseAccessFactory(course=course, role="owner")
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/courses/{course.id!s}/accesses/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -60,7 +60,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         in which they are only instructor.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         course_accesses = (
@@ -108,7 +108,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         in which they are only manager.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         course_accesses = (
@@ -154,7 +154,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         in which they are administrator.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         course_accesses = (
@@ -202,7 +202,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         in which they are owner.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         course_accesses = (
@@ -247,7 +247,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         """Pagination should work as expected."""
 
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         accesses = [
@@ -320,7 +320,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         a course to which they are not related.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         self.assertEqual(len(CourseAccess.ROLE_CHOICES), 4)
@@ -343,7 +343,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         associated course accessesnly instructor.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(
             users=[(user, "instructor")],
@@ -375,7 +375,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         associated course accesses.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(
             users=[(user, "manager")],
@@ -407,7 +407,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         associated course accesses.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "administrator")])
         self.assertEqual(len(CourseAccess.ROLE_CHOICES), 4)
@@ -437,7 +437,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         associated course accesses
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "owner")])
         self.assertEqual(len(CourseAccess.ROLE_CHOICES), 4)
@@ -466,7 +466,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
     ):
         """The course in the url should match the targeted access."""
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course, other_course = factories.CourseFactory.create_batch(2, users=[user])
         access = factories.UserCourseAccessFactory(course=course)
@@ -505,7 +505,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         course = factories.CourseFactory()
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
@@ -532,7 +532,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         course = factories.CourseFactory(users=[(user, "instructor")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
@@ -560,7 +560,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         course = factories.CourseFactory(users=[(user, "manager")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
@@ -589,7 +589,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         course = factories.CourseFactory(users=[(user, "administrator")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
@@ -611,7 +611,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         course = factories.CourseFactory(users=[(user, "administrator")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
@@ -632,7 +632,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         user = factories.UserFactory()
         course = factories.CourseFactory(users=[(user, "owner")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         for i, role in enumerate(["administrator", "instructor", "manager", "owner"]):
             other_user = factories.UserFactory()
@@ -677,7 +677,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
     def test_api_course_accesses_update_authenticated(self):
         """Authenticated users should not be allowed to update a course access."""
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         access = factories.UserCourseAccessFactory()
         old_values = CourseAccessSerializer(instance=access).data
@@ -707,7 +707,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         a user access for this course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "instructor")])
         access = factories.UserCourseAccessFactory(course=course)
@@ -738,7 +738,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         a user access for this course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "manager")])
         access = factories.UserCourseAccessFactory(course=course)
@@ -769,7 +769,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         access for this course, as long as s.he does not try to set the role to owner.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "administrator")])
         access = factories.UserCourseAccessFactory(
@@ -816,7 +816,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         the user access of an owner for this course.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "administrator")])
         access = factories.UserCourseAccessFactory(
@@ -849,7 +849,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         the user access of another user when granting ownership.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "administrator")])
         access = factories.UserCourseAccessFactory(
@@ -890,7 +890,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         a user access for this course except for existing owner accesses.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "owner")])
         access = factories.UserCourseAccessFactory(
@@ -938,7 +938,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         an existing owner access for this course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "owner")])
         access = factories.UserCourseAccessFactory(course=course, role="owner")
@@ -968,7 +968,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         her own user access provided there are other owners in the course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         access = factories.UserCourseAccessFactory(
@@ -1029,7 +1029,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
     def test_api_course_accesses_patch_authenticated(self):
         """Authenticated users should not be allowed to patch a course access."""
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         access = factories.UserCourseAccessFactory()
         old_values = CourseAccessSerializer(instance=access).data
@@ -1059,7 +1059,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         a user access for this course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "instructor")])
         access = factories.UserCourseAccessFactory(course=course)
@@ -1090,7 +1090,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         a user access for this course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "manager")])
         access = factories.UserCourseAccessFactory(course=course)
@@ -1121,7 +1121,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         access for this course, as long as s.he does not try to set the role to owner.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "administrator")])
         access = factories.UserCourseAccessFactory(
@@ -1166,7 +1166,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         the user access of an owner for this course.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "administrator")])
         access = factories.UserCourseAccessFactory(
@@ -1200,7 +1200,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         the user access of another user when granting ownership.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "administrator")])
         access = factories.UserCourseAccessFactory(
@@ -1238,7 +1238,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         a user access for this course except for existing owner accesses.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "owner")])
         access = factories.UserCourseAccessFactory(
@@ -1284,7 +1284,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         an existing owner access for this course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory(users=[(user, "owner")])
         access = factories.UserCourseAccessFactory(course=course, role="owner")
@@ -1315,7 +1315,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         her own user access provided there are other owners in the course.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         access = factories.UserCourseAccessFactory(
@@ -1367,7 +1367,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         """
         access = factories.UserCourseAccessFactory()
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.delete(
             f"/api/v1.0/courses/{access.course.id!s}/accesses/{access.id!s}/",
@@ -1386,7 +1386,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         course = factories.CourseFactory(users=[(user, "instructor")])
         access = factories.UserCourseAccessFactory(course=course)
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(CourseAccess.objects.count(), 2)
         self.assertTrue(CourseAccess.objects.filter(user=access.user).exists())
@@ -1407,7 +1407,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         course = factories.CourseFactory(users=[(user, "manager")])
         access = factories.UserCourseAccessFactory(course=course)
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(CourseAccess.objects.count(), 2)
         self.assertTrue(CourseAccess.objects.filter(user=access.user).exists())
@@ -1430,7 +1430,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             course=course, role=random.choice(["instructor", "administrator"])
         )
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(CourseAccess.objects.count(), 2)
         self.assertTrue(CourseAccess.objects.filter(user=access.user).exists())
@@ -1453,7 +1453,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             course=course, role=random.choice(["instructor", "administrator"])
         )
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(CourseAccess.objects.count(), 2)
         self.assertTrue(CourseAccess.objects.filter(user=access.user).exists())
@@ -1474,7 +1474,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         course = factories.CourseFactory(users=[(user, "owner")])
         access = factories.UserCourseAccessFactory(course=course, role="owner")
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(CourseAccess.objects.count(), 2)
         self.assertTrue(CourseAccess.objects.filter(user=access.user).exists())
@@ -1496,7 +1496,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             course=course, user=user, role="owner"
         )
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(CourseAccess.objects.count(), 1)
         response = self.client.delete(

--- a/src/backend/joanie/tests/core/test_api_course_run.py
+++ b/src/backend/joanie/tests/core/test_api_course_run.py
@@ -31,7 +31,7 @@ class CourseRunApiTest(BaseAPITestCase):
         """
         factories.CourseRunFactory()
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             "/api/v1.0/course-runs/", HTTP_AUTHORIZATION=f"Bearer {token}"
@@ -111,7 +111,7 @@ class CourseRunApiTest(BaseAPITestCase):
         """
         course_run = factories.CourseRunFactory(is_listed=False)
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             f"/api/v1.0/course-runs/{course_run.id}/",
@@ -144,7 +144,7 @@ class CourseRunApiTest(BaseAPITestCase):
     def test_api_course_run_create_authenticated(self):
         """Authenticated users should not be allowed to create a course run."""
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         course = factories.CourseFactory()
         data = {
@@ -196,7 +196,7 @@ class CourseRunApiTest(BaseAPITestCase):
         )
         course = factories.CourseFactory()
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         data = {
             "resource_link": "https://perdu.com",
@@ -250,7 +250,7 @@ class CourseRunApiTest(BaseAPITestCase):
             resource_link="https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/"
         )
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         data = {
             "resource_link": "https://perdu.com",
@@ -286,7 +286,7 @@ class CourseRunApiTest(BaseAPITestCase):
         """Authenticated users should not be allowed to delete a course run."""
         course_run = factories.CourseRunFactory()
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.delete(
             f"/api/v1.0/course-runs/{course_run.id}/",

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -101,7 +101,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         # The user can see his/her enrollment
-        token = self.get_user_token(enrollment.user.username)
+        token = self.generate_token_from_user(enrollment.user)
 
         with self.assertNumQueries(2):
             response = self.client.get(
@@ -166,7 +166,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         # The user linked to the other enrollment can only see his/her enrollment
-        token = self.get_user_token(other_enrollment.user.username)
+        token = self.generate_token_from_user(other_enrollment.user)
 
         with self.assertNumQueries(2):
             response = self.client.get(
@@ -246,7 +246,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         enrollment_ids = [str(enrollment.id) for enrollment in enrollments]
 
         # The user can see his/her enrollment
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             "/api/v1.0/enrollments/?page_size=2",
@@ -302,7 +302,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         enrollment_1 = factories.EnrollmentFactory(user=user, course_run=course_run_1)
         factories.EnrollmentFactory(user=user, course_run=course_run_2)
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Retrieve user's enrollment related to the first course_run
         response = self.client.get(
@@ -366,7 +366,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         should get a 400 error response.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Retrieve user's enrollment related to the first course_run
         response = self.client.get(
@@ -383,7 +383,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         by was_created_by_order.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         [cr1, cr2] = self.create_opened_course_run(2, is_listed=True)
         factories.EnrollmentFactory(
@@ -460,7 +460,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             is_active=True,
             was_created_by_order=True,
         )
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             f"/api/v1.0/enrollments/{enrollment.id}/",
@@ -644,7 +644,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             "is_active": True,
             "was_created_by_order": True,
         }
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.post(
             "/api/v1.0/enrollments/",
@@ -934,7 +934,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             "is_active": True,
             "was_created_by_order": True,
         }
-        token = self.get_user_token(order.owner.username)
+        token = self.generate_token_from_user(order.owner)
 
         response = self.client.post(
             "/api/v1.0/enrollments/",
@@ -1076,7 +1076,7 @@ class EnrollmentApiTest(BaseAPITestCase):
     def test_api_enrollment_create_for_closed_course_run(self):
         """An authenticated user should not be allowed to enroll to a closed course run."""
         user = factories.UserFactory()
-        token = self.get_user_token(username=user.username)
+        token = self.generate_token_from_user(user)
         target_course = factories.CourseFactory()
         course_run = self.create_closed_course_run(
             course=target_course,
@@ -1110,7 +1110,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         """An authenticated user should not be allowed to enroll to an unknown course run."""
 
         user = factories.UserFactory()
-        token = self.get_user_token(username=user.username)
+        token = self.generate_token_from_user(user)
         course_run = factories.CourseRunFactory.build()
         data = {
             "course_run": str(course_run.id),
@@ -1166,7 +1166,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             is_staff=random.choice([True, False]),
             is_superuser=random.choice([True, False]),
         )
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.delete(
             f"/api/v1.0/enrollments/{enrollment.id}/",
@@ -1180,7 +1180,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         enrollment = factories.EnrollmentFactory(
             course_run=self.create_opened_course_run(is_listed=True)
         )
-        token = self.get_user_token(enrollment.user.username)
+        token = self.generate_token_from_user(enrollment.user)
 
         response = self.client.delete(
             f"/api/v1.0/enrollments/{enrollment.id}/",
@@ -1231,7 +1231,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             is_staff=random.choice([True, False]),
             is_superuser=random.choice([True, False]),
         )
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         resource_link = (
             "http://openedx.test/courses/course-v1:edx+{id:05d}+Demo_Course/course"
         )
@@ -1281,7 +1281,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 ),
                 is_active=is_active_old,
             )
-            token = self.get_user_token(enrollment.user.username)
+            token = self.generate_token_from_user(enrollment.user)
 
             response = self.client.patch(
                 f"/api/v1.0/enrollments/{enrollment.id}/",
@@ -1341,7 +1341,7 @@ class EnrollmentApiTest(BaseAPITestCase):
     # pylint: disable=too-many-locals
     def _check_api_enrollment_update_detail(self, enrollment, user, http_code):
         """Nobody should be allowed to update an enrollment."""
-        user_token = self.get_user_token(enrollment.user.username)
+        user_token = self.generate_token_from_user(enrollment.user)
 
         response = self.client.get(
             f"/api/v1.0/enrollments/{enrollment.id}/",
@@ -1370,7 +1370,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             "was_created_by_order": False,
         }
         headers = (
-            {"HTTP_AUTHORIZATION": f"Bearer {self.get_user_token(user.username)}"}
+            {"HTTP_AUTHORIZATION": f"Bearer {self.generate_token_from_user(user)}"}
             if user
             else {}
         )
@@ -1482,7 +1482,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         An authenticated user should be allowed to update its enrollment to unenroll.
         """
         user = factories.UserFactory()
-        user_token = self.get_user_token(user.username)
+        user_token = self.generate_token_from_user(user)
         course_run = self.create_opened_course_run(
             resource_link="http://openedx.test/courses/course-v1:edx+000001+Demo_Course/course",
             is_listed=True,
@@ -1554,7 +1554,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         of one of its enrollment if this one was previously inactive.
         """
         user = factories.UserFactory()
-        user_token = self.get_user_token(user.username)
+        user_token = self.generate_token_from_user(user)
         course_run = self.create_opened_course_run(
             resource_link="http://openedx.test/courses/course-v1:edx+000001+Demo_Course/course",
             is_listed=True,
@@ -1691,7 +1691,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         order and active.
         """
         user = factories.UserFactory()
-        user_token = self.get_user_token(user.username)
+        user_token = self.generate_token_from_user(user)
         target_course = factories.CourseFactory()
         course_run = self.create_opened_course_run(
             course=target_course,

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -58,7 +58,7 @@ class OrderApiTest(BaseAPITestCase):
         order, other_order = factories.OrderFactory.create_batch(2, product=product)
 
         # The owner can see his/her order
-        token = self.get_user_token(order.owner.username)
+        token = self.generate_token_from_user(order.owner)
 
         with self.assertNumQueries(6):
             response = self.client.get(
@@ -101,7 +101,7 @@ class OrderApiTest(BaseAPITestCase):
         )
 
         # The owner of the other order can only see his/her order
-        token = self.get_user_token(other_order.owner.username)
+        token = self.generate_token_from_user(other_order.owner)
 
         response = self.client.get(
             "/api/v1.0/orders/",
@@ -149,7 +149,7 @@ class OrderApiTest(BaseAPITestCase):
         order_ids = [str(order.id) for order in orders]
 
         # The owner can see his/her order
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             "/api/v1.0/orders/?page_size=2",
@@ -202,7 +202,7 @@ class OrderApiTest(BaseAPITestCase):
         # User purchases the product 2
         factories.OrderFactory(owner=user, product=product_2)
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Retrieve user's order related to the product 1
         response = self.client.get(
@@ -250,7 +250,7 @@ class OrderApiTest(BaseAPITestCase):
         should get a 400 error response.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Try to retrieve user's order related with an invalid product id
         # should return a 400 error
@@ -279,7 +279,7 @@ class OrderApiTest(BaseAPITestCase):
         # User purchases the product 2
         factories.OrderFactory(owner=user, product=product_2)
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Retrieve user's order related to the first course linked to the product 1
         with self.assertNumQueries(7):
@@ -340,7 +340,7 @@ class OrderApiTest(BaseAPITestCase):
             owner=user, product=product_2, state=enums.ORDER_STATE_CANCELED
         )
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Retrieve user's order related to the product 1
         response = self.client.get(
@@ -399,7 +399,7 @@ class OrderApiTest(BaseAPITestCase):
             owner=user, product=product_2, state=enums.ORDER_STATE_CANCELED
         )
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Retrieve user's order related to the product 1
         response = self.client.get(
@@ -461,7 +461,7 @@ class OrderApiTest(BaseAPITestCase):
             owner=user, product=product_2, state=enums.ORDER_STATE_CANCELED
         )
 
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Retrieve user's order related to the product 1
         response = self.client.get(
@@ -509,7 +509,7 @@ class OrderApiTest(BaseAPITestCase):
         should get a 400 error response.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Try to retrieve user's order related with an invalid product id
         # should return a 400 error
@@ -1505,7 +1505,7 @@ class OrderApiTest(BaseAPITestCase):
         """The order owner should not be able to delete an order."""
         product = factories.ProductFactory()
         order = factories.OrderFactory(product=product)
-        token = self.get_user_token(order.owner.username)
+        token = self.generate_token_from_user(order.owner)
 
         response = self.client.delete(
             f"/api/v1.0/orders/{order.id}/",
@@ -1532,7 +1532,7 @@ class OrderApiTest(BaseAPITestCase):
         *other_target_courses, _other_course = factories.CourseFactory.create_batch(3)
         other_product = factories.ProductFactory(target_courses=other_target_courses)
         other_order = factories.OrderFactory(owner=other_owner, product=other_product)
-        other_owner_token = self.get_user_token(other_owner.username)
+        other_owner_token = self.generate_token_from_user(other_owner)
 
         other_response = self.client.get(
             f"/api/v1.0/orders/{other_order.id}/",
@@ -1562,7 +1562,7 @@ class OrderApiTest(BaseAPITestCase):
             ],
         )
         headers = (
-            {"HTTP_AUTHORIZATION": f"Bearer {self.get_user_token(user.username)}"}
+            {"HTTP_AUTHORIZATION": f"Bearer {self.generate_token_from_user(user)}"}
             if user
             else {}
         )
@@ -1645,7 +1645,7 @@ class OrderApiTest(BaseAPITestCase):
         without reference parameter, it should return a bad request response.
         """
         invoice = InvoiceFactory()
-        token = self.get_user_token(invoice.order.owner.username)
+        token = self.generate_token_from_user(invoice.order.owner)
 
         response = self.client.get(
             f"/api/v1.0/orders/{invoice.order.id}/invoice/",
@@ -1714,7 +1714,7 @@ class OrderApiTest(BaseAPITestCase):
         a related invoice through its reference
         """
         invoice = InvoiceFactory()
-        token = self.get_user_token(invoice.order.owner.username)
+        token = self.generate_token_from_user(invoice.order.owner)
 
         response = self.client.get(
             (

--- a/src/backend/joanie/tests/core/test_api_organization_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_organization_accesses.py
@@ -38,7 +38,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         organization to which they are not related.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         factories.UserOrganizationAccessFactory(organization=organization)
@@ -63,7 +63,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         in which they are a simple member.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         organization_accesses = (
@@ -121,7 +121,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         in which they are administrator.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         organization_accesses = (
@@ -179,7 +179,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         in which they are owner.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         organization_accesses = (
@@ -236,7 +236,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         """Pagination should work as expected."""
 
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         accesses = [
@@ -311,7 +311,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         an organization to which they are not related.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         self.assertEqual(len(OrganizationAccess.ROLE_CHOICES), 3)
@@ -336,7 +336,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         organization in which they are a simple member.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(
             users=[(user, "member")],
@@ -369,7 +369,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         associated organization accesses
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
         self.assertEqual(len(OrganizationAccess.ROLE_CHOICES), 3)
@@ -401,7 +401,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         associated organization accesses
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "owner")])
         self.assertEqual(len(OrganizationAccess.ROLE_CHOICES), 3)
@@ -432,7 +432,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
     ):
         """The organization in the url should match the targeted access."""
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization, other_organization = factories.OrganizationFactory.create_batch(
             2, users=[user]
@@ -471,7 +471,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         organization = factories.OrganizationFactory()
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
@@ -500,7 +500,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         organization = factories.OrganizationFactory(users=[(user, "member")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
@@ -531,7 +531,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
@@ -553,7 +553,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         user, other_user = factories.UserFactory.create_batch(2)
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
@@ -574,7 +574,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         user = factories.UserFactory()
         organization = factories.OrganizationFactory(users=[(user, "owner")])
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         for i, role in enumerate(["member", "administrator", "owner"]):
             other_user = factories.UserFactory()
@@ -619,7 +619,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
     def test_api_organization_accesses_update_authenticated(self):
         """Authenticated users should not be allowed to update an organization access."""
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         access = factories.UserOrganizationAccessFactory()
         old_values = OrganizationAccessSerializer(instance=access).data
@@ -649,7 +649,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         a user access for this organization.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "member")])
         access = factories.UserOrganizationAccessFactory(organization=organization)
@@ -680,7 +680,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         access for this organization, as long as s.he does not try to set the role to owner.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
         access = factories.UserOrganizationAccessFactory(
@@ -728,7 +728,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         the user access of an owner for this organization.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
         access = factories.UserOrganizationAccessFactory(
@@ -763,7 +763,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         the user access of another user when granting ownership.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
         access = factories.UserOrganizationAccessFactory(
@@ -806,7 +806,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         a user access for this organization except for existing owner accesses.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "owner")])
         access = factories.UserOrganizationAccessFactory(
@@ -855,7 +855,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         an existing owner access for this organization.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "owner")])
         access = factories.UserOrganizationAccessFactory(
@@ -889,7 +889,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         her own user access provided there are other owners in the organization.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         access = factories.UserOrganizationAccessFactory(
@@ -950,7 +950,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
     def test_api_organization_accesses_patch_authenticated(self):
         """Authenticated users should not be allowed to patch an organization access."""
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         access = factories.UserOrganizationAccessFactory()
         old_values = OrganizationAccessSerializer(instance=access).data
@@ -980,7 +980,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         a user access for this organization.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "member")])
         access = factories.UserOrganizationAccessFactory(organization=organization)
@@ -1011,7 +1011,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         access for this organization, as long as s.he does not try to set the role to owner.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
         access = factories.UserOrganizationAccessFactory(
@@ -1057,7 +1057,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         the user access of an owner for this organization.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
         access = factories.UserOrganizationAccessFactory(
@@ -1092,7 +1092,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         the user access of another user when granting ownership.
         """
         user, other_user = factories.UserFactory.create_batch(2)
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "administrator")])
         access = factories.UserOrganizationAccessFactory(
@@ -1132,7 +1132,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         a user access for this organization except for existing owner accesses.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "owner")])
         access = factories.UserOrganizationAccessFactory(
@@ -1179,7 +1179,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         an existing owner access for this organization.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory(users=[(user, "owner")])
         access = factories.UserOrganizationAccessFactory(
@@ -1213,7 +1213,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         her own user access provided there are other owners in the organization.
         """
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         access = factories.UserOrganizationAccessFactory(
@@ -1265,7 +1265,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         """
         access = factories.UserOrganizationAccessFactory()
         user = factories.UserFactory()
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         response = self.client.delete(
             f"/api/v1.0/organizations/{access.organization.id!s}/accesses/{access.id!s}/",
@@ -1284,7 +1284,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         organization = factories.OrganizationFactory(users=[(user, "member")])
         access = factories.UserOrganizationAccessFactory(organization=organization)
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(OrganizationAccess.objects.count(), 2)
         self.assertTrue(OrganizationAccess.objects.filter(user=access.user).exists())
@@ -1307,7 +1307,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             organization=organization, role=random.choice(["member", "administrator"])
         )
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(OrganizationAccess.objects.count(), 2)
         self.assertTrue(OrganizationAccess.objects.filter(user=access.user).exists())
@@ -1330,7 +1330,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             organization=organization, role=random.choice(["member", "administrator"])
         )
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(OrganizationAccess.objects.count(), 2)
         self.assertTrue(OrganizationAccess.objects.filter(user=access.user).exists())
@@ -1353,7 +1353,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             organization=organization, role="owner"
         )
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(OrganizationAccess.objects.count(), 2)
         self.assertTrue(OrganizationAccess.objects.filter(user=access.user).exists())
@@ -1375,7 +1375,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             organization=organization, user=user, role="owner"
         )
 
-        jwt_token = self.get_user_token(user.username)
+        jwt_token = self.generate_token_from_user(user)
 
         self.assertEqual(OrganizationAccess.objects.count(), 1)
         response = self.client.delete(

--- a/src/backend/joanie/tests/core/test_api_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations.py
@@ -31,7 +31,7 @@ class OrganizationApiTest(BaseAPITestCase):
         Authenticated users should only see the organizations to which they have access.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         factories.OrganizationFactory()
         organizations = factories.OrganizationFactory.create_batch(3)
@@ -42,7 +42,7 @@ class OrganizationApiTest(BaseAPITestCase):
             user=user, organization=organizations[1]
         )
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             response = self.client.get(
                 "/api/v1.0/organizations/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -62,7 +62,7 @@ class OrganizationApiTest(BaseAPITestCase):
         Authenticated users should only see the organizations to which they have access.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         factories.OrganizationFactory()
         organization = factories.OrganizationFactory()
@@ -110,8 +110,7 @@ class OrganizationApiTest(BaseAPITestCase):
                 ],
             },
         )
-        self.assertEqual(mock_abilities.call_args_list[0][1]["user"], user)
-        self.assertEqual(str(mock_abilities.call_args_list[0][1]["auth"]), str(token))
+        mock_abilities.called_once_with(user)
 
     def test_api_organization_get_anonymous(self):
         """
@@ -132,7 +131,7 @@ class OrganizationApiTest(BaseAPITestCase):
         if they have no access to it.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
 
@@ -155,7 +154,7 @@ class OrganizationApiTest(BaseAPITestCase):
         if they have access to it.
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         factories.UserOrganizationAccessFactory(user=user, organization=organization)
@@ -200,7 +199,7 @@ class OrganizationApiTest(BaseAPITestCase):
             is_staff=random.choice([True, False]),
             is_superuser=random.choice([True, False]),
         )
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         data = {
             "code": "ORG-001",
@@ -248,7 +247,7 @@ class OrganizationApiTest(BaseAPITestCase):
             is_staff=random.choice([True, False]),
             is_superuser=random.choice([True, False]),
         )
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
 
@@ -289,7 +288,7 @@ class OrganizationApiTest(BaseAPITestCase):
             is_staff=random.choice([True, False]),
             is_superuser=random.choice([True, False]),
         )
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         organization = factories.OrganizationFactory()
         factories.UserOrganizationAccessFactory(user=user, organization=organization)

--- a/src/backend/joanie/tests/core/test_api_products.py
+++ b/src/backend/joanie/tests/core/test_api_products.py
@@ -31,7 +31,7 @@ class ProductApiTest(BaseAPITestCase):
         """
         factories.ProductFactory()
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             "/api/v1.0/products/", HTTP_AUTHORIZATION=f"Bearer {token}"
@@ -206,7 +206,7 @@ class ProductApiTest(BaseAPITestCase):
         should get the order id within the response
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         course = factories.CourseFactory()
         product = factories.ProductFactory(
             courses=[course], type=enums.PRODUCT_TYPE_CREDENTIAL
@@ -231,7 +231,7 @@ class ProductApiTest(BaseAPITestCase):
         should get the order id within the response
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         course = factories.CourseFactory()
         product = factories.ProductFactory(
             courses=[course],
@@ -258,7 +258,7 @@ class ProductApiTest(BaseAPITestCase):
         should not get the order id within the response
         """
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         course = factories.CourseFactory()
         product = factories.ProductFactory(
             courses=[course],
@@ -342,7 +342,7 @@ class ProductApiTest(BaseAPITestCase):
 
         # Create a user
         user = factories.UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         # Purchase certificate for all courses
         order1 = factories.OrderFactory(owner=user, product=product, course=courses[0])
@@ -381,7 +381,7 @@ class ProductApiTest(BaseAPITestCase):
         """
         product = factories.ProductFactory(courses=[])
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.get(
             f"/api/v1.0/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
@@ -415,7 +415,7 @@ class ProductApiTest(BaseAPITestCase):
     def test_api_product_create_authenticated(self):
         """Authenticated users should not be allowed to create a product."""
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         data = {
             "type": "credential",
@@ -458,7 +458,7 @@ class ProductApiTest(BaseAPITestCase):
         """Authenticated users should not be allowed to update a product."""
         product = factories.ProductFactory(price=100.0)
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         data = {
             "type": "credential",
@@ -496,7 +496,7 @@ class ProductApiTest(BaseAPITestCase):
         """Authenticated users should not be allowed to partially update a product."""
         product = factories.ProductFactory(price=100.0)
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         data = {
             "price": 1337.00,
@@ -529,7 +529,7 @@ class ProductApiTest(BaseAPITestCase):
         """Authenticated users should not be allowed to delete a product."""
         product = factories.ProductFactory()
         user = factories.UserFactory.build()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
 
         response = self.client.delete(
             f"/api/v1.0/products/{product.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"

--- a/src/backend/joanie/tests/core/test_models_course.py
+++ b/src/backend/joanie/tests/core/test_models_course.py
@@ -45,7 +45,7 @@ class CourseModelsTestCase(BaseAPITestCase):
     def test_models_course_get_abilities_anonymous(self):
         """Check abilities returned for an anonymous user."""
         course = factories.CourseFactory()
-        abilities = course.get_abilities(user=AnonymousUser())
+        abilities = course.get_abilities(AnonymousUser())
 
         self.assertEqual(
             abilities,
@@ -61,7 +61,7 @@ class CourseModelsTestCase(BaseAPITestCase):
     def test_models_course_get_abilities_authenticated(self):
         """Check abilities returned for an authenticated user."""
         course = factories.CourseFactory()
-        abilities = course.get_abilities(user=factories.UserFactory())
+        abilities = course.get_abilities(factories.UserFactory())
         self.assertEqual(
             abilities,
             {
@@ -76,7 +76,7 @@ class CourseModelsTestCase(BaseAPITestCase):
     def test_models_course_get_abilities_owner(self):
         """Check abilities returned for the owner of a course."""
         access = factories.UserCourseAccessFactory(role="owner")
-        abilities = access.course.get_abilities(user=access.user)
+        abilities = access.course.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -91,7 +91,7 @@ class CourseModelsTestCase(BaseAPITestCase):
     def test_models_course_get_abilities_administrator(self):
         """Check abilities returned for the administrator of a course."""
         access = factories.UserCourseAccessFactory(role="administrator")
-        abilities = access.course.get_abilities(user=access.user)
+        abilities = access.course.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -106,7 +106,7 @@ class CourseModelsTestCase(BaseAPITestCase):
     def test_models_course_get_abilities_instructor(self):
         """Check abilities returned for the instructor of a course."""
         access = factories.UserCourseAccessFactory(role="instructor")
-        abilities = access.course.get_abilities(user=access.user)
+        abilities = access.course.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -123,26 +123,7 @@ class CourseModelsTestCase(BaseAPITestCase):
         access = factories.UserCourseAccessFactory(role="manager")
 
         with self.assertNumQueries(1):
-            abilities = access.course.get_abilities(user=access.user)
-
-        self.assertEqual(
-            abilities,
-            {
-                "delete": False,
-                "get": True,
-                "patch": False,
-                "put": False,
-                "manage_accesses": False,
-            },
-        )
-
-    def test_models_course_get_abilities_member_auth(self):
-        """Check abilities returned when passing a token instead of a user."""
-        access = factories.UserCourseAccessFactory(role="manager")
-        token = self.get_user_token(access.user.username)
-
-        with self.assertNumQueries(1):
-            abilities = access.course.get_abilities(auth=token)
+            abilities = access.course.get_abilities(access.user)
 
         self.assertEqual(
             abilities,
@@ -161,7 +142,7 @@ class CourseModelsTestCase(BaseAPITestCase):
         access.course.user_role = "manager"
 
         with self.assertNumQueries(0):
-            abilities = access.course.get_abilities(user=access.user)
+            abilities = access.course.get_abilities(access.user)
 
         self.assertEqual(
             abilities,

--- a/src/backend/joanie/tests/core/test_models_course_access.py
+++ b/src/backend/joanie/tests/core/test_models_course_access.py
@@ -31,7 +31,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
     def test_models_course_access_get_abilities_anonymous(self):
         """Check abilities returned for an anonymous user."""
         access = factories.UserCourseAccessFactory()
-        abilities = access.get_abilities(user=AnonymousUser())
+        abilities = access.get_abilities(AnonymousUser())
 
         self.assertEqual(
             abilities,
@@ -47,7 +47,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
     def test_models_course_access_get_abilities_authenticated(self):
         """Check abilities returned for an authenticated user."""
         access = factories.UserCourseAccessFactory()
-        abilities = access.get_abilities(user=factories.UserFactory())
+        abilities = access.get_abilities(factories.UserFactory())
         self.assertEqual(
             abilities,
             {
@@ -70,7 +70,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         factories.UserCourseAccessFactory(
             course=access.course, role="owner"
         )  # another one
-        abilities = access.get_abilities(user=access.user)
+        abilities = access.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -88,7 +88,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         only one owner left.
         """
         access = factories.UserCourseAccessFactory(role="owner")
-        abilities = access.get_abilities(user=access.user)
+        abilities = access.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -107,7 +107,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="owner"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -126,7 +126,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="owner"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -145,7 +145,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="owner"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -164,7 +164,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="owner"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -185,7 +185,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="administrator"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -206,7 +206,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="administrator"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -225,7 +225,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="administrator"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -244,7 +244,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="administrator"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -265,7 +265,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="instructor"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -284,7 +284,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="instructor"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -303,7 +303,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="instructor"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -322,7 +322,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="instructor"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -343,7 +343,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="manager"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -362,7 +362,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="manager"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -381,7 +381,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserCourseAccessFactory(
             course=access.course, role="manager"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -402,29 +402,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         ).user
 
         with self.assertNumQueries(1):
-            abilities = access.get_abilities(user=user)
-
-        self.assertEqual(
-            abilities,
-            {
-                "delete": False,
-                "get": True,
-                "patch": False,
-                "put": False,
-                "set_role_to": [],
-            },
-        )
-
-    def test_models_course_access_get_abilities_auth(self):
-        """Check abilities returned when passing a token instead of a user."""
-        access = factories.UserCourseAccessFactory(role="manager")
-        user = factories.UserCourseAccessFactory(
-            course=access.course, role="manager"
-        ).user
-        token = self.get_user_token(user.username)
-
-        with self.assertNumQueries(1):
-            abilities = access.get_abilities(auth=token)
+            abilities = access.get_abilities(user)
 
         self.assertEqual(
             abilities,
@@ -446,7 +424,7 @@ class CourseAccessModelsTestCase(BaseAPITestCase):
         access.user_role = "manager"
 
         with self.assertNumQueries(0):
-            abilities = access.get_abilities(user=user)
+            abilities = access.get_abilities(user)
 
         self.assertEqual(
             abilities,

--- a/src/backend/joanie/tests/core/test_models_organization.py
+++ b/src/backend/joanie/tests/core/test_models_organization.py
@@ -39,7 +39,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
     def test_models_organization_get_abilities_anonymous(self):
         """Check abilities returned for an anonymous user."""
         organization = factories.OrganizationFactory()
-        abilities = organization.get_abilities(user=AnonymousUser())
+        abilities = organization.get_abilities(AnonymousUser())
 
         self.assertEqual(
             abilities,
@@ -55,7 +55,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
     def test_models_organization_get_abilities_authenticated(self):
         """Check abilities returned for an authenticated user."""
         organization = factories.OrganizationFactory()
-        abilities = organization.get_abilities(user=factories.UserFactory())
+        abilities = organization.get_abilities(factories.UserFactory())
         self.assertEqual(
             abilities,
             {
@@ -70,7 +70,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
     def test_models_organization_get_abilities_owner(self):
         """Check abilities returned for the owner of a organization."""
         access = factories.UserOrganizationAccessFactory(role="owner")
-        abilities = access.organization.get_abilities(user=access.user)
+        abilities = access.organization.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -85,7 +85,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
     def test_models_organization_get_abilities_administrator(self):
         """Check abilities returned for the administrator of a organization."""
         access = factories.UserOrganizationAccessFactory(role="administrator")
-        abilities = access.organization.get_abilities(user=access.user)
+        abilities = access.organization.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -102,26 +102,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
         access = factories.UserOrganizationAccessFactory(role="member")
 
         with self.assertNumQueries(1):
-            abilities = access.organization.get_abilities(user=access.user)
-
-        self.assertEqual(
-            abilities,
-            {
-                "delete": False,
-                "get": True,
-                "patch": False,
-                "put": False,
-                "manage_accesses": False,
-            },
-        )
-
-    def test_models_organization_get_abilities_member_auth(self):
-        """Check abilities returned when passing a token instead of a user."""
-        access = factories.UserOrganizationAccessFactory(role="member")
-        token = self.get_user_token(access.user.username)
-
-        with self.assertNumQueries(1):
-            abilities = access.organization.get_abilities(auth=token)
+            abilities = access.organization.get_abilities(access.user)
 
         self.assertEqual(
             abilities,
@@ -140,7 +121,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
         access.organization.user_role = "member"
 
         with self.assertNumQueries(0):
-            abilities = access.organization.get_abilities(user=access.user)
+            abilities = access.organization.get_abilities(access.user)
 
         self.assertEqual(
             abilities,

--- a/src/backend/joanie/tests/core/test_models_organization_access.py
+++ b/src/backend/joanie/tests/core/test_models_organization_access.py
@@ -34,7 +34,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
     def test_models_organization_access_get_abilities_anonymous(self):
         """Check abilities returned for an anonymous user."""
         access = factories.UserOrganizationAccessFactory()
-        abilities = access.get_abilities(user=AnonymousUser())
+        abilities = access.get_abilities(AnonymousUser())
 
         self.assertEqual(
             abilities,
@@ -50,7 +50,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
     def test_models_organization_access_get_abilities_authenticated(self):
         """Check abilities returned for an authenticated user."""
         access = factories.UserOrganizationAccessFactory()
-        abilities = access.get_abilities(user=factories.UserFactory())
+        abilities = access.get_abilities(factories.UserFactory())
         self.assertEqual(
             abilities,
             {
@@ -73,7 +73,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         factories.UserOrganizationAccessFactory(
             organization=access.organization, role="owner"
         )  # another one
-        abilities = access.get_abilities(user=access.user)
+        abilities = access.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -91,7 +91,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         only one owner left.
         """
         access = factories.UserOrganizationAccessFactory(role="owner")
-        abilities = access.get_abilities(user=access.user)
+        abilities = access.get_abilities(access.user)
         self.assertEqual(
             abilities,
             {
@@ -112,7 +112,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="owner"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -133,7 +133,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="owner"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -154,7 +154,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="owner"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -177,7 +177,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="administrator"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -200,7 +200,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="administrator"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -221,7 +221,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="administrator"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -244,7 +244,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="member"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -265,7 +265,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         user = factories.UserOrganizationAccessFactory(
             organization=access.organization, role="member"
         ).user
-        abilities = access.get_abilities(user=user)
+        abilities = access.get_abilities(user)
         self.assertEqual(
             abilities,
             {
@@ -288,29 +288,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         ).user
 
         with self.assertNumQueries(1):
-            abilities = access.get_abilities(user=user)
-
-        self.assertEqual(
-            abilities,
-            {
-                "delete": False,
-                "get": True,
-                "patch": False,
-                "put": False,
-                "set_role_to": [],
-            },
-        )
-
-    def test_models_organization_access_get_abilities_member_auth(self):
-        """Check abilities returned when passing a token instead of a user."""
-        access = factories.UserOrganizationAccessFactory(role="member")
-        user = factories.UserOrganizationAccessFactory(
-            organization=access.organization, role="member"
-        ).user
-        token = self.get_user_token(user.username)
-
-        with self.assertNumQueries(1):
-            abilities = access.get_abilities(auth=token)
+            abilities = access.get_abilities(user)
 
         self.assertEqual(
             abilities,
@@ -332,7 +310,7 @@ class OrganizationAccessModelsTestCase(BaseAPITestCase):
         access.user_role = "member"
 
         with self.assertNumQueries(0):
-            abilities = access.get_abilities(user=user)
+            abilities = access.get_abilities(user)
 
         self.assertEqual(
             abilities,

--- a/src/backend/joanie/tests/core/test_models_user.py
+++ b/src/backend/joanie/tests/core/test_models_user.py
@@ -185,9 +185,7 @@ class UserModelTestCase(BaseAPITestCase):
         with self.assertNumQueries(1):
             roles = list(user.get_abilities(user)["course_roles"])
 
-        self.assertCountEqual(
-            roles, ["manager", "administrator"]
-        )
+        self.assertCountEqual(roles, ["manager", "administrator"])
 
     def test_models_user_get_abilities_organization_roles(self):
         """Check abilities returned for a user with roles on some organizations."""
@@ -199,6 +197,4 @@ class UserModelTestCase(BaseAPITestCase):
         with self.assertNumQueries(1):
             roles = list(user.get_abilities(user)["organization_roles"])
 
-        self.assertCountEqual(
-            roles, ["member", "administrator"]
-        )
+        self.assertCountEqual(roles, ["member", "administrator"])

--- a/src/backend/joanie/tests/payment/test_api_credit_card.py
+++ b/src/backend/joanie/tests/payment/test_api_credit_card.py
@@ -66,7 +66,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_get_credit_cards_list(self):
         """Retrieve all authenticated user's credit cards is allowed."""
         user = UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         cards = CreditCardFactory.create_batch(2, owner=user)
 
         response = self.client.get(
@@ -92,7 +92,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_read_list_pagination(self, _mock_page_size):
         """Pagination should work as expected."""
         user = UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         cards = CreditCardFactory.create_batch(3, owner=user)
         card_ids = [str(card.id) for card in cards]
 
@@ -133,7 +133,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_get_credit_card(self):
         """Retrieve authenticated user's credit card by its id is allowed."""
         user = UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory(owner=user)
 
         response = self.client.get(
@@ -158,7 +158,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_get_non_existing_credit_card(self):
         """Retrieve a non existing credit card should return a 404."""
         user = UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory.build(owner=user)
 
         response = self.client.get(
@@ -172,7 +172,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         authenticated user should return a 404.
         """
         user = UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory()
 
         response = self.client.get(
@@ -203,8 +203,8 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_update_with_expired_token(self):
         """Update a credit card with an expired token is forbidden."""
         user = UserFactory()
-        token = self.get_user_token(
-            username=user.username,
+        token = self.generate_token_from_user(
+            user,
             expires_at=arrow.utcnow().shift(days=-1).datetime,
         )
         card = CreditCardFactory(owner=user)
@@ -222,7 +222,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         Update a credit card with an invalid payload should return a 400 error.
         """
         user = UserFactory()
-        token = self.get_user_token(username=user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory(owner=user)
         response = self.client.put(
             f"/api/v1.0/credit-cards/{card.id}/",
@@ -244,7 +244,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_update_with_bad_user(self):
         """Update a credit card not owned by the authenticated user is forbidden."""
         user = UserFactory()
-        token = self.get_user_token(username=user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory()
         response = self.client.put(
             f"/api/v1.0/credit-cards/{card.id}/",
@@ -258,7 +258,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_demote_credit_card_is_forbidden(self):
         """Demote a main credit card is forbidden"""
         user = UserFactory()
-        token = self.get_user_token(username=user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory(owner=user)
         response = self.client.put(
             f"/api/v1.0/credit-cards/{card.id}/",
@@ -277,7 +277,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         Promote credit card is allowed and existing credit card should be demoted.
         """
         user = UserFactory()
-        token = self.get_user_token(username=user.username)
+        token = self.generate_token_from_user(user)
         main_card, card = CreditCardFactory.create_batch(2, owner=user)
         response = self.client.put(
             f"/api/v1.0/credit-cards/{card.id}/",
@@ -305,7 +305,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         Only title field should be writable !
         """
         user = UserFactory()
-        token = self.get_user_token(username=user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory(owner=user)
         response = self.client.put(
             f"/api/v1.0/credit-cards/{card.id}/",
@@ -382,7 +382,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_delete(self):
         """Delete a authenticated user's credit card is allowed with a valid token."""
         user = UserFactory()
-        token = self.get_user_token(user.username)
+        token = self.generate_token_from_user(user)
         card = CreditCardFactory(owner=user)
         response = self.client.delete(
             f"/api/v1.0/credit-cards/{card.id}/",

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
     sentry-sdk==1.22.2
     url-normalize==1.4.3
     whitenoise==6.4.0
+    weasyprint<59 # temporary pin until marion is fixed
 
 package_dir =
     =.


### PR DESCRIPTION
## Purpose

Train thoughts: our optimization consisting in using `request.auth` instead of `request.user` was a little over-engineered as pointed out by @qbey.

We want to add abilities to the user model but should first refactor the existing `get_abilities` methods.

## Proposal

- [x] Revert to using `request.user` when it was impacting method signatures (2 kwargs, `user` and `auth`, instead of 1 arg: user)
- [x] Add `get_abilities` to the user model with 2 first custom abilities: `course_roles` and `organization_roles`.
- [x] I took this opportunity to also simplify tests by calling `generate_token_from_user` instead of `get_user_token` whenever we have a user and not just a username...