### PR TITLE
✨(core) add nested course api endpoint to list course runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
 - Automatically allocate organization equitably on order creation according to
   their active order count per organization for the course/product couple
 - Add many admin api filters with text search 
+- Add a nested endpoint to retrieve all the course runs of a course
 
 ### Changed
 

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -61,6 +61,11 @@ course_related_router.register(
     api_client.CourseAccessViewSet,
     basename="course_accesses",
 )
+course_related_router.register(
+    "course-runs",
+    api_client.CourseRunViewSet,
+    basename="course_course_runs",
+)
 
 # - Routes nested under an organization
 organization_related_router = DefaultRouter()


### PR DESCRIPTION
## Purpose

API consumer needs to list course runs related to a specific course. In order to do that, we create a new nested course api route `/courses/:course-id/course-runs`.


## Proposal

- [x] Add a nested course api endpoint to list related course runs
