### PR TITLE
✨(frontend) add login stack

### DIFF
--- a/src/frontend/admin/src/components/auth/context/AuthContext.tsx
+++ b/src/frontend/admin/src/components/auth/context/AuthContext.tsx
@@ -1,0 +1,65 @@
+import { Maybe } from "yup";
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+type User = any;
+
+export interface AuthContextInterface {
+  user: Maybe<User> | null;
+  updateUser: (user: Maybe<User> | null) => void;
+}
+
+const AuthContext = createContext<Maybe<AuthContextInterface>>(undefined);
+
+type AuthContextProviderProps = {
+  children: ReactNode;
+  initialUser?: Maybe<User> | null;
+};
+
+export function AuthContextProvider({
+  children,
+  ...props
+}: AuthContextProviderProps) {
+  const [user, setUser] = useState<Maybe<User> | null>(
+    props.initialUser ?? undefined
+  );
+
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (props.initialUser != null) {
+      queryClient.setQueryData(["currentUser"], props.initialUser);
+    }
+  }, []);
+
+  const context: AuthContextInterface = useMemo(
+    () => ({
+      user,
+      updateUser: (newUser: Maybe<User> | null) => {
+        queryClient.setQueryData(["currentUser"], newUser);
+        setUser(newUser);
+      },
+    }),
+    [user]
+  );
+  return (
+    <AuthContext.Provider value={context}>{children}</AuthContext.Provider>
+  );
+}
+
+export const useAuthContext = () => {
+  const authContext = useContext(AuthContext);
+
+  if (authContext) {
+    return authContext;
+  }
+
+  throw new Error(`useAuthContext must be used within a AuthContextProvider`);
+};

--- a/src/frontend/admin/src/components/auth/guard/AuthGuard.tsx
+++ b/src/frontend/admin/src/components/auth/guard/AuthGuard.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { PropsWithChildren } from "react";
+import { useRouter } from "next/router";
+import Box from "@mui/material/Box";
+import { useAuthContext } from "@/components/auth/context/AuthContext";
+
+type Props = {};
+export function AuthGuard(props: PropsWithChildren<Props>) {
+  const { user } = useAuthContext();
+  const router = useRouter();
+
+  if (!user) {
+    router.push("/auth/login");
+    return null;
+  }
+
+  return <Box height="100%">{props.children}</Box>;
+}

--- a/src/frontend/admin/src/components/auth/guard/GuestGuard.tsx
+++ b/src/frontend/admin/src/components/auth/guard/GuestGuard.tsx
@@ -1,0 +1,18 @@
+import { JSX } from "react";
+import { useRouter } from "next/router";
+import { useAuthContext } from "@/components/auth/context/AuthContext";
+
+type Props = {
+  children: JSX.Element;
+};
+export function GuestGuard(props: Props) {
+  const { user } = useAuthContext();
+  const router = useRouter();
+
+  if (user) {
+    router.push("/admin/courses");
+    return null;
+  }
+
+  return props.children;
+}

--- a/src/frontend/admin/src/components/presentational/card/SimpleCard.tsx
+++ b/src/frontend/admin/src/components/presentational/card/SimpleCard.tsx
@@ -8,8 +8,8 @@ export function SimpleCard(props: PropsWithChildren) {
       data-testid="simpleCard"
       elevation={0}
       sx={{
+        width: "100%",
         borderRadius: 4,
-        overflow: "hidden",
         boxShadow:
           "rgb(145 158 171 / 20%) 0px 0px 2px 0px, rgb(145 158 171 / 12%) 0px 12px 24px -4px",
       }}

--- a/src/frontend/admin/src/components/presentational/hook-form/RHFProvider.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFProvider.tsx
@@ -33,7 +33,7 @@ export function RHFProvider<T extends FieldValues>({
   const intl = useIntl();
   return (
     <FormProvider {...methods}>
-      <form id={id} onSubmit={onSubmit}>
+      <form style={{ width: "100%" }} id={id} onSubmit={onSubmit}>
         {children}
         <Box mt={2} display="flex" justifyContent="flex-end">
           <LoadingButton

--- a/src/frontend/admin/src/components/presentational/hook-form/RHFTextField.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFTextField.tsx
@@ -1,5 +1,11 @@
 import TextField, { TextFieldProps } from "@mui/material/TextField";
 import { Controller, useFormContext } from "react-hook-form";
+import InputAdornment from "@mui/material/InputAdornment";
+import IconButton from "@mui/material/IconButton";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import { useState } from "react";
+import { Maybe } from "@/types/utils";
 
 type Props = TextFieldProps & {
   name: string;
@@ -7,6 +13,15 @@ type Props = TextFieldProps & {
 
 export function RHFTextField({ name, helperText, ...props }: Props) {
   const { control } = useFormContext();
+  const [showPassword, setShowPassword] = useState(false);
+
+  const getType = (): Maybe<string> => {
+    if (props.type === "password" && showPassword) {
+      return "text";
+    }
+
+    return props.type;
+  };
 
   return (
     <Controller
@@ -23,7 +38,20 @@ export function RHFTextField({ name, helperText, ...props }: Props) {
           }
           error={!!error}
           helperText={error ? error?.message : helperText}
+          InputProps={{
+            endAdornment: props.type === "password" && (
+              <InputAdornment position="end">
+                <IconButton
+                  onClick={() => setShowPassword(!showPassword)}
+                  edge="end"
+                >
+                  {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
           {...props}
+          type={getType()}
         />
       )}
     />

--- a/src/frontend/admin/src/components/templates/auth/forgot-password/AuthForgotPasswordForm.tsx
+++ b/src/frontend/admin/src/components/templates/auth/forgot-password/AuthForgotPasswordForm.tsx
@@ -1,0 +1,55 @@
+import * as React from "react";
+import Stack from "@mui/material/Stack";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Typography from "@mui/material/Typography";
+import { useIntl } from "react-intl";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFTextField } from "@/components/presentational/hook-form/RHFTextField";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { commonTranslations } from "@/translations/common/commonTranslations";
+
+interface FormValues {
+  email: string;
+}
+
+export function AuthForgotPasswordForm() {
+  const intl = useIntl();
+
+  const LoginSchema = Yup.object().shape({
+    email: Yup.string().email().required(),
+  });
+
+  const methods = useForm<FormValues>({
+    resolver: yupResolver(LoginSchema),
+    defaultValues: {
+      email: "",
+    },
+  });
+
+  const onSubmit = () => {
+    // router.push("/admin/courses");
+    // AuthRepository.login(values.username, values.password).then(() => {
+    //   router.push("/admin/courses");
+    // });
+  };
+
+  return (
+    <RHFProvider methods={methods} onSubmit={methods.handleSubmit(onSubmit)}>
+      <Stack spacing={2}>
+        <RHFTextField
+          name="email"
+          label={intl.formatMessage(commonTranslations.email)}
+        />
+        <Stack direction="row" justifyContent="start">
+          <CustomLink href="/auth/login">
+            <Typography color="text.secondary" variant="caption">
+              {intl.formatMessage(commonTranslations.login)}
+            </Typography>
+          </CustomLink>
+        </Stack>
+      </Stack>
+    </RHFProvider>
+  );
+}

--- a/src/frontend/admin/src/components/templates/auth/login/form/AuthLoginForm.tsx
+++ b/src/frontend/admin/src/components/templates/auth/login/form/AuthLoginForm.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import Stack from "@mui/material/Stack";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Typography from "@mui/material/Typography";
+import { defineMessages, useIntl } from "react-intl";
+import { useRouter } from "next/router";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFTextField } from "@/components/presentational/hook-form/RHFTextField";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { commonTranslations } from "@/translations/common/commonTranslations";
+import { useAuthContext } from "@/components/auth/context/AuthContext";
+
+const messages = defineMessages({
+  forgotPassword: {
+    id: "components.templates.auth.login.form.AuthLoginForm.forgotPasswordLabel",
+    defaultMessage: "Forgot password ?",
+    description: "Text fort forgot password link",
+  },
+});
+
+interface LoginFormValues {
+  username: string;
+  password: string;
+}
+
+export function AuthLoginForm() {
+  const router = useRouter();
+  const authContext = useAuthContext();
+  const intl = useIntl();
+  const LoginSchema = Yup.object().shape({
+    username: Yup.string().required(),
+    password: Yup.string().required(),
+  });
+
+  const methods = useForm<LoginFormValues>({
+    resolver: yupResolver(LoginSchema),
+    defaultValues: {
+      username: "",
+      password: "",
+    },
+  });
+
+  const onSubmit = (values: LoginFormValues) => {
+    authContext.updateUser({ username: values.username });
+    router.push("/admin/courses");
+    // AuthRepository.login(values.username, values.password).then(() => {
+    //   router.push("/admin/courses");
+    // });
+  };
+
+  return (
+    <RHFProvider methods={methods} onSubmit={methods.handleSubmit(onSubmit)}>
+      <Stack spacing={2}>
+        <RHFTextField
+          name="username"
+          label={intl.formatMessage(commonTranslations.username)}
+        />
+        <RHFTextField
+          type="password"
+          name="password"
+          label={intl.formatMessage(commonTranslations.password)}
+        />
+        <Stack direction="row" justifyContent="start">
+          <CustomLink href="/auth/forgot-password">
+            <Typography color="text.secondary" variant="caption">
+              {intl.formatMessage(messages.forgotPassword)}
+            </Typography>
+          </CustomLink>
+        </Stack>
+      </Stack>
+    </RHFProvider>
+  );
+}

--- a/src/frontend/admin/src/contexts/i18n/TranslationsProvider/TranslationsProvider.tsx
+++ b/src/frontend/admin/src/contexts/i18n/TranslationsProvider/TranslationsProvider.tsx
@@ -60,7 +60,7 @@ export function TranslationsProvider({
           messages={translations}
           defaultLocale={LocalesEnum.ENGLISH}
         >
-          {allLanguages && <div>{props.children}</div>}
+          {allLanguages && props.children}
         </IntlProvider>
       </LocalizationProvider>
     </LocaleContext.Provider>

--- a/src/frontend/admin/src/layouts/auth/AuthLayout.tsx
+++ b/src/frontend/admin/src/layouts/auth/AuthLayout.tsx
@@ -1,0 +1,40 @@
+import * as React from "react";
+import { PropsWithChildren } from "react";
+import Box from "@mui/material/Box";
+import { grey } from "@mui/material/colors";
+import Image from "next/image";
+import logo from "../../../public/images/logo/logo-fun.svg";
+import { SimpleCard } from "@/components/presentational/card/SimpleCard";
+
+export function AuthLayout(props: PropsWithChildren) {
+  return (
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      height="100%"
+      bgcolor={grey[50]}
+    >
+      <Box width="100%" maxWidth={480}>
+        <SimpleCard>
+          <Box
+            flexDirection="column"
+            padding={3}
+            display="flex"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <Box mb={3}>
+              <Image
+                src={logo}
+                width={150}
+                alt="France Université Numérique logo"
+              />
+            </Box>
+            {props.children}
+          </Box>
+        </SimpleCard>
+      </Box>
+    </Box>
+  );
+}

--- a/src/frontend/admin/src/layouts/dashboard/DashboardLayout.tsx
+++ b/src/frontend/admin/src/layouts/dashboard/DashboardLayout.tsx
@@ -4,6 +4,7 @@ import { styled } from "@mui/material/styles";
 import Box from "@mui/material/Box";
 import { DashboardLayoutHeader } from "@/layouts/dashboard/header/DashboardLayoutHeader";
 import { DashboardNav } from "@/layouts/dashboard/nav/DashboardNav";
+import { AuthGuard } from "@/components/auth/guard/AuthGuard";
 
 const Main = styled("main", { shouldForwardProp: (prop) => prop !== "open" })<{
   open?: boolean;
@@ -40,14 +41,16 @@ export function DashboardLayout(props: PropsWithChildren) {
   };
 
   return (
-    <Box sx={{ display: "flex" }}>
-      <DashboardLayoutHeader
-        open={open}
-        onToggleNavigation={handleToggleDrawer}
-      />
-      <DashboardNav open={open} handleClose={handleDrawerClose} />
+    <AuthGuard>
+      <Box sx={{ display: "flex" }}>
+        <DashboardLayoutHeader
+          open={open}
+          onToggleNavigation={handleToggleDrawer}
+        />
+        <DashboardNav open={open} handleClose={handleDrawerClose} />
 
-      <Main open={open}>{props.children}</Main>
-    </Box>
+        <Main open={open}>{props.children}</Main>
+      </Box>
+    </AuthGuard>
   );
 }

--- a/src/frontend/admin/src/layouts/dashboard/nav/account/DashboardLayoutNavAccount.tsx
+++ b/src/frontend/admin/src/layouts/dashboard/nav/account/DashboardLayoutNavAccount.tsx
@@ -10,8 +10,13 @@ import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import { defineMessages, useIntl } from "react-intl";
 import { useTheme } from "@mui/material/styles";
+import ListItemText from "@mui/material/ListItemText";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import AccountCircleIcon from "@mui/icons-material/AccountCircle";
+import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import { DashboardNavItem } from "@/layouts/dashboard/nav/item/DashboardNavItem";
 import { DashboardNavItemsList } from "@/layouts/dashboard/nav/item/list/DasboardNavItemsList";
+import { useAuthContext } from "@/components/auth/context/AuthContext";
 
 const messages = defineMessages({
   settingsSubHeader: {
@@ -24,9 +29,20 @@ const messages = defineMessages({
     defaultMessage: "Notifications",
     description: "Notifications navigation label",
   },
+  profile: {
+    id: "layouts.dashboard.nav.account.profile",
+    defaultMessage: "Profile",
+    description: "Profile nav label",
+  },
+  logout: {
+    id: "layouts.dashboard.nav.account.logout",
+    defaultMessage: "Logout",
+    description: "Logout nav label",
+  },
 });
 
 export function DashboardLayoutNavAccount() {
+  const authContext = useAuthContext();
   const ref = useRef<HTMLButtonElement>(null);
   const [navAccountMenuIsOpen, setNavAccountMenuIsOpen] = useState(false);
   const intl = useIntl();
@@ -38,6 +54,13 @@ export function DashboardLayoutNavAccount() {
 
   const handleCloseMenu = () => {
     setNavAccountMenuIsOpen(false);
+  };
+
+  const logout = () => {
+    authContext.updateUser(null);
+    // AuthRepository.logout(() => {
+    //   authContext.updateUser(null);
+    // });
   };
 
   return (
@@ -83,8 +106,25 @@ export function DashboardLayoutNavAccount() {
             open={navAccountMenuIsOpen}
             onClose={handleCloseMenu}
           >
-            <MenuItem onClick={handleCloseMenu}>Profile</MenuItem>
-            <MenuItem onClick={handleCloseMenu}>My account</MenuItem>
+            <MenuItem onClick={handleCloseMenu}>
+              <ListItemIcon>
+                <AccountCircleIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>
+                {intl.formatMessage(messages.profile)}
+              </ListItemText>
+            </MenuItem>
+            <MenuItem
+              onClick={() => {
+                logout();
+                handleCloseMenu();
+              }}
+            >
+              <ListItemIcon>
+                <ExitToAppIcon fontSize="small" />
+              </ListItemIcon>
+              <ListItemText>{intl.formatMessage(messages.logout)}</ListItemText>
+            </MenuItem>
           </Menu>
         </Box>
         <DashboardNavItem

--- a/src/frontend/admin/src/pages/_app.tsx
+++ b/src/frontend/admin/src/pages/_app.tsx
@@ -21,6 +21,7 @@ import { LocalesEnum } from "@/types/i18n/LocalesEnum";
 import { TranslationsProvider } from "@/contexts/i18n/TranslationsProvider/TranslationsProvider";
 import { REACT_QUERY_SETTINGS } from "@/utils/settings";
 import { JoanieThemeProvider } from "@/theme/JoanieThemeProvider";
+import { AuthContextProvider } from "@/components/auth/context/AuthContext";
 
 type NextPageWithLayout = NextPage & {
   getLayout?: (page: React.ReactElement) => React.ReactNode;
@@ -96,7 +97,9 @@ export default function App({ Component, pageProps }: MyAppProps) {
               maxSnack={3}
               anchorOrigin={{ horizontal: "right", vertical: "top" }}
             >
-              {getLayout(<Component {...pageProps} />)}
+              <AuthContextProvider initialUser={{}}>
+                {getLayout(<Component {...pageProps} />)}
+              </AuthContextProvider>
             </SnackbarProvider>
           </JoanieThemeProvider>
         </CacheProvider>

--- a/src/frontend/admin/src/pages/auth/forgot-password/index.tsx
+++ b/src/frontend/admin/src/pages/auth/forgot-password/index.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { AuthLayout } from "@/layouts/auth/AuthLayout";
+import { GuestGuard } from "@/components/auth/guard/GuestGuard";
+import { AuthForgotPasswordForm } from "@/components/templates/auth/forgot-password/AuthForgotPasswordForm";
+
+export default function Login() {
+  return (
+    <GuestGuard>
+      <AuthForgotPasswordForm />
+    </GuestGuard>
+  );
+}
+
+Login.getLayout = (page: React.ReactElement) => <AuthLayout>{page}</AuthLayout>;

--- a/src/frontend/admin/src/pages/auth/login/index.tsx
+++ b/src/frontend/admin/src/pages/auth/login/index.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+import { AuthLayout } from "@/layouts/auth/AuthLayout";
+import { GuestGuard } from "@/components/auth/guard/GuestGuard";
+import { AuthLoginForm } from "@/components/templates/auth/login/form/AuthLoginForm";
+
+export default function Login() {
+  return (
+    <GuestGuard>
+      <AuthLoginForm />
+    </GuestGuard>
+  );
+}
+
+Login.getLayout = (page: React.ReactElement) => <AuthLayout>{page}</AuthLayout>;

--- a/src/frontend/admin/src/services/repositories/auth/AuthRepository.ts
+++ b/src/frontend/admin/src/services/repositories/auth/AuthRepository.ts
@@ -1,0 +1,24 @@
+import { checkStatus, fetchApi } from "@/services/http/HttpService";
+import { exportToFormData } from "@/utils/forms";
+
+export class AuthRepository {
+  static login(username: string, password: string): Promise<any> {
+    return fetchApi("/auth/login", {
+      method: "POST",
+      body: exportToFormData({ username, password }),
+    }).then(checkStatus);
+  }
+
+  static logout(): Promise<any> {
+    return fetchApi("/auth/logout", {
+      method: "POST",
+    }).then(checkStatus);
+  }
+
+  static forgotPassword(email: string): Promise<any> {
+    return fetchApi("/auth/forgot-password", {
+      method: "POST",
+      body: exportToFormData({ email }),
+    }).then(checkStatus);
+  }
+}

--- a/src/frontend/admin/src/styles/globals.scss
+++ b/src/frontend/admin/src/styles/globals.scss
@@ -1,6 +1,11 @@
 @use "abstracts";
 
+html, body, #__next {
+  height: 100%;
+}
+
 body {
+  margin: 0;
   color: rgb(var(--foreground-rgb));
   background: white;
   overflow: auto;

--- a/src/frontend/admin/src/translations/common/commonTranslations.ts
+++ b/src/frontend/admin/src/translations/common/commonTranslations.ts
@@ -21,4 +21,24 @@ export const commonTranslations = defineMessages({
     defaultMessage: "Language",
     description: "Common language label",
   },
+  username: {
+    id: "translations.common.commonTranslations.username",
+    defaultMessage: "Username",
+    description: "Common username label",
+  },
+  email: {
+    id: "translations.common.commonTranslations.email",
+    defaultMessage: "Email",
+    description: "Common email label",
+  },
+  password: {
+    id: "translations.common.commonTranslations.password",
+    defaultMessage: "Password",
+    description: "Common password label",
+  },
+  login: {
+    id: "translations.common.commonTranslations.login",
+    defaultMessage: "Log in",
+    description: "Common log in label",
+  },
 });


### PR DESCRIPTION
## Purpose

Currently, to login, we use the django admin, and we use cookies. However, we want to add this functionality directly in the admin joanie


## Proposal

- [x] Add AuthGuard and GuestGuard
- [x] Create login and register pages
- [x] add AuthRepository
