### PR TITLE
✨(backend) allow to download enrollment certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to
 
 ### Changed
 
+- Allow to download enrollment certificate from related download api endpoint
 - Data returned by product admin serializer
 - Refactor the Order FSM to make a better use of transitions
 - Allow to get course product relation anonymously

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -579,8 +579,9 @@ class CertificateViewSet(
         username = request.auth["username"] if request.auth else request.user.username
         try:
             certificate = models.Certificate.objects.get(
+                Q(order__owner__username=username)
+                | Q(enrollment__user__username=username),
                 pk=pk,
-                order__owner__username=username,
             )
         except models.Certificate.DoesNotExist:
             return Response(

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -420,7 +420,18 @@ class EnrollmentFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Enrollment
 
-    course_run = factory.SubFactory(CourseRunFactory)
+    # Create an enrollable course run for free by default
+    course_run = factory.SubFactory(
+        CourseRunFactory,
+        is_listed=True,
+        state=factory.fuzzy.FuzzyChoice(
+            [
+                CourseState.ONGOING_OPEN,
+                CourseState.FUTURE_OPEN,
+                CourseState.ARCHIVED_OPEN,
+            ]
+        ),
+    )
     user = factory.SubFactory(UserFactory)
     is_active = factory.fuzzy.FuzzyChoice([True, False])
     state = factory.fuzzy.FuzzyChoice([s[0] for s in enums.ENROLLMENT_STATE_CHOICES])


### PR DESCRIPTION
## Purpose

Currently, the endpoint to download a certificate was only looking for order id. Since a certificate can be linked to an enrollment, we must update this logic to look for both enrollment and order.


## Proposal

- [x] Allow to download enrollment certificate
- [x] Update tests
