### PR TITLE
🔨(backend) PRODUCT_CERTIFICATE in demo-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## Added
 
+- Add multiples product, order, certificates and enrollment in the database
+  that's initialized with the `make demo-dev`
 - Add client api filter to filter `Order` resource by `product__type` 
 - Add a backoffice redirect view to redirect to the frontend admin backoffice
 - Add filters to CourseRun list for a given course on admin api

--- a/src/backend/joanie/core/utils/webhooks.py
+++ b/src/backend/joanie/core/utils/webhooks.py
@@ -49,10 +49,11 @@ def synchronize_course_runs(serialized_course_runs):
                 timeout=3,
             )
 
-        except requests.exceptions.RetryError:
+        except requests.exceptions.RetryError as exc:
             logger.error(
                 "Synchronization failed due to max retries exceeded with url %s",
                 webhook["url"],
+                exc_info=exc,
             )
         except requests.exceptions.RequestException as exc:
             logger.error(

--- a/src/backend/joanie/demo/defaults.py
+++ b/src/backend/joanie/demo/defaults.py
@@ -10,3 +10,9 @@ NB_OBJECTS = {
     "enrollments": 30000,
     "max_orders_per_product": 50,
 }
+
+NB_DEV_OBJECTS = {
+    "product_credential": 5,
+    "product_certificate": 5,
+    "course": 10,
+}

--- a/src/backend/joanie/demo/management/commands/create_dev_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_dev_demo.py
@@ -6,6 +6,7 @@ from django.utils import translation
 
 from joanie.core import enums, factories, models
 from joanie.core.models import CourseState
+from joanie.demo.defaults import NB_DEV_OBJECTS
 
 OPENEDX_COURSE_RUN_URI = (
     "http://openedx.test/courses/course-v1:edx+{course:s}+{course_run:s}/course"
@@ -60,23 +61,152 @@ class Command(BaseCommand):
                 )
         return courses
 
-    def _create_product(self, user, organization):
-        """Create a single product for given user and organization."""
-        course = self.create_course(user, organization)
-        target_courses = self.create_course(
-            user, organization, batch_size=3, with_course_runs=True
-        )
-        return factories.ProductFactory(
-            courses=[course],
-            target_courses=target_courses,
-            type=enums.PRODUCT_TYPE_CREDENTIAL,
-        )
-
-    def create_product(self, user, organization, batch_size=1):
+    def create_product_credential(self, user, organization, batch_size=1):
         """Create batch or products for given user and organization."""
         if batch_size == 1:
-            return self._create_product(user, organization)
-        return [self.create_product(user, organization) for i in range(batch_size + 1)]
+            course = factories.CourseFactory(
+                organizations=[organization],
+                users=[[user, enums.OWNER]],
+            )
+            product = factories.ProductFactory(
+                type=enums.PRODUCT_TYPE_CREDENTIAL,
+                courses=[course],
+            )
+            target_course_list = factories.CourseFactory.create_batch(
+                2,
+                organizations=[organization],
+                users=[[user, enums.OWNER]],
+            )
+
+            for target_course in target_course_list:
+                factories.ProductTargetCourseRelationFactory(
+                    course=target_course, product=product
+                )
+                factories.CourseRunFactory(
+                    course=target_course,
+                    is_listed=True,
+                    state=CourseState.ONGOING_OPEN,
+                    languages=self.get_random_languages(),
+                    resource_link=OPENEDX_COURSE_RUN_URI.format(
+                        course=target_course.code, course_run="{course.title}_run1"
+                    ),
+                )
+                factories.CourseRunFactory(
+                    course=target_course,
+                    is_listed=True,
+                    state=CourseState.ONGOING_OPEN,
+                    languages=self.get_random_languages(),
+                    resource_link=OPENEDX_COURSE_RUN_URI.format(
+                        course=target_course.code, course_run="{course.title}_run2"
+                    ),
+                )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully create product credential on course {course.code}"
+                )
+            )
+            return product
+        return [
+            self.create_product_credential(user, organization)
+            for i in range(batch_size)
+        ]
+
+    def create_product_certificate(self, user, organization, batch_size=1):
+        """Create batch or products certificate for given user and organization."""
+        if batch_size == 1:
+            course = factories.CourseFactory(
+                organizations=[organization],
+                users=[[user, enums.OWNER]],
+            )
+            factories.CourseRunFactory(
+                course=course,
+                is_listed=True,
+                state=CourseState.ONGOING_OPEN,
+                languages=self.get_random_languages(),
+                resource_link=OPENEDX_COURSE_RUN_URI.format(
+                    course=course.code, course_run="{course.title}_run1"
+                ),
+            )
+            factories.CourseRunFactory(
+                course=course,
+                is_listed=True,
+                state=CourseState.ONGOING_OPEN,
+                languages=self.get_random_languages(),
+                resource_link=OPENEDX_COURSE_RUN_URI.format(
+                    course=course.code, course_run="{course.title}_run2"
+                ),
+            )
+            product = factories.ProductFactory(
+                type=enums.PRODUCT_TYPE_CERTIFICATE, courses=[course]
+            )
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Successfully create product credential on course {course.code}"
+                )
+            )
+            return product
+        return [
+            self.create_product_certificate(user, organization)
+            for i in range(batch_size)
+        ]
+
+    def create_product_certificate_enrollment(self, user, organization):
+        """Create a product certificate and it's enrollment."""
+        product = self.create_product_certificate(user, organization)
+        course = product.courses.first()
+        return factories.EnrollmentFactory(
+            user=user,
+            course_run=course.course_runs.first(),
+            is_active=True,
+            state=enums.ENROLLMENT_STATE_SET,
+        )
+
+    def create_product_purchased(self, user, organization, product_type):
+        """Create a product certificate, it's enrollment and it's order."""
+        if product_type == enums.PRODUCT_TYPE_CERTIFICATE:
+            product = self.create_product_certificate(user, organization)
+        elif product_type == enums.PRODUCT_TYPE_CREDENTIAL:
+            product = self.create_product_credential(user, organization)
+        else:
+            raise ValueError(f"Given product_type ({product_type}) is not allowed.")
+
+        course = product.courses.first()
+
+        if product_type == enums.PRODUCT_TYPE_CERTIFICATE:
+            factories.EnrollmentFactory(
+                user=user,
+                course_run=course.course_runs.first(),
+                is_active=True,
+                state=enums.ENROLLMENT_STATE_SET,
+            )
+
+        return factories.OrderFactory(
+            state=enums.ORDER_STATE_VALIDATED,
+            product=product,
+            course=course,
+            owner=user,
+        )
+
+    def create_product_purchased_with_certificate(
+        self, user, organization, product_type
+    ):
+        """
+        Create a product, it's enrollment and it's order.
+        Also create the order's linked certificate.
+        """
+        order = self.create_product_purchased(user, organization, product_type)
+        return factories.OrderCertificateFactory(order=order)
+
+    def create_enrollment_certificate(self, user, organization):
+        """create an enrollment and it's linked certificate."""
+        course = self.create_course(user, organization, 1, True)
+        factories.EnrollmentCertificateFactory(
+            enrollment__user=user,
+            enrollment__course_run=course.course_runs.first(),
+            enrollment__is_active=True,
+            enrollment__state=enums.ENROLLMENT_STATE_SET,
+            organization=organization,
+        )
 
     def handle(self, *args, **options):  # pylint: disable=too-many-locals
         translation.activate("en-us")
@@ -159,20 +289,97 @@ class Command(BaseCommand):
 
         # Now create a course product to learn how to become a botanist and get a certificate
         # 1/ Create the credential Product linked to the botany Course
-        factories.ProductFactory(
+        product = factories.ProductFactory(
             type=enums.PRODUCT_TYPE_CREDENTIAL,
+            # organization=[organization],
             title="Become a certified botanist",
+            courses=[factories.CourseFactory(organizations=[organization])],
             target_courses=credential_courses,
             certificate_definition=factories.CertificateDefinitionFactory(
                 title="Botanist Certification",
                 name="Become a certified botanist certificate",
             ),
         )
+        self.stdout.write(
+            self.style.SUCCESS(f'Successfully create "{product.title}" product')
+        )
 
         # We need some pagination going on, let's create few more courses and products
         self.create_course(
-            admin_user, organization, batch_size=10, with_course_runs=True
+            admin_user,
+            organization,
+            batch_size=NB_DEV_OBJECTS["course"],
+            with_course_runs=True,
         )
-        self.create_product(admin_user, organization, batch_size=10)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully create {NB_DEV_OBJECTS['course']} fake courses"
+            )
+        )
+
+        self.create_product_credential(
+            admin_user, organization, batch_size=NB_DEV_OBJECTS["product_credential"]
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully create {NB_DEV_OBJECTS['product_credential']} \
+                fake PRODUCT_CREDENTIAL"
+            )
+        )
+
+        self.create_product_certificate(
+            admin_user, organization, batch_size=NB_DEV_OBJECTS["product_certificate"]
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Successfully create {NB_DEV_OBJECTS['product_certificate']} \
+                fake PRODUCT_CERTIFICATE"
+            )
+        )
+
+        # Enrollments and orders
+        self.create_product_certificate_enrollment(admin_user, organization)
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Successfully create a enrollment for a course with a PRODUCT_CERTIFICATE"
+            )
+        )
+
+        # Order for a PRODUCT_CERTIFICATE
+        self.create_product_purchased(
+            admin_user, organization, enums.PRODUCT_TYPE_CERTIFICATE
+        )
+        self.stdout.write(
+            self.style.SUCCESS("Successfully create a order for a PRODUCT_CERTIFICATE")
+        )
+
+        # Order for a PRODUCT_CERTIFICATE with a generated certificate
+        self.create_product_purchased_with_certificate(
+            admin_user, organization, enums.PRODUCT_TYPE_CERTIFICATE
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Successfully create a order for a PRODUCT_CERTIFICATE \
+                with a generated certificate"
+            )
+        )
+
+        # Order for a PRODUCT_CREDENTIAL with a generated certificate
+        self.create_product_purchased_with_certificate(
+            admin_user, organization, enums.PRODUCT_TYPE_CREDENTIAL
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Successfully create a order for a PRODUCT_CREDENTIAL with a generated certificate"
+            )
+        )
+
+        # Enrollment with a certificate
+        self.create_enrollment_certificate(admin_user, organization)
+        self.stdout.write(
+            self.style.SUCCESS(
+                "Successfully create a enrollment with a generated certificate"
+            )
+        )
 
         self.stdout.write(self.style.SUCCESS("Successfully fake data creation"))

--- a/src/backend/joanie/tests/demo/test_commands_create_dev_demo.py
+++ b/src/backend/joanie/tests/demo/test_commands_create_dev_demo.py
@@ -1,0 +1,67 @@
+"""Test suite for the management command 'create_demo'"""
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from joanie.core import factories, models
+from joanie.demo.defaults import NB_DEV_OBJECTS
+
+
+class CreateDevDemoTestCase(TestCase):
+    """Test case for the management command 'create_demo'"""
+
+    @override_settings(DEBUG=True)
+    def test_commands_create_dev_demo(self):
+        """The create_dev_demo management command should create objects as expected."""
+        factories.UserFactory(
+            username="admin", email="admin@example.com", password="admin"
+        )
+
+        call_command("create_dev_demo")
+
+        nb_users = models.User.objects.count()
+        self.assertEqual(nb_users, 1)
+
+        nb_product_certificate = NB_DEV_OBJECTS["product_certificate"]
+        nb_product_certificate += 1  # product_certificate_enrollment
+        nb_product_certificate += 1  # create_product_purchased (type CERTIFICATE)
+        nb_product_certificate += (
+            1  # create_product_certificate_purchased_with_certificate
+        )
+
+        nb_product_credential = NB_DEV_OBJECTS["product_credential"]
+        nb_product_credential += (
+            1  # create_product_credential_purchased_with_certificate
+        )
+
+        nb_product = nb_product_credential + nb_product_certificate
+        nb_product += 1  # Become a certified botanist gradeo
+        self.assertEqual(models.Product.objects.count(), nb_product)
+
+        nb_organization = 1  # The school of glory
+        nb_organization += (
+            nb_product  # ProductFactory create a extra seller organization
+        )
+        self.assertEqual(models.Organization.objects.count(), nb_organization)
+
+        nb_courses = NB_DEV_OBJECTS["course"]
+        nb_courses += (
+            4  # Become a certified botanist gradeo: 1 course, 3 target courses
+        )
+        # product credential have 2 target courses and 1 course
+        nb_courses += nb_product_credential * 3
+        # product certificate 1 course and no target courses
+        nb_courses += nb_product_certificate * 1
+        nb_courses += 1  # enrollment_certificate
+        self.assertEqual(models.Course.objects.count(), nb_courses)
+
+        nb_enrollment = 1  # product_certificate_enrollment
+        nb_enrollment += 1  # product_certificate_order
+        nb_enrollment += 1  # product_certificate_order_certificate
+        nb_enrollment += 1  # enrollment_certificate
+        self.assertEqual(models.Enrollment.objects.count(), nb_enrollment)
+
+        nb_certificate = 1  # enrollment_certificate
+        nb_certificate += 1  # product_certificate_order_certificate
+        nb_certificate += 1  # create_product_credential_purchased_with_certificate
+        self.assertEqual(models.Certificate.objects.count(), nb_certificate)


### PR DESCRIPTION
## Purpose

In order to do the incoming feature to buy a product certificate from enrollment, we need to have some data in our demo-dev script.

## Proposal

* [x] create some PRODUCT_CREDENTIAL
* [x] create a enrollment for a course with a PRODUCT_CREDENTIAL
* [x] create a order for a PRODUCT_CREDENTIAL
* [x] create a order for a PRODUCT_CREDENTIAL with a generated certificate

## Notes
This script can generate some errors when executed on step "create 5 fake PRODUCT_CREDENTIAL"
I got some fails with error: 
```
Max retries exceeded with url: /api/v1.0/course-runs-sync/ (Caused by ResponseError('too many 500 error responses'))
```