### PR TITLE
💄(frontend) update TranslatableContent UI

### DIFF
--- a/src/frontend/admin/src/components/presentational/card/SimpleCard.tsx
+++ b/src/frontend/admin/src/components/presentational/card/SimpleCard.tsx
@@ -9,6 +9,7 @@ export function SimpleCard(props: PropsWithChildren) {
       elevation={0}
       sx={{
         borderRadius: 4,
+        overflow: "hidden",
         boxShadow:
           "rgb(145 158 171 / 20%) 0px 0px 2px 0px, rgb(145 158 171 / 12%) 0px 12px 24px -4px",
       }}

--- a/src/frontend/admin/src/components/presentational/translatable-content/TranslatableContent.tsx
+++ b/src/frontend/admin/src/components/presentational/translatable-content/TranslatableContent.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { PropsWithChildren, useEffect, useState } from "react";
-import { Box, Tab, Tabs } from "@mui/material";
+import { Box, Tab, Tabs, useTheme } from "@mui/material";
 import { TabContext } from "@mui/lab";
 import { TRANSLATE_CONTENT_LANGUAGE } from "@/utils/constants";
 import { LocalesEnum } from "@/types/i18n/LocalesEnum";
@@ -10,8 +10,9 @@ interface Props {
   onSelectLang: (lang: string) => void;
 }
 
-export function TranslatableContent(props: PropsWithChildren<Props>) {
+export function TranslatableContent({ ...props }: PropsWithChildren<Props>) {
   const [value, setValue] = useState(getAcceptLanguage());
+  const theme = useTheme();
 
   const a11yProps = (index: number) => {
     return {
@@ -33,7 +34,12 @@ export function TranslatableContent(props: PropsWithChildren<Props>) {
 
   return (
     <TabContext value={value}>
-      <Box mb={2}>
+      <Box
+        mb={2}
+        sx={{
+          backgroundColor: theme.palette.grey[50],
+        }}
+      >
         <Tabs
           value={value}
           onChange={handleChange}


### PR DESCRIPTION
## Purpose

In the edit view of a multilingual resource, the language tabs are not visually separated from the edit form, so it is difficult for the user to quickly understand that he is able to change the language by clicking on these tabs.

## Proposal

- Add background color
