### PR TITLE
✨(api) add related certificate products to enrollment API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ## Added
 
-- Remove djmoney and Moneyfields
+- Add related certificate products to enrollment API endpoint
 - Add admin endpoints to create/update/delete organization/course accesses
 - Add admin endpoint to search users
 - Add endpoints to get course product relations and courses from organization
@@ -50,6 +50,7 @@ and this project adheres to
 
 ### Removed
 
+- Remove djmoney and Moneyfields
 - Badge providers now live in the obc python package
 - Remove unused `OrderLiteSerializer`
 


### PR DESCRIPTION
## Purpose

We want to be able to sell certificate products from the dashboard ie to students already enrolled to a course. 

## Proposal

Add a `products` field to the enrollment API endpoint serializer.

I tried to optimize queries a little by prefetching product relations for an enrollment in the API viewset. The serializer uses the prefetched products if available from the viewset and otherwise does the query itself.

Related to https://github.com/openfun/joanie/issues/316



