### PR TITLE
✨(backend) add admin route for OrderGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add admin route to add and modify OrderGroups
 - Allow to filter contracts through their signature state
 - Allow filtering orders by state or product type exclusion
 - Allow filtering orders by enrollment

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from joanie.core import filters, models, serializers
+from joanie.core.api.base import NestedGenericViewSet
 from joanie.core.authentication import SessionAuthenticationWithAuthenticateHeader
 
 
@@ -308,3 +309,32 @@ class ContractDefinitionViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
     serializer_class = serializers.AdminContractDefinitionSerializer
     queryset = models.ContractDefinition.objects.all()
+
+
+class NestedProductOrderGroupViewSet(
+    mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.ListModelMixin,
+    NestedGenericViewSet,
+):
+    """
+    OrderGroup ViewSet
+    """
+
+    authentication_classes = [SessionAuthenticationWithAuthenticateHeader]
+    permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
+    serializer_classes = {
+        "create": serializers.AdminOrderGroupCreateSerializer,
+    }
+    default_serializer_class = serializers.AdminOrderGroupSerializer
+    queryset = models.OrderGroup.objects.all().select_related("product")
+    ordering = "created_on"
+    lookup_fields = ["product", "pk"]
+    lookup_url_kwargs = ["product_id", "pk"]
+
+    def get_serializer_class(self):
+        """
+        Return the serializer class to use depending on the action.
+        """
+        return self.serializer_classes.get(self.action, self.default_serializer_class)

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -652,14 +652,14 @@ class OrderLightSerializer(serializers.ModelSerializer):
 class OrderGroupSerializer(serializers.ModelSerializer):
     """Serializer for order groups in a product."""
 
-    nb_availabilities = serializers.SerializerMethodField(read_only=True)
+    nb_available_seats = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = models.OrderGroup
-        fields = ["id", "is_active", "nb_seats", "nb_availabilities"]
+        fields = ["id", "is_active", "nb_seats", "nb_available_seats"]
         read_only_fields = fields
 
-    def get_nb_availabilities(self, order_group):
+    def get_nb_available_seats(self, order_group):
         """Return the number of available seats for this order group."""
         return order_group.nb_seats - order_group.get_nb_binding_orders()
 

--- a/src/backend/joanie/tests/core/test_api_admin_order_group.py
+++ b/src/backend/joanie/tests/core/test_api_admin_order_group.py
@@ -1,0 +1,290 @@
+"""
+Test suite for OrderGroup Admin API.
+"""
+
+from operator import itemgetter
+
+from django.test import TestCase
+
+from joanie.core import factories, models
+
+
+class OrderGroupAdminApiTest(TestCase):
+    """
+    Test suite for OrderGroup Admin API.
+    """
+
+    base_url = "/api/v1.0/admin/products"
+
+    # list
+    def test_admin_api_order_group_list_anonymous(self):
+        """
+        Anonymous users should not be able to list order groups.
+        """
+
+        product = factories.ProductFactory()
+        response = self.client.get(f"{self.base_url}/{product.id}/order-groups/")
+        self.assertEqual(response.status_code, 401)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_admin_api_order_group_list_authenticated(self):
+        """
+        Authenticated users should be able to list order groups.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        order_groups = factories.OrderGroupFactory.create_batch(3, product=product)
+        factories.OrderGroupFactory.create_batch(5)
+
+        with self.assertNumQueries(7):
+            response = self.client.get(f"{self.base_url}/{product.id}/order-groups/")
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        expected_return = [
+            {
+                "id": str(order_group.id),
+                "nb_seats": order_group.nb_seats,
+                "is_active": order_group.is_active,
+                "nb_available_seats": order_group.nb_seats
+                - order_group.get_nb_binding_orders(),
+                "created_on": order_group.created_on.isoformat().replace("+00:00", "Z"),
+            }
+            for order_group in order_groups
+        ]
+        self.assertEqual(content["count"], 3)
+        self.assertEqual(
+            content["results"],
+            sorted(expected_return, key=itemgetter("created_on")),
+        )
+
+    def test_admin_api_order_group_list_lambda_user(self):
+        """
+        Non admin user should not be able to request order groups endpoint.
+        """
+        admin = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=admin.username, password="password")
+        product = factories.ProductFactory()
+
+        response = self.client.get(f"{self.base_url}/{product.id}/order-groups/")
+
+        self.assertEqual(response.status_code, 403)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "You do not have permission to perform this action."
+        )
+
+    # details
+    def test_admin_api_order_group_retrieve_anonymous(self):
+        """
+        Anonymous users should not be able to request order groups details.
+        """
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product)
+
+        response = self.client.get(
+            f"{self.base_url}/{product.id}/order-groups/{order_group.id}/"
+        )
+        self.assertEqual(response.status_code, 401)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_admin_api_order_group_retrieve_authenticated(self):
+        """
+        Authenticated users should be able to request order groups details.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product)
+
+        with self.assertNumQueries(4):
+            response = self.client.get(
+                f"{self.base_url}/{product.id}/order-groups/{order_group.id}/"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        expected_return = {
+            "id": str(order_group.id),
+            "nb_seats": order_group.nb_seats,
+            "is_active": order_group.is_active,
+            "nb_available_seats": order_group.nb_seats
+            - order_group.get_nb_binding_orders(),
+            "created_on": order_group.created_on.isoformat().replace("+00:00", "Z"),
+        }
+        self.assertEqual(content, expected_return)
+
+    # create
+    def test_admin_api_order_group_create_anonymous(self):
+        """
+        Anonymous users should not be able to create an order groups.
+        """
+
+        product = factories.ProductFactory()
+
+        data = {"nb_seats": 5, "is_active": True}
+        response = self.client.post(
+            f"{self.base_url}/{product.id}/order-groups/",
+            content_type="application/json",
+            data=data,
+        )
+        self.assertEqual(response.status_code, 401)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_admin_api_order_group_create_authenticated(self):
+        """
+        Authenticated users should be able to request order groups list.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        data = {"nb_seats": 5, "is_active": True, "product": str(product.id)}
+        with self.assertNumQueries(5):
+            response = self.client.post(
+                f"{self.base_url}/{product.id}/order-groups/",
+                content_type="application/json",
+                data=data,
+            )
+
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertEqual(content["nb_seats"], data["nb_seats"])
+        self.assertEqual(content["is_active"], data["is_active"])
+        self.assertEqual(models.OrderGroup.objects.filter(**data).count(), 1)
+
+    # update
+    def test_admin_api_order_group_update_anonymous(self):
+        """
+        Anonymous users should not be able to update order groups.
+        """
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product)
+
+        response = self.client.put(
+            f"{self.base_url}/{product.id}/order-groups/{order_group.id}/"
+        )
+        self.assertEqual(response.status_code, 401)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_admin_api_order_group_update_authenticated(self):
+        """
+        Authenticated users should be able to update order groups.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product)
+        data = {
+            "nb_seats": 505,
+            "is_active": True,
+        }
+        with self.assertNumQueries(5):
+            response = self.client.put(
+                f"{self.base_url}/{product.id}/order-groups/{str(order_group.id)}/",
+                content_type="application/json",
+                data=data,
+            )
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(content["nb_seats"], data["nb_seats"])
+        self.assertEqual(content["is_active"], data["is_active"])
+        self.assertEqual(models.OrderGroup.objects.filter(**data).count(), 1)
+
+    # patch
+    def test_admin_api_order_group_patch_anonymous(self):
+        """
+        Anonymous users should not be able to patch order groups.
+        """
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product)
+
+        response = self.client.patch(
+            f"{self.base_url}/{product.id}/order-groups/{order_group.id}/"
+        )
+        self.assertEqual(response.status_code, 401)
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_admin_api_order_group_patch_authenticated(self):
+        """
+        Authenticated users should be able to patch order groups.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product, is_active=False)
+        data = {
+            "is_active": True,
+        }
+        with self.assertNumQueries(5):
+            response = self.client.patch(
+                f"{self.base_url}/{product.id}/order-groups/{str(order_group.id)}/",
+                content_type="application/json",
+                data=data,
+            )
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(content["nb_seats"], order_group.nb_seats)
+        self.assertEqual(content["is_active"], data["is_active"])
+        self.assertEqual(
+            models.OrderGroup.objects.filter(
+                nb_seats=order_group.nb_seats, **data
+            ).count(),
+            1,
+        )
+
+    # delete
+    def test_admin_api_order_group_delete_anonymous(self):
+        """
+        Anonymous users should not be able to delete order groups.
+        """
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product)
+
+        response = self.client.delete(
+            f"{self.base_url}/{product.id}/order-groups/{order_group.id}/"
+        )
+        self.assertEqual(response.status_code, 401)
+        content = response.json()
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                content["detail"], "Authentication credentials were not provided."
+            )
+
+    def test_admin_api_order_group_delete_authenticated(self):
+        """
+        Authenticated users should not be able to delete order groups.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        product = factories.ProductFactory()
+        order_group = factories.OrderGroupFactory(product=product)
+        with self.assertNumQueries(2):
+            response = self.client.delete(
+                f"{self.base_url}/{product.id}/order-groups/{order_group.id}/",
+            )
+        self.assertEqual(response.status_code, 405)

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -83,6 +83,7 @@ class ProductAdminApiTest(TestCase):
             )
         )
         relations[2].save()
+        order_group = factories.OrderGroupFactory(product=product)
 
         response = self.client.get(f"/api/v1.0/admin/products/{product.id}/")
 
@@ -193,6 +194,18 @@ class ProductAdminApiTest(TestCase):
                             "id": str(relation.organizations.first().id),
                         }
                     ],
+                }
+            ],
+            "order_groups": [
+                {
+                    "id": str(order_group.id),
+                    "nb_seats": order_group.nb_seats,
+                    "is_active": order_group.is_active,
+                    "nb_available_seats": order_group.nb_seats
+                    - order_group.get_nb_binding_orders(),
+                    "created_on": order_group.created_on.isoformat().replace(
+                        "+00:00", "Z"
+                    ),
                 }
             ],
         }

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -621,13 +621,13 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 {
                     "id": str(order_group1.id),
                     "is_active": True,
-                    "nb_availabilities": order_group1.nb_seats - 3,
+                    "nb_available_seats": order_group1.nb_seats - 3,
                     "nb_seats": order_group1.nb_seats,
                 },
                 {
                     "id": str(order_group2.id),
                     "is_active": True,
-                    "nb_availabilities": order_group2.nb_seats,
+                    "nb_available_seats": order_group2.nb_seats,
                     "nb_seats": order_group2.nb_seats,
                 },
             ],
@@ -656,7 +656,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 {
                     "id": str(order_group.id),
                     "is_active": True,
-                    "nb_availabilities": 10,
+                    "nb_available_seats": 10,
                     "nb_seats": 10,
                 },
             ],
@@ -678,7 +678,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 {
                     "id": str(order_group.id),
                     "is_active": True,
-                    "nb_availabilities": 9,
+                    "nb_available_seats": 9,
                     "nb_seats": 10,
                 },
             ],
@@ -700,7 +700,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 {
                     "id": str(order_group.id),
                     "is_active": True,
-                    "nb_availabilities": 10,
+                    "nb_available_seats": 10,
                     "nb_seats": 10,
                 },
             ],

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -155,6 +155,11 @@ admin_product_related_router.register(
     basename="admin_product_target_courses",
 )
 
+admin_product_related_router.register(
+    "order-groups",
+    api_admin.NestedProductOrderGroupViewSet,
+    basename="admin_product_order_groups",
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
## Purpose
Add routes to create and edit order groups on the admin api

resolves part of issue #408 

## Proposal
- [x] Add OrderGroup route, serializer and viewset
- [x] Add tests
- [x] Add OrderGroups to Product serializer 