### PR TITLE
✨(core) add `has_listed_course_runs` filter to course resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to
   their active order count per organization for the course/product couple
 - Add many admin api filters with text search 
 - Add a nested endpoint to retrieve all the course runs of a course
+- Filter courses according to whether they have listed course runs or not
 
 ### Changed
 

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -690,6 +690,7 @@ class CourseViewSet(
     """
 
     lookup_field = "pk"
+    filterset_class = filters.CourseViewSetFilter
     pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
     serializer_class = serializers.CourseSerializer

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -46,3 +46,27 @@ class EnrollmentViewSetFilter(filters.FilterSet):
     class Meta:
         model = models.Enrollment
         fields: List[str] = []
+
+
+class CourseViewSetFilter(filters.FilterSet):
+    """
+    CourseViewSetFilter allows to filter this resource according to if it has related
+    course runs or not.
+    """
+
+    has_listed_course_runs = filters.BooleanFilter(
+        method="filter_has_listed_course_runs"
+    )
+
+    class Meta:
+        model = models.Course
+        fields: List[str] = ["has_listed_course_runs"]
+
+    def filter_has_listed_course_runs(self, queryset, _name, value):
+        """
+        Filter resource by looking for course runs which are listed.
+        """
+        if value is True:
+            return queryset.filter(course_runs__is_listed=True)
+
+        return queryset.exclude(course_runs__is_listed=True)


### PR DESCRIPTION
## Purpose

In some case, api consumer needs to retrieve courses which have listed course runs. So we add a course filter to allow to filter courses according to whether they have listed course runs or not.

## Proposal

- [x] Create a `CourseViewSetFilter` to filter courses according to whether they have listed course runs or not.
