### PR TITLE
✨(lms) create missing courses automatically on course run sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Create missing courses automatically on course run sync
 - Create `certificate` template
 - Add contract and contract definition models with related API endpoints
 - Add `instructions` markdown field to `Product` model

--- a/src/backend/joanie/lms_handler/api.py
+++ b/src/backend/joanie/lms_handler/api.py
@@ -91,8 +91,8 @@ def course_runs_sync(request):
         try:
             course = models.Course.objects.get(code=course_number)
         except models.Course.DoesNotExist:
-            return Response(
-                {"resource_link": [f"Unknown course: {course_number:s}."]}, status=400
+            course = models.Course.objects.create(
+                code=course_number, title=request.data.get("title", course_number)
             )
 
         # Instantiate a new course run


### PR DESCRIPTION

## Purpose

We need to synchronize the complete catalog from a remote LMS. 

## Proposal

Since we trust this LMS, we can create missing courses automatically with the information included in the course run synchronization payload. If the title information is not in the payload, we default to using the code as a first title that can later be changed in joanie.
