### PR TITLE
Frontend/admin/fix deps issue

### DIFF
--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -14,10 +14,10 @@
     "i18n:compile": "formatjs compile-folder --format crowdin ./i18n/locales ./src/translations"
   },
   "dependencies": {
+    "@emotion/cache": "11.11.0",
     "@emotion/react": "11.11.1",
     "@emotion/server": "11.11.0",
     "@emotion/styled": "11.11.0",
-    "@emotion/cache": "11.11.0",
     "@faker-js/faker": "8.0.2",
     "@fontsource/roboto": "5.0.5",
     "@hookform/resolvers": "3.1.1",
@@ -27,6 +27,7 @@
     "@mui/x-data-grid": "6.10.1",
     "@mui/x-date-pickers": "6.10.1",
     "@tanstack/react-query": "4.32.0",
+    "@tanstack/react-query-devtools": "4.32.0",
     "classnames": "2.3.2",
     "date-fns": "2.30.0",
     "js-cookie": "3.0.5",
@@ -48,7 +49,6 @@
   "devDependencies": {
     "@formatjs/cli": "6.1.3",
     "@jest/globals": "29.6.1",
-    "@tanstack/react-query-devtools": "4.32.0",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",

--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -85,5 +85,8 @@
   },
   "msw": {
     "workerDirectory": "public"
+  },
+  "volta": {
+    "node": "16.15.1"
   }
 }


### PR DESCRIPTION
## Purpose

Currently, frontend admin project cannot be built due to a linter error.

## Proposal

- [x] Fix linter error by moving "@tanstack/react-query-devtools" from "devDependencies" to "dependencies"
- [x] Pin node to version 16.15 for [volta](https://volta.sh/) users.
