### PR TITLE
✨(backend) add can_sign_contract ability to organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add can_sign_contract ability to organization
 - Add mermaid graph for Order workflow
 - Add a route to reorder target_courses
 - Add target_course route and list view for products

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -196,6 +196,7 @@ class Organization(parler_models.TranslatableModel, BaseModel):
             "put": is_owner_or_admin,
             "delete": role == enums.OWNER,
             "manage_accesses": is_owner_or_admin,
+            "can_sign_contract": role == enums.OWNER,
         }
 
 

--- a/src/backend/joanie/tests/core/test_models_organization.py
+++ b/src/backend/joanie/tests/core/test_models_organization.py
@@ -49,6 +49,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
                 "patch": False,
                 "put": False,
                 "manage_accesses": False,
+                "can_sign_contract": False,
             },
         )
 
@@ -64,6 +65,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
                 "patch": False,
                 "put": False,
                 "manage_accesses": False,
+                "can_sign_contract": False,
             },
         )
 
@@ -79,6 +81,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
                 "patch": True,
                 "put": True,
                 "manage_accesses": True,
+                "can_sign_contract": True,
             },
         )
 
@@ -94,6 +97,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
                 "patch": True,
                 "put": True,
                 "manage_accesses": True,
+                "can_sign_contract": False,
             },
         )
 
@@ -112,6 +116,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
                 "patch": False,
                 "put": False,
                 "manage_accesses": False,
+                "can_sign_contract": False,
             },
         )
 
@@ -131,5 +136,6 @@ class OrganizationModelsTestCase(BaseAPITestCase):
                 "patch": False,
                 "put": False,
                 "manage_accesses": False,
+                "can_sign_contract": False,
             },
         )


### PR DESCRIPTION
closes #392 

## Purpose

We need an ability to check if an user can sign a contract for a given organization
for now authorization is granted to owners of the organization

## Proposal

- [x] Add can_sign_contract ability to organization
- [x] Set can_sign_contract to True if user is owner of the org
