### PR TITLE
✨(core) take products in account to process course state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to
 
 ### Changed
 
+- Take products in account to process Course state
 - Update OrderSerializer to bind Course information
 - Use ThumbnailImageField instead of ImageField for Organization logo
 - Refactor how the user is authenticated and passed throughout the request

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -38,7 +38,7 @@ class CourseApiTest(BaseAPITestCase):
         factories.UserCourseAccessFactory(user=user, course=courses[0])
         factories.UserCourseAccessFactory(user=user, course=courses[1])
 
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(16):
             response = self.client.get(
                 "/api/v1.0/courses/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -167,7 +167,7 @@ class CourseApiTest(BaseAPITestCase):
             organizations=factories.OrganizationFactory.create_batch(2),
         )
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(10):
             response = self.client.get(
                 f"/api/v1.0/courses/{course.id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",


### PR DESCRIPTION
## Purpose

Course model implements a property `state` inherits from Richie in charge of processing its state according to its course runs. As in Joanie a course can contain course runs AND products we must take these two resources in account to process course state.


## Proposal

- [x] Take products in account to process Course state
