### PR TITLE
✨(core) allow to filter order by product type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add client api filter to filter `Order` resource by `product__type` 
 - Add a backoffice redirect view to redirect to the frontend admin backoffice
 - Add filters to CourseRun list for a given course on admin api
 - Allow issuing a certificate directly for an enrollment (without an order)

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -5,8 +5,9 @@ from typing import List
 
 from django_filters import rest_framework as filters
 
+from joanie.core import enums
+
 from .. import models
-from ..enums import ORDER_STATE_CHOICES
 
 
 class OrderViewSetFilter(filters.FilterSet):
@@ -16,7 +17,11 @@ class OrderViewSetFilter(filters.FilterSet):
 
     product = filters.UUIDFilter(field_name="product")
     course = filters.CharFilter(field_name="course__code")
-    state = filters.ChoiceFilter(field_name="state", choices=ORDER_STATE_CHOICES)
+    state = filters.ChoiceFilter(field_name="state", choices=enums.ORDER_STATE_CHOICES)
+    product__type = filters.MultipleChoiceFilter(
+        field_name="product__type",
+        choices=enums.PRODUCT_TYPE_CHOICES,
+    )
 
     class Meta:
         model = models.Order


### PR DESCRIPTION
## Purpose

We are now selling several product types (credential, certificate). Frontend now needs to be able to filter user's order by product type.


## Proposal

- [x] Update `OrderFilter``
- [x] Write tests