### PR TITLE
✨(backend) Refactor order FSM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,8 @@ jobs:
   lint-back:
     docker:
       - image: cimg/python:3.10
+        environment:
+          PYTHONPATH: /home/circleci/joanie/src/backend:/home/circleci/joanie/src/backend/joanie
     working_directory: ~/joanie/src/backend
     steps:
       - checkout:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to
 
 ### Changed
 
+- Refactor the Order FSM to make a better use of transitions
 - Allow to get course product relation anonymously
   through a course id / product id pair
 - Take products in account to process Course state

--- a/env.d/development/common
+++ b/env.d/development/common
@@ -5,7 +5,7 @@ DJANGO_SETTINGS_MODULE=joanie.settings
 DJANGO_SUPERUSER_PASSWORD=admin
 
 # Python
-PYTHONPATH=/app/src/backend
+PYTHONPATH=/app:/app/joanie
 
 # LMS BACKENDS
 # OpenEdX

--- a/src/backend/joanie/core/api/__init__.py
+++ b/src/backend/joanie/core/api/__init__.py
@@ -1,6 +1,7 @@
 """API for the joanie project."""
 from django.core.exceptions import ValidationError as DjangoValidationError
 
+from django_fsm import TransitionNotAllowed
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.views import exception_handler as drf_exception_handler
 
@@ -11,6 +12,8 @@ def exception_handler(exc, context):
     For the parameters, see ``exception_handler``
     This code comes from twidi's gist:
     https://gist.github.com/twidi/9d55486c36b6a51bdcb05ce3a763e79f
+
+    Handle TransitionNotAllowed from django_fsm to avoid getting a 500
     """
     if isinstance(exc, DjangoValidationError):
         if hasattr(exc, "message_dict"):
@@ -19,7 +22,9 @@ def exception_handler(exc, context):
             detail = exc.message
         elif hasattr(exc, "messages"):
             detail = exc.messages
-
         exc = DRFValidationError(detail=detail)
+    elif isinstance(exc, TransitionNotAllowed):
+        detail = str(exc)
+        exc = DRFValidationError(detail=detail, code=422)
 
     return drf_exception_handler(exc, context)

--- a/src/backend/joanie/core/enums.py
+++ b/src/backend/joanie/core/enums.py
@@ -50,15 +50,17 @@ CATALOG_VISIBILITY_CHOICES = (
     HIDDEN,
 )
 
-ORDER_STATE_PENDING = "pending"  # waiting for payment
+ORDER_STATE_DRAFT = "draft"  # order has been created
+ORDER_STATE_SUBMITTED = "submitted"  # order information have been validated
+ORDER_STATE_PENDING = "pending"  # payment has failed but can be retried
 ORDER_STATE_CANCELED = "canceled"  # has been canceled
-ORDER_STATE_FAILED = "failed"  # payment failed
 ORDER_STATE_VALIDATED = "validated"  # is free or has an invoice linked
 
 ORDER_STATE_CHOICES = (
-    (ORDER_STATE_PENDING, _("Pending")),  # default
+    (ORDER_STATE_DRAFT, _("Draft")),  # default
+    (ORDER_STATE_SUBMITTED, _("Submitted")),
+    (ORDER_STATE_PENDING, _("Pending")),
     (ORDER_STATE_CANCELED, pgettext_lazy("As in: the order is cancelled.", "Canceled")),
-    (ORDER_STATE_FAILED, pgettext_lazy("As in: the order is failed.", "Failed")),
     (
         ORDER_STATE_VALIDATED,
         pgettext_lazy("As in: the order is validated.", "Validated"),

--- a/src/backend/joanie/payment/backends/base.py
+++ b/src/backend/joanie/payment/backends/base.py
@@ -107,10 +107,10 @@ class BasePaymentBackend:
     def _do_on_payment_failure(order):
         """
         Generic actions triggered when a failed payment has been received.
-        Mark the invoice as canceled and cancel the order.
+        Mark the invoice as pending.
         """
         # - Unvalidate order
-        order.cancel()
+        order.pending()
 
     @staticmethod
     def _do_on_refund(amount, invoice, refund_reference):

--- a/src/backend/joanie/payment/models.py
+++ b/src/backend/joanie/payment/models.py
@@ -19,7 +19,7 @@ from howard.issuers import InvoiceDocument
 from parler.utils import get_language_settings
 from parler.utils.context import switch_language
 
-from joanie.core.models import BaseModel, Order
+from joanie.core.models.base import BaseModel
 from joanie.core.utils import merge_dict
 
 from . import enums as payment_enums
@@ -48,7 +48,7 @@ class Invoice(BaseModel):
         unique=True,
     )
     order = models.ForeignKey(
-        to=Order,
+        to="core.Order",
         verbose_name=_("order"),
         related_name="invoices",
         on_delete=models.PROTECT,

--- a/src/backend/joanie/tests/core/test_commands_generate_certificates.py
+++ b/src/backend/joanie/tests/core/test_commands_generate_certificates.py
@@ -48,6 +48,7 @@ class CreateCertificatesTestCase(TestCase):
             target_courses=[course_run.course],
         )
         order = factories.OrderFactory(product=product)
+        order.submit()
         certificate_qs = models.Certificate.objects.filter(order=order)
 
         self.assertEqual(certificate_qs.count(), 0)
@@ -77,6 +78,7 @@ class CreateCertificatesTestCase(TestCase):
             courses=[course_run.course],
         )
         order = factories.OrderFactory(product=product, course=course_run.course)
+        order.submit()
         factories.EnrollmentFactory(
             user=order.owner, course_run=course_run, is_active=True
         )
@@ -108,6 +110,8 @@ class CreateCertificatesTestCase(TestCase):
         )
         course = factories.CourseFactory(products=[product])
         orders = factories.OrderFactory.create_batch(2, product=product, course=course)
+        for order in orders:
+            order.submit()
         certificate_qs = models.Certificate.objects.filter(order__in=orders)
 
         self.assertEqual(certificate_qs.count(), 0)
@@ -142,6 +146,8 @@ class CreateCertificatesTestCase(TestCase):
             factories.OrderFactory(product=product, course=course_1),
             factories.OrderFactory(product=product, course=course_2),
         ]
+        for order in orders:
+            order.submit()
         certificate_qs = models.Certificate.objects.filter(order__in=orders)
 
         self.assertEqual(certificate_qs.count(), 0)
@@ -179,6 +185,8 @@ class CreateCertificatesTestCase(TestCase):
             factories.OrderFactory(course=course, product=product_1),
             factories.OrderFactory(course=course, product=product_2),
         ]
+        for order in orders:
+            order.submit()
         certificate_qs = models.Certificate.objects.filter(order__in=orders)
 
         self.assertEqual(certificate_qs.count(), 0)
@@ -225,6 +233,8 @@ class CreateCertificatesTestCase(TestCase):
             factories.OrderFactory(course=course_2, product=product_1),
             factories.OrderFactory(course=course_2, product=product_2),
         ]
+        for order in orders:
+            order.submit()
         certificate_qs = models.Certificate.objects.filter(order__in=orders)
 
         self.assertEqual(certificate_qs.count(), 0)
@@ -278,6 +288,8 @@ class CreateCertificatesTestCase(TestCase):
             factories.OrderFactory(course=course, product=product_1),
             factories.OrderFactory(course=course, product=product_2),
         ]
+        for order in orders:
+            order.submit()
         certificate_qs = models.Certificate.objects.filter(order__in=orders)
 
         self.assertEqual(certificate_qs.count(), 0)

--- a/src/backend/joanie/tests/core/test_helpers.py
+++ b/src/backend/joanie/tests/core/test_helpers.py
@@ -54,6 +54,7 @@ class HelpersTestCase(TestCase):
         )
         course = factories.CourseFactory(products=[product])
         order = factories.OrderFactory(product=product, course=course)
+        order.submit()
         certificate_qs = models.Certificate.objects.filter(order=order)
         self.assertEqual(certificate_qs.count(), 0)
 
@@ -89,6 +90,7 @@ class HelpersTestCase(TestCase):
         )
         course = factories.CourseFactory(products=[product])
         order = factories.OrderFactory(product=product, course=course)
+        order.submit()
         certificate_qs = models.Certificate.objects.filter(order=order)
         self.assertEqual(certificate_qs.count(), 0)
 
@@ -128,6 +130,7 @@ class HelpersTestCase(TestCase):
         )
         course = factories.CourseFactory(products=[product])
         order = factories.OrderFactory(product=product, course=course)
+        order.submit()
         certificate_qs = models.Certificate.objects.filter(order=order)
 
         self.assertEqual(certificate_qs.count(), 0)
@@ -178,6 +181,9 @@ class HelpersTestCase(TestCase):
                 product=product_1, course=course, state=enums.ORDER_STATE_CANCELED
             ),
         ]
+
+        for order in orders[0:-1]:
+            order.submit()
 
         certificate_qs = models.Certificate.objects.filter(order__in=orders)
 

--- a/src/backend/joanie/tests/core/test_models_enrollment.py
+++ b/src/backend/joanie/tests/core/test_models_enrollment.py
@@ -237,7 +237,8 @@ class EnrollmentModelsTestCase(TestCase):
         )
 
         # - Once the product purchased, enrollment should be allowed
-        factories.OrderFactory(owner=user, product=product)
+        order = factories.OrderFactory(owner=user, product=product)
+        order.submit()
         factories.EnrollmentFactory(
             course_run=course_run, user=user, was_created_by_order=True
         )
@@ -263,7 +264,8 @@ class EnrollmentModelsTestCase(TestCase):
         course_relation = product.target_course_relations.get(course=course)
         course_relation.course_runs.set([cr1])
 
-        factories.OrderFactory(owner=user, product=product)
+        order = factories.OrderFactory(owner=user, product=product)
+        order.submit()
 
         # - Enroll to cr2 should fail
         with self.assertRaises(ValidationError) as context:
@@ -394,6 +396,7 @@ class EnrollmentModelsTestCase(TestCase):
 
         # Then if user purchases the product, the flag should not have been updated
         order = factories.OrderFactory(owner=user, product=product)
+        order.submit()
         order_enrollment = order.get_enrollments().first()
         self.assertEqual(enrollment, order_enrollment)
         self.assertFalse(order_enrollment.was_created_by_order)

--- a/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_credential_product.py
+++ b/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_credential_product.py
@@ -34,6 +34,7 @@ class CredentialProductGetOrGenerateCertificateOrderModelsTestCase(TestCase):
             target_courses=[course_run.course],
         )
         order = factories.OrderFactory(product=product)
+        order.submit()
 
         new_certificate, created = order.get_or_generate_certificate()
 
@@ -186,6 +187,7 @@ class CredentialProductGetOrGenerateCertificateOrderModelsTestCase(TestCase):
             target_courses=[course_run.course],
         )
         order = factories.OrderFactory(product=product)
+        order.submit()
         enrollment = Enrollment.objects.get()
         enrollment.is_active = False
         enrollment.save()

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -7,6 +7,7 @@ from django.core import mail
 
 from rest_framework.test import APIRequestFactory
 
+from joanie.core import enums
 from joanie.core.factories import OrderFactory, UserFactory
 from joanie.payment.backends.base import BasePaymentBackend
 from joanie.payment.factories import BillingAddressDictFactory
@@ -137,7 +138,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         """
         backend = TestBasePaymentBackend()
         owner = UserFactory(email="sam@fun-test.fr", language="en-us")
-        order = OrderFactory(owner=owner)
+        order = OrderFactory(owner=owner, state=enums.ORDER_STATE_SUBMITTED)
         billing_address = BillingAddressDictFactory()
         payment = {
             "id": "pay_0",
@@ -171,12 +172,12 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         order.
         """
         backend = TestBasePaymentBackend()
-        order = OrderFactory()
+        order = OrderFactory(state=enums.ORDER_STATE_SUBMITTED)
 
         backend.call_do_on_payment_failure(order)
 
-        # - Order has been canceled
-        self.assertEqual(order.state, "canceled")
+        # - Payment has failed gracefully and changed order state to pending
+        self.assertEqual(order.state, enums.ORDER_STATE_PENDING)
 
         # - No email has been sent
         self.assertEqual(len(mail.outbox), 0)
@@ -188,7 +189,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         transaction.
         """
         backend = TestBasePaymentBackend()
-        order = OrderFactory()
+        order = OrderFactory(state=enums.ORDER_STATE_SUBMITTED)
         billing_address = BillingAddressDictFactory()
 
         # Create payment and register it
@@ -244,7 +245,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
         """Check error is raised if send_mails fails"""
         backend = TestBasePaymentBackend()
         owner = UserFactory(email="sam@fun-test.fr", username="Samantha")
-        order = OrderFactory(owner=owner)
+        order = OrderFactory(owner=owner, state=enums.ORDER_STATE_SUBMITTED)
         billing_address = BillingAddressDictFactory()
         payment = {
             "id": "pay_0",
@@ -290,7 +291,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
             last_name="Smith",
             language="en-us",
         )
-        order = OrderFactory(owner=owner)
+        order = OrderFactory(owner=owner, state=enums.ORDER_STATE_SUBMITTED)
         billing_address = BillingAddressDictFactory()
         payment = {
             "id": "pay_0",
@@ -330,7 +331,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase):
             first_name="Dave",
             last_name="Bowman",
         )
-        order = OrderFactory(owner=owner)
+        order = OrderFactory(owner=owner, state=enums.ORDER_STATE_SUBMITTED)
         billing_address = BillingAddressDictFactory()
         payment = {
             "id": "pay_0",

--- a/src/backend/joanie/tests/payment/test_backend_payplug.py
+++ b/src/backend/joanie/tests/payment/test_backend_payplug.py
@@ -9,6 +9,7 @@ import payplug
 from payplug.exceptions import BadRequest, Forbidden, UnknownAPIResource
 from rest_framework.test import APIRequestFactory
 
+from joanie.core import enums
 from joanie.core.factories import OrderFactory, ProductFactory, UserFactory
 from joanie.payment.backends.base import BasePaymentBackend
 from joanie.payment.backends.payplug import PayplugBackend
@@ -443,7 +444,9 @@ class PayplugBackendTestCase(BasePaymentTestCase):
         payment_id = "pay_00000"
         product = ProductFactory()
         owner = UserFactory(language="en-us")
-        order = OrderFactory(product=product, owner=owner)
+        order = OrderFactory(
+            product=product, owner=owner, state=enums.ORDER_STATE_SUBMITTED
+        )
         backend = PayplugBackend(self.configuration)
         billing_address = BillingAddressDictFactory()
         payplug_billing_address = billing_address.copy()


### PR DESCRIPTION
resolve #363
Add states and transitions to the Order FSM

## Purpose

Refactor the Order's model FSM and allow to create orders without billing_address.
An order (for a non free product) created without billing_address must be in draft state


## Proposal

Description...

- [x] Change the states in the FSM
- [x] Adapt transitions
- [x] Allow creation of billing_addressless Orders for priced products
