### PR TITLE
✨(api) add data and filters to contract api route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add data and filters to contract api endpoint
 - Add contract and contract definition models with related API endpoints
 - Add `instructions` markdown field to `Product` model
 - Add filter course by product type

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -89,3 +89,24 @@ class CourseViewSetFilter(filters.FilterSet):
         Filter courses by looking for related products with matching type
         """
         return queryset.filter(products__type=value).distinct()
+
+
+class ContractViewSetFilter(filters.FilterSet):
+    """
+    ContractFilter allows to filter this resource with a
+    course id, org id, or its signature state.
+    """
+
+    course = filters.UUIDFilter(field_name="order__course")
+    organization = filters.UUIDFilter(field_name="order__organization")
+    signature = filters.BooleanFilter(method="get_is_signed")
+
+    class Meta:
+        model = models.Contract
+        fields: List[str] = ["organization", "course", "signature"]
+
+    def get_is_signed(self, queryset, _name, value):
+        """
+        Filter Contracts by signature status
+        """
+        return queryset.filter(signed_on__isnull=not value)

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -52,7 +52,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(4):
             response = self.client.get(
                 "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
             )
@@ -90,6 +90,8 @@ class CertificateApiTest(BaseAPITestCase):
                                 "logo": "_this_field_is_mocked",
                                 "title": order.organization.title,
                             },
+                            "learner_name": certificate.order.owner.get_full_name(),
+                            "title": certificate.order.product.title,
                         },
                     },
                 ],
@@ -216,6 +218,8 @@ class CertificateApiTest(BaseAPITestCase):
                         "logo": "_this_field_is_mocked",
                         "title": certificate.order.organization.title,
                     },
+                    "learner_name": certificate.order.owner.get_full_name(),
+                    "title": certificate.order.product.title,
                 },
             },
         )

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -1,21 +1,90 @@
 """Tests for the Contract API"""
+import datetime
 import json
 import uuid
 from unittest import mock
 
 from rest_framework.pagination import PageNumberPagination
 
+from joanie.core import models
 from joanie.core.factories import (
     ContractFactory,
     OrderFactory,
     ProductFactory,
     UserFactory,
+    UserOrganizationAccessFactory,
 )
 from joanie.tests.base import BaseAPITestCase
 
 
 class ContractApiTest(BaseAPITestCase):
     """Contract API test case."""
+
+    def _return_from_contract(self, contract):
+        """
+        Return the dictionary that should match the api return for a contract
+        """
+        return {
+            "id": str(contract.id),
+            "definition": {
+                "description": contract.definition.description,
+                "name": contract.definition.name,
+                "title": contract.definition.title,
+            },
+            "order": {
+                "id": str(contract.order.id),
+                "course": {
+                    "code": contract.order.course.code,
+                    "cover": {
+                        "filename": contract.order.course.cover.name,
+                        "height": contract.order.course.cover.height,
+                        "width": contract.order.course.cover.width,
+                        "src": f"http://testserver{contract.order.course.cover.url}.1x1_q85.webp",
+                        "srcset": (
+                            f"http://testserver{contract.order.course.cover.url}.1920x1080_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "1920w, "
+                            f"http://testserver{contract.order.course.cover.url}.1280x720_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "1280w, "
+                            f"http://testserver{contract.order.course.cover.url}.768x432_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "768w, "
+                            f"http://testserver{contract.order.course.cover.url}.384x216_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "384w"
+                        ),
+                        "size": contract.order.course.cover.size,
+                    },
+                    "id": str(contract.order.course.id),
+                    "title": contract.order.course.title,
+                },
+                "organization": {
+                    "id": str(contract.order.organization.id),
+                    "code": contract.order.organization.code,
+                    "logo": {
+                        "filename": contract.order.organization.logo.name,
+                        "height": contract.order.organization.logo.height,
+                        "width": contract.order.organization.logo.width,
+                        "src": f"http://testserver{contract.order.organization.logo.url}.1x1_q85.webp",  # noqa pylint: disable=line-too-long
+                        "srcset": (
+                            f"http://testserver{contract.order.organization.logo.url}.1024x1024_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "1024w, "
+                            f"http://testserver{contract.order.organization.logo.url}.512x512_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "512w, "
+                            f"http://testserver{contract.order.organization.logo.url}.256x256_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "256w, "
+                            f"http://testserver{contract.order.organization.logo.url}.128x128_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                            "128w"
+                        ),
+                        "size": contract.order.organization.logo.size,
+                    },
+                    "title": contract.order.organization.title,
+                },
+                "learner_name": contract.order.owner.get_full_name(),
+                "title": contract.order.product.title,
+            },
+            "signed_on": contract.signed_on.isoformat().replace("+00:00", "Z")
+            if contract.signed_on
+            else None,
+            "created_on": contract.created_on.isoformat().replace("+00:00", "Z"),
+        }
 
     def test_api_contract_read_list_anonymous(self):
         """It should not be possible to retrieve the list of contracts for anonymous user"""
@@ -38,29 +107,153 @@ class ContractApiTest(BaseAPITestCase):
         user = UserFactory()
         order = OrderFactory(owner=user, product=ProductFactory())
         contract = ContractFactory(order=order)
+        order = OrderFactory(owner=user, product=ProductFactory())
+        signed_contract = ContractFactory(order=order)
+        signed_contract.definition_checksum = "test"
+        signed_contract.context = {"test": "test"}
+        signed_contract.signed_on = datetime.datetime.utcnow()
+        signed_contract.save()
+        signed_contract.refresh_from_db()
 
         token = self.get_user_token(user.username)
 
-        response = self.client.get(
-            "/api/v1.0/contracts/", HTTP_AUTHORIZATION=f"Bearer {token}"
+        with self.assertNumQueries(11):
+            response = self.client.get(
+                "/api/v1.0/contracts/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 2,
+                "next": None,
+                "previous": None,
+                "results": [
+                    self._return_from_contract(contract),
+                    self._return_from_contract(signed_contract),
+                ],
+            },
         )
 
-        self.assertEqual(response.status_code, 200)
+    def test_api_contract_read_list_authenticated_organization_owner(self):
+        """
+        When an authenticated user with owner rights on an organization retrieves
+        the list of contracts, it should return all contracts linked to the org.
+        """
+        user = UserFactory()
 
+        contracts = ContractFactory.create_batch(3)
+        for organization in models.Organization.objects.all():
+            UserOrganizationAccessFactory(
+                organization=organization, user=user, role="owner"
+            )
+        ContractFactory.create_batch(5)
+
+        token = self.get_user_token(user.username)
+
+        with self.assertNumQueries(14):
+            response = self.client.get(
+                "/api/v1.0/contracts/", HTTP_AUTHORIZATION=f"Bearer {token}"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        expected_value = [
+            self._return_from_contract(contract)
+            for contract in sorted(contracts, key=lambda x: x.created_on)
+        ]
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 3,
+                "next": None,
+                "previous": None,
+                "results": expected_value,
+            },
+        )
+
+    def test_api_contract_read_list_authenticated_filter(self):
+        """
+        An authenticated user can filter contracts they can read by
+        organization, course or signature state
+        """
+        user = UserFactory()
+        token = self.get_user_token(user.username)
+
+        contracts = ContractFactory.create_batch(5)
+        signed_contract = ContractFactory()
+        signed_contract.definition_checksum = "test"
+        signed_contract.context = {"test": "test"}
+        signed_contract.signed_on = datetime.datetime.utcnow()
+        signed_contract.save()
+        signed_contract.refresh_from_db()
+
+        for organization in models.Organization.objects.all():
+            UserOrganizationAccessFactory(
+                organization=organization, user=user, role="owner"
+            )
+
+        response = self.client.get(
+            "/api/v1.0/contracts/?signature=False", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+        self.assertEqual(response.status_code, 200)
+        expected_value = [
+            self._return_from_contract(contract)
+            for contract in sorted(contracts, key=lambda x: x.created_on)
+        ]
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 5,
+                "next": None,
+                "previous": None,
+                "results": expected_value,
+            },
+        )
+
+        response = self.client.get(
+            "/api/v1.0/contracts/?signature=True", HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+        self.assertEqual(response.status_code, 200)
+        expected_value = [self._return_from_contract(signed_contract)]
         self.assertEqual(
             response.json(),
             {
                 "count": 1,
                 "next": None,
                 "previous": None,
-                "results": [
-                    {
-                        "id": str(contract.id),
-                        "definition": str(contract.definition.id),
-                        "order": str(contract.order.id),
-                        "signed_on": None,
-                    },
-                ],
+                "results": expected_value,
+            },
+        )
+
+        response = self.client.get(
+            f"/api/v1.0/contracts/?organization={contracts[0].order.organization.id}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        expected_value = [self._return_from_contract(contracts[0])]
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": expected_value,
+            },
+        )
+
+        response = self.client.get(
+            f"/api/v1.0/contracts/?course={contracts[0].order.course.id}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        expected_value = [self._return_from_contract(contracts[0])]
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": expected_value,
             },
         )
 
@@ -155,12 +348,7 @@ class ContractApiTest(BaseAPITestCase):
         content = json.loads(response.content)
         self.assertEqual(
             content,
-            {
-                "id": str(owned_contract.id),
-                "definition": str(owned_contract.definition.id),
-                "order": str(owned_contract.order.id),
-                "signed_on": None,
-            },
+            self._return_from_contract(owned_contract),
         )
 
     def test_api_contract_create(self):


### PR DESCRIPTION
## Purpose

solves #393 
Add data to contract api route to answer the need of the teacher dashboard. Also added the possibility to filter contracts by signature state, course or organization

## Proposal

Description...
- [x] Add filter by signature, course and organization
- [x] Order contracts by signature state and creation date
- [x] Add data to contracts
- [x] Allow organization owners to see contracts linked to the organization
