### PR TITLE
✨(frontend) allow click to edit on main ressource attribute

### DIFF
--- a/src/frontend/admin/src/components/presentational/link/CustomLink.tsx
+++ b/src/frontend/admin/src/components/presentational/link/CustomLink.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { PropsWithChildren } from "react";
+import { Link, LinkProps } from "@mui/material";
+import NextLink from "next/link";
+
+type Props = LinkProps;
+export function CustomLink({ children, ...props }: PropsWithChildren<Props>) {
+  return (
+    <Link
+      underline="hover"
+      key={props.href}
+      component={NextLink}
+      color="inherit"
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/src/frontend/admin/src/components/templates/certificates-definitions/list/CertificatesDefintionsList.tsx
+++ b/src/frontend/admin/src/components/templates/certificates-definitions/list/CertificatesDefintionsList.tsx
@@ -9,6 +9,8 @@ import { PATH_ADMIN } from "@/utils/routes/path";
 import { CertificateDefinition } from "@/services/api/models/CertificateDefinition";
 import { useCertificateDefinitions } from "@/hooks/useCertificateDefinitions/useCertificateDefinitions";
 import { Maybe } from "@/types/utils";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { commonTranslations } from "@/translations/common/commonTranslations";
 
 const messages = defineMessages({
   nameHeader: {
@@ -31,16 +33,36 @@ export function CertificatesDefinitionsList() {
 
   const debouncedSetSearch = useDebouncedCallback(setSearch, 300);
 
-  const columns: GridColDef[] = [
+  const columns: GridColDef<CertificateDefinition>[] = [
     {
       field: "name",
       headerName: intl.formatMessage(messages.nameHeader),
       minWidth: 400,
+      renderCell: (cell) => {
+        return (
+          <CustomLink
+            href={PATH_ADMIN.certificates.edit(cell.row.id)}
+            title={intl.formatMessage(commonTranslations.edit)}
+          >
+            {cell.row.name}
+          </CustomLink>
+        );
+      },
     },
     {
       field: "title",
       headerName: intl.formatMessage(messages.titleHeader),
       flex: 1,
+      renderCell: (cell) => {
+        return (
+          <CustomLink
+            href={PATH_ADMIN.certificates.edit(cell.row.id)}
+            title={intl.formatMessage(commonTranslations.edit)}
+          >
+            {cell.row.title}
+          </CustomLink>
+        );
+      },
     },
   ];
 

--- a/src/frontend/admin/src/components/templates/courses-runs/list/CourseRunsListColumns.tsx
+++ b/src/frontend/admin/src/components/templates/courses-runs/list/CourseRunsListColumns.tsx
@@ -4,6 +4,9 @@ import { defineMessages, IntlShape } from "react-intl";
 import { Box, IconButton } from "@mui/material";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { CourseRun } from "@/services/api/models/CourseRun";
+import { PATH_ADMIN } from "@/utils/routes/path";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { commonTranslations } from "@/translations/common/commonTranslations";
 
 const messages = defineMessages({
   resourceLink: {
@@ -41,19 +44,29 @@ const messages = defineMessages({
 
 export const getCoursesRunsListColumns = (
   intl: IntlShape
-): GridColDef<any, CourseRun>[] => {
+): GridColDef<CourseRun>[] => {
   return [
     {
       field: "title",
       headerName: intl.formatMessage(messages.title),
       minWidth: 300,
+      renderCell: (cell) => {
+        return (
+          <CustomLink
+            href={PATH_ADMIN.courses_run.edit(cell.row.id)}
+            title={intl.formatMessage(commonTranslations.edit)}
+          >
+            {cell.row.title}
+          </CustomLink>
+        );
+      },
     },
     {
       field: "resource_link",
       headerName: intl.formatMessage(messages.resourceLink),
       minWidth: 400,
       flex: 1,
-      renderCell: (params: GridRenderCellParams<any, CourseRun>) => {
+      renderCell: (params) => {
         return (
           <Box
             sx={{

--- a/src/frontend/admin/src/components/templates/courses/list/CoursesList.tsx
+++ b/src/frontend/admin/src/components/templates/courses/list/CoursesList.tsx
@@ -2,14 +2,15 @@ import * as React from "react";
 import { useState } from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { useRouter } from "next/router";
-import { GridColDef, GridRenderCellParams } from "@mui/x-data-grid";
+import { GridColDef } from "@mui/x-data-grid";
 import { useDebouncedCallback } from "use-debounce";
 import { TableComponent } from "@/components/presentational/table/TableComponent";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { Course } from "@/services/api/models/Course";
-import { CourseRun } from "@/services/api/models/CourseRun";
 import { Maybe } from "@/types/utils";
 import { useCourses } from "@/hooks/useCourses/useCourses";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { commonTranslations } from "@/translations/common/commonTranslations";
 
 const messages = defineMessages({
   codeHeader: {
@@ -39,19 +40,32 @@ export function CoursesList() {
     setSearch(term);
   }, 300);
 
-  const columns: GridColDef[] = [
+  const columns: GridColDef<Course>[] = [
     {
       field: "code",
       headerName: intl.formatMessage(messages.codeHeader),
       minWidth: 150,
       maxWidth: 250,
     },
-    { field: "title", headerName: intl.formatMessage(messages.title), flex: 1 },
+    {
+      field: "title",
+      headerName: intl.formatMessage(messages.title),
+      flex: 1,
+      renderCell: (cell) => {
+        return (
+          <CustomLink
+            href={PATH_ADMIN.courses.edit(cell.row.id)}
+            title={intl.formatMessage(commonTranslations.edit)}
+          >
+            {cell.row.title}
+          </CustomLink>
+        );
+      },
+    },
     {
       field: "state",
       headerName: intl.formatMessage(messages.state),
-      renderCell: (params: GridRenderCellParams<any, CourseRun>) =>
-        params.row.state?.text,
+      renderCell: (params) => params.row.state?.text,
     },
   ];
 

--- a/src/frontend/admin/src/components/templates/organizations/list/OrganizationsList.tsx
+++ b/src/frontend/admin/src/components/templates/organizations/list/OrganizationsList.tsx
@@ -9,6 +9,8 @@ import { TableComponent } from "@/components/presentational/table/TableComponent
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { useOrganizations } from "@/hooks/useOrganizations/useOrganizations";
 import { Maybe } from "@/types/utils";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { commonTranslations } from "@/translations/common/commonTranslations";
 
 const messages = defineMessages({
   codeHeader: {
@@ -37,7 +39,21 @@ export function OrganizationsList() {
       headerName: intl.formatMessage(messages.codeHeader),
       maxWidth: 200,
     },
-    { field: "title", headerName: intl.formatMessage(messages.title), flex: 1 },
+    {
+      field: "title",
+      headerName: intl.formatMessage(messages.title),
+      flex: 1,
+      renderCell: (cell) => {
+        return (
+          <CustomLink
+            href={PATH_ADMIN.organizations.edit(cell.row.id)}
+            title={intl.formatMessage(commonTranslations.edit)}
+          >
+            {cell.row.title}
+          </CustomLink>
+        );
+      },
+    },
   ];
 
   return (

--- a/src/frontend/admin/src/translations/common/commonTranslations.ts
+++ b/src/frontend/admin/src/translations/common/commonTranslations.ts
@@ -11,6 +11,11 @@ export const commonTranslations = defineMessages({
     defaultMessage: "Add",
     description: "Common add label",
   },
+  edit: {
+    id: "translations.common.commonTranslations.edit",
+    defaultMessage: "Edit",
+    description: "Common edit label",
+  },
   language: {
     id: "translations.common.commonTranslations.language",
     defaultMessage: "Language",


### PR DESCRIPTION
## Purpose

Currently to edit a ressource, the user must click on the three vertical dots icon then click on "edit" link that is weird.

## Proposal

Make the main attribute of a resource clickable to be redirected to the edit form.