### PR TITLE
🐛(backend) allow target course creation without course run

### DIFF
--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -221,6 +221,10 @@ class TargetCoursesViewSet(
         data = request.data
         serializer = self.get_serializer(data=data)
         data["product"] = kwargs.get("product_id")
+        # Data has to be fixed before validation because the front-end
+        # may set "course_runs": "" which is not accepted by the serializer
+        if not data.get("course_runs", None):
+            data["course_runs"] = []
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
         course_runs = serializer.validated_data.pop("course_runs", [])
@@ -237,6 +241,8 @@ class TargetCoursesViewSet(
         """
         data = request.data
         data["product"] = kwargs.get("product_id")
+        # Data has to be fixed before validation because the front-end
+        # may set "course_runs": "" which is not accepted by the serializer
         if data.get("course_runs", None) == "":
             data["course_runs"] = []
         relation = self.queryset.get(product=data["product"], course=kwargs["pk"])

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -324,6 +324,45 @@ class ProductAdminApiTest(TestCase):
             expected_result,
         )
 
+    def test_admin_api_product_add_target_course_empty_course_run(self):
+        """
+        Authenticated users should be able to add a target-course without
+        course run to a product
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        course = factories.CourseFactory()
+        response = self.client.post(
+            f"/api/v1.0/admin/products/{product.id}/target-courses/",
+            content_type="application/json",
+            data={"course": str(course.id), "course_runs": ""},
+        )
+        self.assertEqual(response.status_code, 201)
+        relation = models.ProductTargetCourseRelation.objects.get()
+        expected_result = {
+            "id": str(relation.id),
+            "course": {
+                "code": relation.course.code,
+                "title": relation.course.title,
+                "id": str(relation.course.id),
+                "state": {
+                    "priority": relation.course.state["priority"],
+                    "datetime": relation.course.state["datetime"],
+                    "call_to_action": relation.course.state["call_to_action"],
+                    "text": relation.course.state["text"],
+                },
+            },
+            "is_graded": relation.is_graded,
+            "position": relation.position,
+            "course_runs": [],
+        }
+        self.assertEqual(
+            response.json(),
+            expected_result,
+        )
+
     def test_admin_api_product_delete_target_course_without_authentication(self):
         """
         Anonymous users should not be able to delete a target_course from a product
@@ -378,6 +417,30 @@ class ProductAdminApiTest(TestCase):
         self.assertEqual(response.status_code, 201)
         relation.refresh_from_db()
         self.assertTrue(relation.is_graded)
+
+    def test_admin_api_product_edit_target_course_empty_course_runs(self):
+        """
+        User can modify a TargetCourse to remove all course_runs
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        course = factories.CourseFactory()
+        product.target_courses.add(course)
+        relation = models.ProductTargetCourseRelation.objects.get(
+            product=product, course=course
+        )
+        relation.is_graded = False
+        relation.save()
+        response = self.client.patch(
+            f"/api/v1.0/admin/products/{product.id}/target-courses/{course.id}/",
+            data={"is_graded": True, "course_runs": ""},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 201)
+        relation.refresh_from_db()
+        self.assertEqual(relation.course_runs.count(), 0)
 
     def test_admin_api_product_reorder_target_course(self):
         """


### PR DESCRIPTION
## Purpose

Creation of a target_course without course_run should not crash when course_run is given as an empty string

## Proposal

- [x] Handle empty string as an empty array of course_run
