### PR TITLE
Feat/admin/bind accesses to course and organization

### DIFF
--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -20,6 +20,14 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.OrganizationAdminFilterSet
 
+    def get_serializer_class(self):
+        """
+        Return the serializer class to use depending on the action.
+        """
+        if self.action == "list":
+            return serializers.AdminOrganizationLightSerializer
+        return self.serializer_class
+
 
 class ProductViewSet(viewsets.ModelViewSet):
     """
@@ -44,6 +52,14 @@ class CourseViewSet(viewsets.ModelViewSet):
     queryset = models.Course.objects.all().prefetch_related("organizations", "products")
     filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.CourseAdminFilterSet
+
+    def get_serializer_class(self):
+        """
+        Return the serializer class to use depending on the action.
+        """
+        if self.action == "list":
+            return serializers.AdminCourseLightSerializer
+        return self.serializer_class
 
 
 class CourseRunViewSet(viewsets.ModelViewSet):

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -242,5 +242,5 @@ class AdminUserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.User
-        fields = ["username", "full_name"]
-        read_only_fields = ["username", "full_name"]
+        fields = ["id", "username", "full_name"]
+        read_only_fields = ["id", "username", "full_name"]

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -26,8 +26,38 @@ class AdminCourseLightSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Course
-        fields = ("code", "title", "id")
-        read_only_fields = ("code", "title", "id")
+        fields = ("code", "title", "id", "state")
+        read_only_fields = ("code", "title", "id", "state")
+
+
+class AdminUserSerializer(serializers.ModelSerializer):
+    """Serializer for User model."""
+
+    full_name = serializers.CharField(source="get_full_name")
+
+    class Meta:
+        model = models.User
+        fields = ["id", "username", "full_name"]
+        read_only_fields = ["id", "username", "full_name"]
+
+
+class AdminOrganizationAccessSerializer(serializers.ModelSerializer):
+    """Serializer for OrganizationAccess model."""
+
+    user = AdminUserSerializer()
+
+    class Meta:
+        model = models.CourseAccess
+        fields = (
+            "id",
+            "user",
+            "role",
+        )
+        read_only_fields = (
+            "id",
+            "user",
+            "role",
+        )
 
 
 class AdminOrganizationSerializer(serializers.ModelSerializer):
@@ -36,11 +66,23 @@ class AdminOrganizationSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     logo = ThumbnailDetailField(required=False)
     signature = ImageDetailField(required=False)
+    accesses = AdminOrganizationAccessSerializer(many=True, read_only=True)
 
     class Meta:
         model = models.Organization
-        fields = ["id", "code", "title", "representative", "signature", "logo"]
-        read_only_fields = ["id"]
+        fields = (
+            "accesses",
+            "code",
+            "id",
+            "logo",
+            "representative",
+            "signature",
+            "title",
+        )
+        read_only_fields = (
+            "accesses",
+            "id",
+        )
 
 
 class AdminOrganizationLightSerializer(serializers.ModelSerializer):
@@ -48,8 +90,8 @@ class AdminOrganizationLightSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Organization
-        fields = ["code", "title", "id"]
-        read_only_fields = ["code", "title", "id"]
+        fields = ("code", "title", "id")
+        read_only_fields = ("code", "title", "id")
 
 
 class AdminProductSerializer(serializers.ModelSerializer):
@@ -98,6 +140,25 @@ class AdminProductRelationSerializer(serializers.ModelSerializer):
         read_only_fields = ["id"]
 
 
+class AdminCourseAccessSerializer(serializers.ModelSerializer):
+    """Serializer for CourseAccess model."""
+
+    user = AdminUserSerializer()
+
+    class Meta:
+        model = models.CourseAccess
+        fields = (
+            "id",
+            "user",
+            "role",
+        )
+        read_only_fields = (
+            "id",
+            "user",
+            "role",
+        )
+
+
 class AdminCourseSerializer(serializers.ModelSerializer):
     """Serializer for Course model."""
 
@@ -105,19 +166,25 @@ class AdminCourseSerializer(serializers.ModelSerializer):
     cover = ThumbnailDetailField(required=False)
     organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
     product_relations = AdminProductRelationSerializer(many=True, read_only=True)
+    accesses = AdminCourseAccessSerializer(many=True, read_only=True)
 
     class Meta:
         model = models.Course
         fields = (
-            "id",
+            "accesses",
             "code",
             "cover",
-            "title",
+            "id",
             "organizations",
             "product_relations",
             "state",
+            "title",
         )
-        read_only_fields = ["id", "state"]
+        read_only_fields = (
+            "accesses",
+            "id",
+            "state",
+        )
 
     def validate(self, attrs):
         """
@@ -233,14 +300,3 @@ class AdminCourseRunSerializer(serializers.ModelSerializer):
                 )
 
         return validated_data
-
-
-class AdminUserSerializer(serializers.ModelSerializer):
-    """Serializer for User model."""
-
-    full_name = serializers.CharField(source="get_full_name")
-
-    class Meta:
-        model = models.User
-        fields = ["id", "username", "full_name"]
-        read_only_fields = ["id", "username", "full_name"]

--- a/src/backend/joanie/tests/core/test_api_admin_courses.py
+++ b/src/backend/joanie/tests/core/test_api_admin_courses.py
@@ -47,13 +47,27 @@ class CourseAdminApiTest(TestCase):
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=admin.username, password="password")
         courses_count = random.randint(1, 10)
-        factories.CourseFactory.create_batch(courses_count)
+        courses = factories.CourseFactory.create_batch(courses_count)
 
         response = self.client.get("/api/v1.0/admin/courses/")
 
         self.assertEqual(response.status_code, 200)
-        content = response.json()
-        self.assertEqual(content["count"], courses_count)
+        self.assertCountEqual(
+            response.json(),
+            {
+                "count": courses_count,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": str(course.id),
+                        "code": course.code,
+                        "title": course.title,
+                    }
+                    for course in courses
+                ],
+            },
+        )
 
     def test_admin_api_course_list_filter_by_query(self):
         """
@@ -62,59 +76,24 @@ class CourseAdminApiTest(TestCase):
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=admin.username, password="password")
         courses_count = random.randint(1, 10)
-        items = factories.CourseFactory.create_batch(courses_count)
+        [course, *_] = factories.CourseFactory.create_batch(courses_count)
 
         response = self.client.get("/api/v1.0/admin/courses/?query=")
         self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertEqual(content["count"], courses_count)
 
-        response = self.client.get(f"/api/v1.0/admin/courses/?query={items[0].title}")
+        response = self.client.get(f"/api/v1.0/admin/courses/?query={course.title}")
         self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertEqual(content["count"], 1)
+        self.assertEqual(content["results"][0]["id"], str(course.id))
 
-        response = self.client.get(f"/api/v1.0/admin/courses/?query={items[0].code}")
+        response = self.client.get(f"/api/v1.0/admin/courses/?query={course.code}")
         self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertEqual(content["count"], 1)
-
-        course_1 = items[0]
-        self.assertEqual(
-            content,
-            {
-                "count": 1,
-                "next": None,
-                "previous": None,
-                "results": [
-                    {
-                        "id": str(course_1.id),
-                        "code": course_1.code,
-                        "cover": {
-                            "size": course_1.cover.size,
-                            "src": f"http://testserver{course_1.cover.url}.1x1_q85.webp",
-                            "srcset": (
-                                f"http://testserver{course_1.cover.url}.1920x1080_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
-                                "1920w, "
-                                f"http://testserver{course_1.cover.url}.1280x720_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
-                                "1280w, "
-                                f"http://testserver{course_1.cover.url}.768x432_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
-                                "768w, "
-                                f"http://testserver{course_1.cover.url}.384x216_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
-                                "384w"
-                            ),
-                            "height": course_1.cover.height,
-                            "width": course_1.cover.width,
-                            "filename": course_1.cover.name,
-                        },
-                        "title": course_1.title,
-                        "organizations": [],
-                        "product_relations": [],
-                        "state": course_1.state,
-                    }
-                ],
-            },
-        )
+        self.assertEqual(content["results"][0]["id"], str(course.id))
 
     def test_admin_api_course_list_filter_by_query_language(self):
         """
@@ -150,16 +129,68 @@ class CourseAdminApiTest(TestCase):
 
     def test_admin_api_course_get(self):
         """
-        Staff user should be able to get a course through its id.
+        Staff user should be able to get a course through its id
+        with detailed information.
         """
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=admin.username, password="password")
         course = factories.CourseFactory()
-        response = self.client.get(f"/api/v1.0/admin/courses/{course.id}/")
 
+        # Add course access to the course
+        accesses_count = random.randint(0, 5)
+        factories.UserCourseAccessFactory.create_batch(accesses_count, course=course)
+
+        response = self.client.get(f"/api/v1.0/admin/courses/{course.id}/")
         self.assertEqual(response.status_code, 200)
-        content = response.json()
-        self.assertEqual(content["id"], str(course.id))
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(course.id),
+                "code": course.code,
+                "cover": {
+                    "size": course.cover.size,
+                    "src": f"http://testserver{course.cover.url}.1x1_q85.webp",
+                    "srcset": (
+                        f"http://testserver{course.cover.url}.1920x1080_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        "1920w, "
+                        f"http://testserver{course.cover.url}.1280x720_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        "1280w, "
+                        f"http://testserver{course.cover.url}.768x432_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        "768w, "
+                        f"http://testserver{course.cover.url}.384x216_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        "384w"
+                    ),
+                    "height": course.cover.height,
+                    "width": course.cover.width,
+                    "filename": course.cover.name,
+                },
+                "title": course.title,
+                "organizations": [],
+                "product_relations": [],
+                "state": {
+                    "priority": course.state["priority"],
+                    "datetime": course.state["datetime"]
+                    .isoformat()
+                    .replace("+00:00", "Z")
+                    if course.state["datetime"]
+                    else None,
+                    "call_to_action": course.state["call_to_action"],
+                    "text": course.state["text"],
+                },
+                "accesses": [
+                    {
+                        "id": str(access.id),
+                        "role": access.role,
+                        "user": {
+                            "id": str(access.user.id),
+                            "full_name": access.user.get_full_name(),
+                            "username": access.user.username,
+                        },
+                    }
+                    for access in course.accesses.all()
+                ],
+            },
+        )
 
     def test_admin_api_course_create(self):
         """

--- a/src/backend/joanie/tests/core/test_api_admin_users.py
+++ b/src/backend/joanie/tests/core/test_api_admin_users.py
@@ -97,6 +97,7 @@ class UserAdminApiTest(TestCase):
         self.assertEqual(
             content["results"][0],
             {
+                "id": str(fonzie.id),
                 "username": fonzie.username,
                 "full_name": fonzie.get_full_name(),
             },
@@ -116,6 +117,7 @@ class UserAdminApiTest(TestCase):
         self.assertEqual(
             content["results"][0],
             {
+                "id": str(joanie.id),
                 "username": joanie.username,
                 "full_name": joanie.get_full_name(),
             },


### PR DESCRIPTION
## Purpose

In back office, we want to list all accesses for course/organization. So we bind
this information into their respective serializer. In order to improve
performance, we use respective light serializer to list those resources.

## Proposal

- [x] Bind accesses into `AdminCourseSerializer` and `AdminOrganizationSerializer`
- [x] Use light serializers to list `Course` and `Organization` resources
