### PR TITLE
🧑‍💻(backend) Adapt course endpoint for dashboad teacher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to
 
 ## Added
 
-- Add api endpoint to retrieve the list of course product relations
 - Add `max_validated_orders` field to CourseProductRelation model
+- Add api endpoint to retrieve course product relations
 - Add `get_selling_organizations` method to Course model
 - Add courses client api endpoint
 - Add ThumbnailImageField "cover" to Course model

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -759,11 +759,13 @@ class CourseProductRelationSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.CourseProductRelation
         fields = [
+            "id",
             "created_on",
             "course",
             "product",
         ]
         read_only_fields = [
+            "id",
             "created_on",
             "course",
             "product",


### PR DESCRIPTION
[#1997](https://github.com/openfun/richie/pull/1997) is ready to merge. Should be done after the merge of this branch.

## Purpose

In order to ease development, the demo data should generated listed course runs.
Furthermore, API consumer needs to retrieve a single course product relation through its id.

## Proposal

- [x] Update demo data command to generate listed course runs
- [x] Add `Retrieve` mixin to `CourseProductRelationViewSet`
- [x] Update tests 
