### PR TITLE
🐛(api/client) fix has_listed_course_runs course filter

### DIFF
--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -67,6 +67,8 @@ class CourseViewSetFilter(filters.FilterSet):
         Filter resource by looking for course runs which are listed.
         """
         if value is True:
-            return queryset.filter(course_runs__is_listed=True)
+            filtered_queryset = queryset.filter(course_runs__is_listed=True)
+        else:
+            filtered_queryset = queryset.exclude(course_runs__is_listed=True)
 
-        return queryset.exclude(course_runs__is_listed=True)
+        return filtered_queryset.distinct()

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -133,6 +133,8 @@ class CourseApiTest(BaseAPITestCase):
         courses = factories.CourseFactory.create_batch(3)
         factories.CourseRunFactory(course=courses[0], is_listed=False)
         factories.CourseRunFactory(course=courses[0], is_listed=True)
+        factories.CourseRunFactory(course=courses[0], is_listed=True)
+        factories.CourseRunFactory(course=courses[1], is_listed=False)
         factories.CourseRunFactory(course=courses[1], is_listed=False)
 
         # Give user access to all courses


### PR DESCRIPTION
## Purpose

The filter `has_listed_course_runs` return non distinct course. So when filtering course whose have listed course runs it returns the resource as many as it has listed course runs.


## Proposal

- [x] Add `distinct` clause to `has_listed_course_runs` filter queryset
