### PR TITLE
✨(api) allow to send blank description/instructions field

### DIFF
--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -168,13 +168,17 @@ class AdminProductSerializer(serializers.ModelSerializer):
     """Serializer for Product model."""
 
     title = serializers.CharField()
-    description = serializers.CharField(required=False)
+    description = serializers.CharField(
+        allow_blank=True, trim_whitespace=False, required=False
+    )
     call_to_action = serializers.CharField()
     price = serializers.DecimalField(
         coerce_to_string=False, decimal_places=2, max_digits=9, min_value=0
     )
     price_currency = serializers.SerializerMethodField(read_only=True)
-    instructions = serializers.CharField(allow_blank=True, trim_whitespace=False)
+    instructions = serializers.CharField(
+        allow_blank=True, trim_whitespace=False, required=False
+    )
 
     class Meta:
         model = models.Product

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -222,6 +222,52 @@ class ProductAdminApiTest(TestCase):
         self.assertEqual(content["title"], "Product 001")
         self.assertEqual(content["instructions"], "test instruction")
 
+    def test_admin_api_product_create_with_blank_description(self):
+        """
+        Staff user should be able to create a product with blank description.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        data = {
+            "title": "Product 001",
+            "price": "100.00",
+            "price_currency": "EUR",
+            "type": "enrollment",
+            "call_to_action": "Purchase now",
+            "instructions": "Product instructions",
+        }
+
+        response = self.client.post("/api/v1.0/admin/products/", data=data)
+
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertIsNotNone(content["id"])
+        self.assertEqual(content["title"], "Product 001")
+        self.assertEqual(content["description"], "")
+
+    def test_admin_api_product_create_with_blank_instructions(self):
+        """
+        Staff user should be able to create a product with blank instructions.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        data = {
+            "title": "Product 001",
+            "price": "100.00",
+            "price_currency": "EUR",
+            "type": "enrollment",
+            "description": "This is a product description",
+            "call_to_action": "Purchase now",
+        }
+
+        response = self.client.post("/api/v1.0/admin/products/", data=data)
+
+        self.assertEqual(response.status_code, 201)
+        content = response.json()
+        self.assertIsNotNone(content["id"])
+        self.assertEqual(content["title"], "Product 001")
+        self.assertEqual(content["instructions"], "")
+
     def test_admin_api_product_update(self):
         """
         Staff user should be able to update a product.


### PR DESCRIPTION
## Purpose

The product model accepts blank values for description and instructions but the  admin api endpoint does not allow to create this resource with blank values for those fields. So we update serializer to fix this point.

## Proposal

- [x] Allow to create product with blank description and instructions
