### PR TITLE
✨(api) product serializer accepts empty instructions

### DIFF
--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -174,7 +174,7 @@ class AdminProductSerializer(serializers.ModelSerializer):
         coerce_to_string=False, decimal_places=2, max_digits=9, min_value=0
     )
     price_currency = serializers.SerializerMethodField(read_only=True)
-    instructions = serializers.CharField(required=False)
+    instructions = serializers.CharField(allow_blank=True, trim_whitespace=False)
 
     class Meta:
         model = models.Product


### PR DESCRIPTION
## Purpose

We need to allow users to update products with empty instructions, and allow instructions to have trailing newline and whitespace

## Proposal

Description...

- [x] Allow users to update product with empty instructions.
- [x] Allow trailing newline in instructions
