### PR TITLE
🐛(backend) fix contract definition admin view

### DIFF
--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -110,7 +110,7 @@ class CourseRunFilter(AutocompleteFilter):
 
 
 @admin.register(models.ContractDefinition)
-class ContractDefinitionAdmin(TranslatableAdmin):
+class ContractDefinitionAdmin(admin.ModelAdmin):
     """Admin class for the ContractDefinition model"""
 
     list_display = ("title", "language")
@@ -149,6 +149,7 @@ class CertificateAdmin(admin.ModelAdmin):
     list_display = ("organization", "order", "enrollment", "owner", "issued_on")
     list_filter = [OrganizationFilter]
     readonly_fields = (
+        "id",
         "organization",
         "order",
         "enrollment",


### PR DESCRIPTION
## Purpose

Currently, it is not possible to access to contract definition django admin view . Indeed the related model Admin class currently inherits from TranslatableAdmin
 but this model is not translatable so an error is raised.

## Proposal

- [x] Inherit ContractDefinitionAdmin class from `django.model.AdminModel` instead of `parler.admin.TranslatableAdmin`
