### PR TITLE
🐛(models) fix auto enrollment with closed and specific course runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to
 
 ### Fixed
 
+- Fix auto enrollment with closed and specific course runs
 - Fix demo-dev command synchronization error.
 
 ## [1.2.0] - 2023-08-28

--- a/src/backend/joanie/tests/core/test_models_enrollment.py
+++ b/src/backend/joanie/tests/core/test_models_enrollment.py
@@ -283,8 +283,8 @@ class EnrollmentModelsTestCase(TestCase):
         """
         user = factories.UserFactory()
         course = factories.CourseFactory()
-        [cr1, cr2] = factories.CourseRunFactory.create_batch(
-            2,
+        [cr1, cr2, cr3] = factories.CourseRunFactory.create_batch(
+            3,
             state=CourseState.ONGOING_OPEN,
             is_listed=False,
             course=course,
@@ -293,7 +293,7 @@ class EnrollmentModelsTestCase(TestCase):
 
         # - Restrict available course runs for this product to cr1
         course_relation = product.target_course_relations.get(course=course)
-        course_relation.course_runs.set([cr1])
+        course_relation.course_runs.set([cr1, cr2])
 
         order = factories.OrderFactory(owner=user, product=product)
         order.submit()
@@ -301,12 +301,12 @@ class EnrollmentModelsTestCase(TestCase):
         # - Enroll to cr2 should fail
         with self.assertRaises(ValidationError) as context:
             factories.EnrollmentFactory(
-                course_run=cr2, user=user, was_created_by_order=True, is_active=True
+                course_run=cr3, user=user, was_created_by_order=True, is_active=True
             )
 
         self.assertEqual(
             (
-                f"{{'__all__': ['Course run \"{cr2.id}\" "
+                f"{{'__all__': ['Course run \"{cr3.id}\" "
                 "requires a valid order to enroll.']}"
             ),
             str(context.exception),

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -369,7 +369,7 @@ class OrderModelsTestCase(TestCase):
         InvoiceFactory(order=order, total=order.total)
 
         # - Validate the order should automatically enroll user to course run
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(23):
             order.validate()
 
         self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
@@ -418,7 +418,7 @@ class OrderModelsTestCase(TestCase):
         InvoiceFactory(order=order, total=order.total)
 
         # - Validate the order should automatically enroll user to course run
-        with self.assertNumQueries(28):
+        with self.assertNumQueries(27):
             order.validate()
 
         enrollment.refresh_from_db()

--- a/src/backend/joanie/tests/core/test_models_order_enroll_user_to_course_run.py
+++ b/src/backend/joanie/tests/core/test_models_order_enroll_user_to_course_run.py
@@ -1,0 +1,238 @@
+"""
+Test suite the `enroll_user_to_course_run` method on Order model
+"""
+import random
+
+from django.test import RequestFactory, TestCase
+
+from joanie.core import enums, factories
+from joanie.core.models import CourseState, Enrollment
+from joanie.payment.factories import BillingAddressDictFactory, InvoiceFactory
+
+
+# pylint: disable=too-many-public-methods
+class EnrollUserToCourseRunOrderModelsTestCase(TestCase):
+    """Test suite for `enroll_user_to_course_run` method on the the Order model."""
+
+    def _create_validated_order(self, **kwargs):
+        order = factories.OrderFactory(**kwargs)
+        order.submit(
+            request=RequestFactory().request(),
+            billing_address=BillingAddressDictFactory(),
+        )
+
+        self.assertEqual(order.state, enums.ORDER_STATE_SUBMITTED)
+        self.assertEqual(Enrollment.objects.count(), 0)
+
+        # - Create an invoice to mark order as validated
+        InvoiceFactory(order=order, total=order.total)
+
+        # - Validate the order should automatically enroll user to course run
+        order.validate()
+
+        self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
+
+    def test_models_order_enroll_user_to_course_run_one_open(self):
+        """
+        If a target course has only one open course run, the enrollment should be automatic.
+        """
+        [course, target_course] = factories.CourseFactory.create_batch(2)
+        product = factories.ProductFactory(courses=[course])
+
+        factories.CourseRunFactory(
+            course=target_course,
+            state=random.choice(
+                [
+                    CourseState.ONGOING_OPEN,
+                    CourseState.FUTURE_OPEN,
+                    CourseState.ARCHIVED_OPEN,
+                ]
+            ),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product, course=target_course
+        )
+
+        self._create_validated_order(
+            product=product,
+            course=course,
+        )
+
+        self.assertEqual(Enrollment.objects.count(), 1)
+
+    def test_models_order_enroll_user_to_course_run_one_closed(self):
+        """
+        If a target course has only one course run. The enrollment should not be automatic if
+        this course run is closed.
+        """
+        [course, target_course] = factories.CourseFactory.create_batch(2)
+        product = factories.ProductFactory(courses=[course])
+
+        factories.CourseRunFactory(
+            course=target_course,
+            state=random.choice(
+                [
+                    CourseState.FUTURE_NOT_YET_OPEN,
+                    CourseState.FUTURE_CLOSED,
+                    CourseState.ONGOING_CLOSED,
+                    CourseState.ARCHIVED_CLOSED,
+                    CourseState.TO_BE_SCHEDULED,
+                ]
+            ),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product, course=target_course
+        )
+
+        self._create_validated_order(
+            product=product,
+            course=course,
+        )
+
+        self.assertFalse(Enrollment.objects.exists())
+
+    def test_models_order_enroll_user_to_course_run_several_open(self):
+        """
+        If a target course has several open course runs, the enrollment should not be automatic.
+        """
+        [course, target_course] = factories.CourseFactory.create_batch(2)
+        product = factories.ProductFactory(courses=[course])
+
+        for _i in range(3):
+            factories.CourseRunFactory(
+                course=target_course,
+                state=random.choice(
+                    [
+                        CourseState.ONGOING_OPEN,
+                        CourseState.FUTURE_OPEN,
+                        CourseState.ARCHIVED_OPEN,
+                    ]
+                ),
+            )
+
+        factories.ProductTargetCourseRelationFactory(
+            product=product, course=target_course
+        )
+
+        self._create_validated_order(
+            product=product,
+            course=course,
+        )
+
+        self.assertFalse(Enrollment.objects.exists())
+
+    def test_models_order_enroll_user_to_course_run_specific_open(self):
+        """
+        If a target course has several open course runs but only one of them is specifically
+        linked to the target course, the enrollment should be automatic because enrollment is
+        possible only on this course run.
+        """
+        [course, target_course] = factories.CourseFactory.create_batch(2)
+        product = factories.ProductFactory(courses=[course])
+
+        # - Link 2 course runs to the target_course
+        course_run, *_other_course_runs = factories.CourseRunFactory.create_batch(
+            3,
+            course=target_course,
+            state=random.choice(
+                [
+                    CourseState.ONGOING_OPEN,
+                    CourseState.FUTURE_OPEN,
+                    CourseState.ARCHIVED_OPEN,
+                ]
+            ),
+        )
+
+        # - Only one of the course runs is specifically targeted
+        factories.ProductTargetCourseRelationFactory(
+            product=product, course=target_course, course_runs=[course_run]
+        )
+
+        self._create_validated_order(
+            product=product,
+            course=course,
+        )
+
+        self.assertEqual(Enrollment.objects.count(), 1)
+
+    def test_models_order_enroll_user_to_course_run_several_but_one_open(self):
+        """
+        If a target course has several course runs but only one of them is open, the enrollment
+        should be automatic because enrollment is possible only on this course run.
+        """
+        [course, target_course] = factories.CourseFactory.create_batch(2)
+        product = factories.ProductFactory(courses=[course])
+
+        # - Link several course runs to the target_course, but only one is open
+        factories.CourseRunFactory(
+            course=target_course,
+            state=random.choice(
+                [
+                    CourseState.ONGOING_OPEN,
+                    CourseState.FUTURE_OPEN,
+                    CourseState.ARCHIVED_OPEN,
+                ]
+            ),
+        )
+        for state in [
+            CourseState.FUTURE_NOT_YET_OPEN,
+            CourseState.FUTURE_CLOSED,
+            CourseState.ONGOING_CLOSED,
+            CourseState.ARCHIVED_CLOSED,
+            CourseState.TO_BE_SCHEDULED,
+        ]:
+            factories.CourseRunFactory(course=target_course, state=state)
+
+        factories.ProductTargetCourseRelationFactory(
+            product=product, course=target_course
+        )
+
+        self._create_validated_order(
+            product=product,
+            course=course,
+        )
+
+        self.assertEqual(Enrollment.objects.count(), 1)
+
+    def test_models_order_enroll_user_to_course_run_specific_closed_other_open(self):
+        """
+        If a target course has an open course run and a closed course run specifically
+        linked to it, validating the order should not enroll to the open course run.
+        """
+        [course, target_course] = factories.CourseFactory.create_batch(2)
+        product = factories.ProductFactory(courses=[course])
+
+        # - Link several course runs to the target_course, but only one is open
+        factories.CourseRunFactory(
+            course=target_course,
+            state=random.choice(
+                [
+                    CourseState.ONGOING_OPEN,
+                    CourseState.FUTURE_OPEN,
+                    CourseState.ARCHIVED_OPEN,
+                ]
+            ),
+        )
+        closed_course_run = factories.CourseRunFactory(
+            course=target_course,
+            state=random.choice(
+                [
+                    CourseState.FUTURE_NOT_YET_OPEN,
+                    CourseState.FUTURE_CLOSED,
+                    CourseState.ONGOING_CLOSED,
+                    CourseState.ARCHIVED_CLOSED,
+                    CourseState.TO_BE_SCHEDULED,
+                ]
+            ),
+        )
+
+        factories.ProductTargetCourseRelationFactory(
+            product=product, course=target_course, course_runs=[closed_course_run]
+        )
+
+        self._create_validated_order(
+            product=product,
+            course=course,
+        )
+
+        self.assertEqual(Enrollment.objects.count(), 0)


### PR DESCRIPTION
## Purpose

When a course has several course runs, some of them being open and others being closed, the query does not see that only one course run is open and fails to enroll the user automatically. 

The case of a product with target courses limited to specific course runs is also not taken into account.

## Proposal

I proposed a refactoring of the query (not so trivial! :sweat_smile:) and added tests for all the overlooked use cases I could think of.

Fixes https://github.com/openfun/joanie/issues/389