### PR TITLE
✨(api/admin) add endpoint to create/udpate/delete course accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add admin endpoint to create/update/delete course accesses
 - Add admin endpoint to search users
 - Add endpoints to get course product relations and courses from organization
 - Add `max_validated_orders` field to CourseProductRelation model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ## Added
 
-- Add admin endpoint to create/update/delete course accesses
+- Add admin endpoints to create/update/delete organization/course accesses
 - Add admin endpoint to search users
 - Add endpoints to get course product relations and courses from organization
 - Add `max_validated_orders` field to CourseProductRelation model

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -110,3 +110,27 @@ class UserViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             return models.User.objects.none()
 
         return super().get_queryset()
+
+
+class CourseAccessViewSet(
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    """
+    Write only Course Access ViewSet
+    """
+
+    authentication_classes = [authentication.SessionAuthentication]
+    permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
+    serializer_class = serializers.AdminCourseAccessSerializer
+    queryset = models.CourseAccess.objects.all().select_related("user")
+
+    def get_serializer_context(self):
+        """
+        Extra context provided to the serializer class.
+        """
+        context = super().get_serializer_context()
+        context["course_id"] = self.kwargs["course_id"]
+        return context

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -134,3 +134,27 @@ class CourseAccessViewSet(
         context = super().get_serializer_context()
         context["course_id"] = self.kwargs["course_id"]
         return context
+
+
+class OrganizationAccessViewSet(
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    """
+    Write only Organization Access ViewSet
+    """
+
+    authentication_classes = [authentication.SessionAuthentication]
+    permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
+    serializer_class = serializers.AdminOrganizationAccessSerializer
+    queryset = models.OrganizationAccess.objects.all().select_related("user")
+
+    def get_serializer_context(self):
+        """
+        Extra context provided to the serializer class.
+        """
+        context = super().get_serializer_context()
+        context["organization_id"] = self.kwargs["organization_id"]
+        return context

--- a/src/backend/joanie/tests/core/test_api_admin_course_access.py
+++ b/src/backend/joanie/tests/core/test_api_admin_course_access.py
@@ -1,0 +1,329 @@
+"""
+Test suite for CourseAccess Admin API.
+"""
+import uuid
+
+from django.test import TestCase
+
+from joanie.core import enums, factories
+
+
+class CourseAccessAdminApiTest(TestCase):
+    """
+    Test suite for CourseAccess Admin API.
+    """
+
+    def test_admin_api_course_accesses_request_anonymous(self):
+        """
+        Anonymous users should not be able to request course accesses endpoint.
+        """
+        course = factories.CourseFactory()
+        response = self.client.get(f"/api/v1.0/admin/courses/{course.id}/accesses/")
+
+        self.assertEqual(response.status_code, 403)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_admin_api_course_accesses_request_authenticated(self):
+        """
+        Authenticated users should not be able to request course accesses endpoint.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        course = factories.CourseFactory()
+        response = self.client.get(f"/api/v1.0/admin/courses/{course.id}/accesses/")
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    def test_admin_api_course_accesses_request_list(self):
+        """
+        Super admin user should not be able to list course accesses.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        response = self.client.get(f"/api/v1.0/admin/courses/{course.id}/accesses/")
+
+        self.assertContains(
+            response,
+            'Method \\"GET\\" not allowed.',
+            status_code=405,
+        )
+
+    def test_admin_api_course_accesses_request_get(self):
+        """
+        Super admin user should not be able to retrieve a course accesses.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        course_access = factories.UserCourseAccessFactory(course=course)
+        response = self.client.get(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/{course_access.id}/"
+        )
+
+        self.assertContains(
+            response,
+            'Method \\"GET\\" not allowed.',
+            status_code=405,
+        )
+
+    def test_admin_api_course_accesses_request_create(self):
+        """
+        Super admin user should be able to create a course access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory()
+        self.assertEqual(course.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MANAGER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(course.accesses.count(), 1)
+        course_access = course.accesses.first()
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(course_access.id),
+                "role": "manager",
+                "user": {
+                    "id": str(user.id),
+                    "username": user.username,
+                    "full_name": user.get_full_name(),
+                },
+            },
+        )
+
+    def test_admin_api_course_accesses_request_create_with_unknown_user_id(self):
+        """
+        An 400 Bad request error should be raised if the user id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory.build()
+        self.assertEqual(course.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MANAGER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"user": ["Resource does not exist."]})
+
+    def test_admin_api_course_accesses_request_create_with_unknown_course_id(self):
+        """
+        An 404 Not found error should be raised if the course id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory.build()
+        user = factories.UserFactory()
+        self.assertEqual(course.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MANAGER,
+            },
+        )
+
+        self.assertContains(response, "Not found.", status_code=404)
+
+    def test_admin_api_course_accesses_request_create_with_invalid_role(self):
+        """
+        An 400 Bad request error should be raised if the role is not valid.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory()
+        self.assertEqual(course.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": "invalid_role",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(), {"role": ['"invalid_role" is not a valid choice.']}
+        )
+
+    def test_admin_api_course_accesses_request_update(self):
+        """
+        Super admin user should be able to update a course access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory()
+        course_access = factories.UserCourseAccessFactory(
+            course=course, user=user, role=enums.MANAGER
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/{course_access.id}/",
+            content_type="application/json",
+            data={
+                "user": str(user.id),
+                "role": enums.INSTRUCTOR,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(course_access.id),
+                "role": "instructor",
+                "user": {
+                    "id": str(user.id),
+                    "username": user.username,
+                    "full_name": user.get_full_name(),
+                },
+            },
+        )
+
+    def test_admin_api_course_accesses_request_update_with_unknown_course_id(self):
+        """
+        An 404 Not found error should be raised if the course access id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory.build()
+        user = factories.UserFactory()
+        self.assertEqual(course.accesses.count(), 0)
+
+        response = self.client.put(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/{uuid.uuid4()}/",
+            data={
+                "user": str(user.id),
+                "role": enums.MANAGER,
+            },
+        )
+
+        self.assertContains(response, "Not found.", status_code=404)
+
+    def test_admin_api_course_accesses_request_update_with_partial_payload(self):
+        """
+        An 400 Bad request error should be raised if a partial payload is provided.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory()
+        course_access = factories.UserCourseAccessFactory(
+            course=course, user=user, role=enums.MANAGER
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/{course_access.id}/",
+            content_type="application/json",
+            data={
+                "role": enums.INSTRUCTOR,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        content = response.json()
+        self.assertEqual(content, {"user": ["This field is required."]})
+
+    def test_admin_api_course_accesses_request_update_with_unknown_user(self):
+        """
+        An 400 Bad request error should be raised if the user id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory.build()
+        self.assertEqual(course.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MANAGER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"user": ["Resource does not exist."]})
+
+    def test_admin_api_course_accesses_request_partial_update(self):
+        """
+        Super admin user should be able to partially update a course access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory()
+        course_access = factories.UserCourseAccessFactory(
+            course=course, user=user, role=enums.MANAGER
+        )
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/{course_access.id}/",
+            content_type="application/json",
+            data={
+                "role": enums.INSTRUCTOR,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(course_access.id),
+                "role": "instructor",
+                "user": {
+                    "id": str(user.id),
+                    "username": user.username,
+                    "full_name": user.get_full_name(),
+                },
+            },
+        )
+
+    def test_admin_api_course_accesses_request_delete(self):
+        """
+        Super admin user should be able to delete a course access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        user = factories.UserFactory()
+        course_access = factories.UserCourseAccessFactory(
+            course=course, user=user, role=enums.MANAGER
+        )
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/courses/{course.id}/accesses/{course_access.id}/"
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(course.accesses.count(), 0)

--- a/src/backend/joanie/tests/core/test_api_admin_organization_access.py
+++ b/src/backend/joanie/tests/core/test_api_admin_organization_access.py
@@ -1,0 +1,341 @@
+"""
+Test suite for OrganizationAccess Admin API.
+"""
+import uuid
+
+from django.test import TestCase
+
+from joanie.core import enums, factories
+
+
+class OrganizationAccessAdminApiTest(TestCase):
+    """
+    Test suite for OrganizationAccess Admin API.
+    """
+
+    def test_admin_api_organization_accesses_request_anonymous(self):
+        """
+        Anonymous users should not be able to request organization accesses endpoint.
+        """
+        organization = factories.OrganizationFactory()
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/"
+        )
+
+        self.assertEqual(response.status_code, 403)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_admin_api_organization_accesses_request_authenticated(self):
+        """
+        Authenticated users should not be able to request organization accesses endpoint.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        organization = factories.OrganizationFactory()
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/"
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    def test_admin_api_organization_accesses_request_list(self):
+        """
+        Super admin user should not be able to list organization accesses.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/"
+        )
+
+        self.assertContains(
+            response,
+            'Method \\"GET\\" not allowed.',
+            status_code=405,
+        )
+
+    def test_admin_api_organization_accesses_request_get(self):
+        """
+        Super admin user should not be able to retrieve an organization access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        organization_access = factories.UserOrganizationAccessFactory(
+            organization=organization
+        )
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/{organization_access.id}/"
+        )
+
+        self.assertContains(
+            response,
+            'Method \\"GET\\" not allowed.',
+            status_code=405,
+        )
+
+    def test_admin_api_organization_accesses_request_create(self):
+        """
+        Super admin user should be able to create a course access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        self.assertEqual(organization.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MEMBER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(organization.accesses.count(), 1)
+        organization_access = organization.accesses.first()
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(organization_access.id),
+                "role": "member",
+                "user": {
+                    "id": str(user.id),
+                    "username": user.username,
+                    "full_name": user.get_full_name(),
+                },
+            },
+        )
+
+    def test_admin_api_organization_accesses_request_create_with_unknown_user_id(self):
+        """
+        An 400 Bad request error should be raised if the user id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory.build()
+        self.assertEqual(organization.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MEMBER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"user": ["Resource does not exist."]})
+
+    def test_admin_api_organization_accesses_request_create_with_unknown_course_id(
+        self,
+    ):
+        """
+        An 404 Not found error should be raised if the organization id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory.build()
+        user = factories.UserFactory()
+        self.assertEqual(organization.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MEMBER,
+            },
+        )
+
+        self.assertContains(response, "Not found.", status_code=404)
+
+    def test_admin_api_organization_accesses_request_create_with_invalid_role(self):
+        """
+        An 400 Bad request error should be raised if the role is not valid.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        self.assertEqual(organization.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": "invalid_role",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(), {"role": ['"invalid_role" is not a valid choice.']}
+        )
+
+    def test_admin_api_organization_accesses_request_update(self):
+        """
+        Super admin user should be able to update an organization access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        organization_access = factories.UserOrganizationAccessFactory(
+            organization=organization, user=user, role=enums.MEMBER
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/{organization_access.id}/",
+            content_type="application/json",
+            data={
+                "user": str(user.id),
+                "role": enums.OWNER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(organization_access.id),
+                "role": "owner",
+                "user": {
+                    "id": str(user.id),
+                    "username": user.username,
+                    "full_name": user.get_full_name(),
+                },
+            },
+        )
+
+    def test_admin_api_organization_accesses_request_update_with_unknown_course_id(
+        self,
+    ):
+        """
+        An 404 Not found error should be raised if the organization access id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory.build()
+        user = factories.UserFactory()
+        self.assertEqual(organization.accesses.count(), 0)
+
+        response = self.client.put(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/{uuid.uuid4()}/",
+            data={
+                "user": str(user.id),
+                "role": enums.MEMBER,
+            },
+        )
+
+        self.assertContains(response, "Not found.", status_code=404)
+
+    def test_admin_api_organization_accesses_request_update_with_partial_payload(self):
+        """
+        An 400 Bad request error should be raised if a partial payload is provided.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        organization_access = factories.UserOrganizationAccessFactory(
+            organization=organization, user=user, role=enums.MEMBER
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/{organization_access.id}/",
+            content_type="application/json",
+            data={
+                "role": enums.ADMIN,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        content = response.json()
+        self.assertEqual(content, {"user": ["This field is required."]})
+
+    def test_admin_api_organization_accesses_request_update_with_unknown_user(self):
+        """
+        An 400 Bad request error should be raised if the user id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory.build()
+        self.assertEqual(organization.accesses.count(), 0)
+
+        response = self.client.post(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/",
+            data={
+                "user": str(user.id),
+                "role": enums.MEMBER,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"user": ["Resource does not exist."]})
+
+    def test_admin_api_organization_accesses_request_partial_update(self):
+        """
+        Super admin user should be able to partially update an organization access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        organization_access = factories.UserOrganizationAccessFactory(
+            organization=organization, user=user, role=enums.MEMBER
+        )
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/{organization_access.id}/",
+            content_type="application/json",
+            data={
+                "role": enums.ADMIN,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(organization_access.id),
+                "role": "administrator",
+                "user": {
+                    "id": str(user.id),
+                    "username": user.username,
+                    "full_name": user.get_full_name(),
+                },
+            },
+        )
+
+    def test_admin_api_organization_accesses_request_delete(self):
+        """
+        Super admin user should be able to delete an organization access.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        organization_access = factories.UserOrganizationAccessFactory(
+            organization=organization, user=user, role=enums.MEMBER
+        )
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/{organization_access.id}/"
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(organization.accesses.count(), 0)

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -108,6 +108,14 @@ admin_course_related_router.register(
     "accesses", api_admin.CourseAccessViewSet, basename="admin_course_accesses"
 )
 
+# Admin API routes nested under an organization
+admin_organization_related_router = DefaultRouter()
+admin_organization_related_router.register(
+    "accesses",
+    api_admin.OrganizationAccessViewSet,
+    basename="admin_organization_accesses",
+)
+
 urlpatterns = [
     path("admin/", admin.site.urls),
     path(
@@ -117,6 +125,10 @@ urlpatterns = [
     path(
         f"api/{API_VERSION}/admin/courses/<uuid:course_id>/",
         include(admin_course_related_router.urls),
+    ),
+    path(
+        f"api/{API_VERSION}/admin/organizations/<uuid:organization_id>/",
+        include(admin_organization_related_router.urls),
     ),
     path(
         f"api/{API_VERSION}/",

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -88,23 +88,35 @@ organization_related_router.register(
 # 2) Admin API
 admin_router = DefaultRouter()
 admin_router.register(
-    "organizations", api_admin.OrganizationViewSet, basename="organizations"
+    "organizations", api_admin.OrganizationViewSet, basename="admin_organizations"
 )
-admin_router.register("products", api_admin.ProductViewSet, basename="products")
-admin_router.register("courses", api_admin.CourseViewSet, basename="courses")
-admin_router.register("course-runs", api_admin.CourseRunViewSet, basename="course-runs")
+admin_router.register("products", api_admin.ProductViewSet, basename="admin_products")
+admin_router.register("courses", api_admin.CourseViewSet, basename="admin_courses")
+admin_router.register(
+    "course-runs", api_admin.CourseRunViewSet, basename="admin_course-runs"
+)
 admin_router.register(
     "certificate-definitions",
     api_admin.CertificateDefinitionViewSet,
-    basename="certificate-definitions",
+    basename="admin_certificate-definitions",
 )
-admin_router.register("users", api_admin.UserViewSet, basename="user")
+admin_router.register("users", api_admin.UserViewSet, basename="admin_user")
+
+# Admin API routes nested under a course
+admin_course_related_router = DefaultRouter()
+admin_course_related_router.register(
+    "accesses", api_admin.CourseAccessViewSet, basename="admin_course_accesses"
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path(
         f"api/{API_VERSION}/admin/",
         include([*admin_router.urls]),
+    ),
+    path(
+        f"api/{API_VERSION}/admin/courses/<uuid:course_id>/",
+        include(admin_course_related_router.urls),
     ),
     path(
         f"api/{API_VERSION}/",


### PR DESCRIPTION
## Purpose

Backoffice need to create / update / delete course accesses to create api endpoints to allow that.

## Proposal

- [x] Add api endpoint to create / update / delete course accesses
- [x] Add api endpoint to create / update / delete organization accesses

### New routes description
#### Course Accesses
- [POST] `/api/v1.0/admin/courses/<course_id:uuid>/accesses/`
- [OPTIONS] `/api/v1.0/admin/courses/<course_id:uuid>/accesses/`
- [PUT] `/api/v1.0/admin/courses/<course_id:uuid>/accesses/<course_access_id:uuid>/`
- [PATCH] `/api/v1.0/admin/courses/<course_id:uuid>/accesses/<course_access_id:uuid>/`
- [DELETE] `/api/v1.0/admin/courses/<course_id:uuid>/accesses/<course_access_id:uuid>/`

#### Organization Accesses
- [POST] `/api/v1.0/admin/organizations/<organization_id:uuid>/accesses/`
- [OPTIONS] `/api/v1.0/admin/organizations/<organization_id:uuid>/accesses/`
- [PUT] `/api/v1.0/admin/organizations/<organization_id:uuid>/accesses/<organization_access_id:uuid>/`
- [PATCH] `/api/v1.0/admin/organizations/<organization_id:uuid>/accesses/<organization_access_id:uuid>/`
- [DELETE] `/api/v1.0/admin/organizations/<organization_id:uuid>/accesses/<organization_access_id:uuid>/`
