### PR TITLE
Add filter on order endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow filtering orders by enrollment
 - Create missing courses automatically on course run sync
 - Create `certificate` template
 - Add contract and contract definition models with related API endpoints

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow filtering orders by state or product type exclusion
 - Allow filtering orders by enrollment
 - Create missing courses automatically on course run sync
 - Create `certificate` template

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -21,9 +21,17 @@ class OrderViewSetFilter(filters.FilterSet):
     state = filters.MultipleChoiceFilter(
         field_name="state", choices=enums.ORDER_STATE_CHOICES
     )
+    state__exclude = filters.MultipleChoiceFilter(
+        field_name="state", choices=enums.ORDER_STATE_CHOICES, exclude=True
+    )
     product__type = filters.MultipleChoiceFilter(
         field_name="product__type",
         choices=enums.PRODUCT_TYPE_CHOICES,
+    )
+    product__type__exclude = filters.MultipleChoiceFilter(
+        field_name="product__type",
+        choices=enums.PRODUCT_TYPE_CHOICES,
+        exclude=True,
     )
 
     class Meta:

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -16,6 +16,7 @@ class OrderViewSetFilter(filters.FilterSet):
     """
 
     product = filters.UUIDFilter(field_name="product")
+    enrollment = filters.UUIDFilter(field_name="enrollment")
     course = filters.CharFilter(field_name="course__code")
     state = filters.MultipleChoiceFilter(
         field_name="state", choices=enums.ORDER_STATE_CHOICES


### PR DESCRIPTION
## Purpose

In PR https://github.com/openfun/joanie/pull/425 @rlecellier made the following request:

> I'll need to have a filter on (enrollment/productId) in the OrderViewset. This is used when we display the payment button, mostly to be sure that we disable the button when an order is created (avoid double click) 

## Proposal

Allow filtering orders related to a specific enrollment (filtering on a specific product is already there).

While working on this, it occured to me that the frontend needed to filter all orders except the ones that are `canceled`. The frontend does this by listing in the querystring all the states other than the one it wants to exclude. This is an anti-pattern prone to future bugs if we later add a new state. Since the intention is to exclude the `canceled` orders, our filters should allow expressing it as close to the intention as possible. 

So I added the possibility to filter orders by excluding a specific state. This is done by adding a "~" character in front of the value:
```
/api/v1/orders/?state=~canceled
```
