### PR TITLE
✨(api) add list of related orders to enrollments API payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to
 - Allow issuing a certificate directly for an enrollment (without an order)
 - Generate certificates for products of type `certificate`
 - Add route detailing current user
-- Add related certificate products to enrollment API endpoint
+- Add related certificate products and orders to enrollment API endpoint
 - Add admin endpoints to create/update/delete organization/course accesses
 - Add admin endpoint to search users
 - Add endpoints to get course product relations and courses from organization

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -228,6 +228,7 @@ class EnrollmentViewSet(
             .select_related("course_run__course")
             .prefetch_related(
                 "certificate",
+                "related_orders",
                 Prefetch(
                     "course_run__course__product_relations",
                     queryset=models.CourseProductRelation.objects.select_related(


### PR DESCRIPTION
## Purpose

Products are being sold on enrollments. If the product is already subject to an order on an enrollment, the "purchase" button should not be shown. We need to include the complete information about orders related to an enrollment so the frontend is able to decide what should be displayed.

## Proposal

- [x] Add light serializer for orders
- [x] Include list of related orders (in a light representation) to enrollment serializer 
