### PR TITLE
Feat/api contract endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow to filter contracts through their signature state
 - Allow filtering orders by state or product type exclusion
 - Allow filtering orders by enrollment
 - Create missing courses automatically on course run sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to
 
 ### Changed
 
+- Update contract api endpoint to retrieve contracts by ownership
 - Internalize degree template
 - Allow to download enrollment certificate from related download api endpoint
 - Data returned by product admin serializer

--- a/src/backend/joanie/core/api/base.py
+++ b/src/backend/joanie/core/api/base.py
@@ -1,0 +1,56 @@
+"""Base API classes for the Joanie project. """
+from rest_framework import viewsets
+
+
+class NestedGenericViewSet(viewsets.GenericViewSet):
+    """
+    A generic Viewset aims to be used in a nested route context.
+    e.g: `/api/v1.0/resource_1/<resource_1_pk>/resource_2/<resource_2_pk>/`
+
+    It allows to define all url kwargs and lookup fields to perform the lookup.
+    """
+
+    lookup_fields: list[str] = ["pk"]
+    lookup_url_kwargs: list[str] = []
+
+    def __getattribute__(self, item):
+        """
+        This method is overridden to allow to get the last lookup field or lookup url kwarg
+        when accessing the `lookup_field` or `lookup_url_kwarg` attribute. This is useful
+        to keep compatibility with all methods used by the parent class `GenericViewSet`.
+        """
+        if item in ["lookup_field", "lookup_url_kwarg"]:
+            return getattr(self, item + "s", [None])[-1]
+
+        return super().__getattribute__(item)
+
+    def get_queryset(self):
+        """
+        Get the list of items for this view.
+
+        `lookup_fields` attribute is enumerated here to perform the nested lookup.
+        """
+        queryset = super().get_queryset()
+
+        # The last lookup field is removed to perform the nested lookup as it corresponds
+        # to the object pk, it is used within get_object method.
+        lookup_url_kwargs = (
+            self.lookup_url_kwargs[:-1]
+            if self.lookup_url_kwargs
+            else self.lookup_fields[:-1]
+        )
+
+        filter_kwargs = {}
+        for index, lookup_url_kwarg in enumerate(lookup_url_kwargs):
+            if lookup_url_kwarg not in self.kwargs:
+                raise KeyError(
+                    f"Expected view {self.__class__.__name__} to be called with a URL "
+                    f'keyword argument named "{lookup_url_kwarg}". Fix your URL conf, or '
+                    "set the `.lookup_fields` attribute on the view correctly."
+                )
+
+            filter_kwargs.update(
+                {self.lookup_fields[index]: self.kwargs[lookup_url_kwarg]}
+            )
+
+        return queryset.filter(**filter_kwargs)

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -558,21 +558,21 @@ class CertificateViewSet(
     pagination_class = Pagination
     serializer_class = serializers.CertificateSerializer
     permission_classes = [permissions.IsAuthenticated]
+    queryset = models.Certificate.objects.all().select_related(
+        "certificate_definition", "order__course", "order__organization", "order__owner"
+    )
 
     def get_queryset(self):
         """
         Custom queryset to get user certificates
         """
+        queryset = super().get_queryset()
         username = (
             self.request.auth["username"]
             if self.request.auth
             else self.request.user.username
         )
-        return models.Certificate.objects.filter(
-            order__owner__username=username
-        ).select_related(
-            "certificate_definition", "order__course", "order__organization"
-        )
+        return queryset.filter(order__owner__username=username)
 
     @action(detail=True, methods=["GET"])
     def download(self, request, pk=None):  # pylint: disable=no-self-use, invalid-name

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -943,6 +943,7 @@ class GenericContractViewSet(
     pagination_class = Pagination
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = serializers.ContractSerializer
+    filterset_class = filters.ContractViewSetFilter
     ordering = ["-signed_on", "-created_on"]
     queryset = models.Contract.objects.all().select_related(
         "definition",

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -98,3 +98,19 @@ class CourseViewSetFilter(filters.FilterSet):
         Filter courses by looking for related products with matching type
         """
         return queryset.filter(products__type=value).distinct()
+
+
+class ContractViewSetFilter(filters.FilterSet):
+    """ContractFilter allows to filter this resource with a signature state."""
+
+    is_signed = filters.BooleanFilter(method="get_is_signed")
+
+    class Meta:
+        model = models.Contract
+        fields: List[str] = ["is_signed"]
+
+    def get_is_signed(self, queryset, _name, value):
+        """
+        Filter Contracts by signature status
+        """
+        return queryset.filter(signed_on__isnull=not value)

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -240,11 +240,21 @@ class NestedOrderSerializer(serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, required=False)
     course = CourseLightSerializer(read_only=True, exclude_abilities=True)
     organization = OrganizationSerializer(read_only=True, exclude_abilities=True)
+    product = serializers.SlugRelatedField(
+        queryset=models.Product.objects.all(), slug_field="title"
+    )
+    owner = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Order
-        fields = ["id", "course", "organization"]
+        fields = ["id", "course", "organization", "owner", "product"]
         read_only_fields = fields
+
+    def get_owner(self, instance):
+        """
+        Return the name full name of the order's owner or fallback to username
+        """
+        return instance.owner.get_full_name() or instance.owner.username
 
 
 class CertificationDefinitionSerializer(serializers.ModelSerializer):

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -44,7 +44,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(4):
             response = self.client.get(
                 "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
             )
@@ -82,6 +82,8 @@ class CertificateApiTest(BaseAPITestCase):
                                 "logo": "_this_field_is_mocked",
                                 "title": order.organization.title,
                             },
+                            "owner": certificate.order.owner.username,
+                            "product": certificate.order.product.title,
                         },
                     },
                 ],
@@ -213,6 +215,8 @@ class CertificateApiTest(BaseAPITestCase):
                         "logo": "_this_field_is_mocked",
                         "title": certificate.order.organization.title,
                     },
+                    "owner": certificate.order.owner.username,
+                    "product": certificate.order.product.title,
                 },
             },
         )

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -44,7 +44,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             response = self.client.get(
                 "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
             )

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -188,6 +188,82 @@ class OrganizationContractApiTest(BaseAPITestCase):
             },
         )
 
+    def test_api_organizations_contracts_list_filter_is_signed(self):
+        """
+        Authenticated user with admin or owner access to the organization
+        can query organization's contracts and filter them by signature state.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        factories.UserOrganizationAccessFactory(
+            user=user,
+            organization=organization,
+            role=random.choice([enums.ADMIN, enums.OWNER]),
+        )
+
+        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        unsigned_contracts = factories.ContractFactory.create_batch(
+            5,
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+        )
+
+        signed_contract = factories.ContractFactory.create(
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+            signed_on=timezone.now(),
+            definition_checksum="test",
+            context={"title": "test"},
+        )
+
+        # Create random contracts that should not be returned
+        factories.ContractFactory.create_batch(5)
+        factories.ContractFactory(order__owner=user)
+
+        # - List without filter should return 6 contracts
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertEqual(content["count"], 6)
+
+        # - Filter by is_signed=false should return 5 contracts
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/?is_signed=false",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        count = content["count"]
+        result_ids = [result["id"] for result in content["results"]]
+        self.assertEqual(count, 5)
+        self.assertCountEqual(
+            result_ids, [str(contract.id) for contract in unsigned_contracts]
+        )
+
+        # - Filter by is_signed=true should return 1 contract
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/?is_signed=true",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        count = content["count"]
+        result_ids = [result["id"] for result in content["results"]]
+        self.assertEqual(count, 1)
+        self.assertEqual(result_ids, [str(signed_contract.id)])
+
     def test_api_organizations_contracts_retrieve_anonymous(self):
         """
         Anonymous user cannot query an organization's contract.

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -1,0 +1,478 @@
+"""Test suite for the Organizations Contract API"""
+import random
+from unittest import mock
+
+from django.utils import timezone
+
+from joanie.core import enums, factories, models
+from joanie.core.serializers import fields
+from joanie.tests.base import BaseAPITestCase
+
+
+class OrganizationContractApiTest(BaseAPITestCase):
+    """Test suite for the Organizations Contract API"""
+
+    def test_api_organizations_contracts_list_anonymous(self):
+        """
+        Anonymous user cannot query all contracts from an organization.
+        """
+        organization = factories.OrganizationFactory()
+
+        with self.assertNumQueries(0):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/"
+            )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_organizations_contracts_list_without_access(self):
+        """
+        Authenticated user without access to the organization cannot query
+        organization's contracts.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        factories.ContractFactory.create_batch(
+            5,
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+        )
+
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 0,
+                "next": None,
+                "previous": None,
+                "results": [],
+            },
+        )
+
+    def test_api_organizations_contracts_list_without_admin_or_owner_accesses(self):
+        """
+        Authenticated user without admin or owner access to the organization
+        cannot query organization's contracts.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        factories.UserOrganizationAccessFactory(
+            user=user,
+            organization=organization,
+            role=enums.MEMBER,
+        )
+
+        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        factories.ContractFactory.create_batch(
+            5,
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+        )
+
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 0,
+                "next": None,
+                "previous": None,
+                "results": [],
+            },
+        )
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_api_organizations_contracts_list_with_accesses(self, _):
+        """
+        Authenticated user with admin or owner access to the organization
+        can query organization's contracts.
+        """
+        organizations = factories.OrganizationFactory.create_batch(2)
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+
+        # - Create contracts for two organizations with admin or owner access
+        for organization in organizations:
+            factories.UserOrganizationAccessFactory(
+                user=user,
+                organization=organization,
+                role=random.choice([enums.ADMIN, enums.OWNER]),
+            )
+
+            relation = factories.CourseProductRelationFactory(
+                organizations=[organization]
+            )
+            factories.ContractFactory.create_batch(
+                5,
+                order__product=relation.product,
+                order__course=relation.course,
+                order__organization=organization,
+            )
+
+        # - Create random contracts that should not be returned
+        factories.ContractFactory.create_batch(5)
+        factories.ContractFactory(order__owner=user)
+
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organizations[0].id)}/contracts/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        contracts = models.Contract.objects.filter(order__organization=organizations[0])
+        expected_contracts = sorted(contracts, key=lambda x: x.created_on, reverse=True)
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 5,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": str(contract.id),
+                        "created_on": contract.created_on.isoformat().replace(
+                            "+00:00", "Z"
+                        ),
+                        "signed_on": contract.signed_on.isoformat().replace(
+                            "+00:00", "Z"
+                        )
+                        if contract.signed_on
+                        else None,
+                        "definition": {
+                            "description": contract.definition.description,
+                            "id": str(contract.definition.id),
+                            "language": contract.definition.language,
+                            "title": contract.definition.title,
+                        },
+                        "order": {
+                            "id": str(contract.order.id),
+                            "course": {
+                                "code": contract.order.course.code,
+                                "cover": "_this_field_is_mocked",
+                                "id": str(contract.order.course.id),
+                                "title": contract.order.course.title,
+                            },
+                            "organization": {
+                                "id": str(contract.order.organization.id),
+                                "code": contract.order.organization.code,
+                                "logo": "_this_field_is_mocked",
+                                "title": contract.order.organization.title,
+                            },
+                            "owner": contract.order.owner.username,
+                            "product": contract.order.product.title,
+                        },
+                    }
+                    for contract in expected_contracts
+                ],
+            },
+        )
+
+    def test_api_organizations_contracts_retrieve_anonymous(self):
+        """
+        Anonymous user cannot query an organization's contract.
+        """
+        contract = factories.ContractFactory()
+        organization = contract.order.organization
+
+        with self.assertNumQueries(0):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
+            )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_organizations_contracts_retrieve_without_access(self):
+        """
+        Authenticated user without access to the organization cannot query
+        an organization's contract.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        contract = factories.ContractFactory(
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+        )
+
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_api_organizations_contracts_retrieve_without_admin_or_owner_accesses(self):
+        """
+        Authenticated user without admin or owner access to the organization
+        cannot query an organization's contract.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        factories.UserOrganizationAccessFactory(
+            user=user,
+            organization=organization,
+            role=enums.MEMBER,
+        )
+
+        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        contract = factories.ContractFactory(
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+        )
+
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 404)
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_api_organizations_contracts_retrieve_with_accesses(self, _):
+        """
+        Authenticated user with admin or owner access to the organization
+        can query an organization's contract.
+        """
+        organizations = factories.OrganizationFactory.create_batch(2)
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+
+        # - Create contracts for two organizations with admin or owner access
+        for organization in organizations:
+            factories.UserOrganizationAccessFactory(
+                user=user,
+                organization=organization,
+                role=random.choice([enums.ADMIN, enums.OWNER]),
+            )
+
+            relation = factories.CourseProductRelationFactory(
+                organizations=[organization]
+            )
+            factories.ContractFactory.create_batch(
+                5,
+                order__product=relation.product,
+                order__course=relation.course,
+                order__organization=organization,
+            )
+
+        contract = models.Contract.objects.filter(
+            order__organization=organizations[0]
+        ).first()
+
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                (
+                    f"/api/v1.0/organizations/{str(organizations[0].id)}"
+                    f"/contracts/{str(contract.id)}/"
+                ),
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(contract.id),
+                "created_on": contract.created_on.isoformat().replace("+00:00", "Z"),
+                "signed_on": contract.signed_on.isoformat().replace("+00:00", "Z")
+                if contract.signed_on
+                else None,
+                "definition": {
+                    "description": contract.definition.description,
+                    "id": str(contract.definition.id),
+                    "language": contract.definition.language,
+                    "title": contract.definition.title,
+                },
+                "order": {
+                    "id": str(contract.order.id),
+                    "course": {
+                        "code": contract.order.course.code,
+                        "cover": "_this_field_is_mocked",
+                        "id": str(contract.order.course.id),
+                        "title": contract.order.course.title,
+                    },
+                    "organization": {
+                        "id": str(contract.order.organization.id),
+                        "code": contract.order.organization.code,
+                        "logo": "_this_field_is_mocked",
+                        "title": contract.order.organization.title,
+                    },
+                    "owner": contract.order.owner.username,
+                    "product": contract.order.product.title,
+                },
+            },
+        )
+
+    def test_api_organizations_contracts_retrieve_with_accesses_and_organization_code(
+        self,
+    ):
+        """
+        Authenticated user with admin or owner access to the organization
+        can query an organization's contract. Furthermore, the api endpoint should work
+        with the organization code instead of the organization id.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        factories.UserOrganizationAccessFactory(
+            user=user,
+            organization=organization,
+            role=random.choice([enums.ADMIN, enums.OWNER]),
+        )
+
+        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        contract = factories.ContractFactory(
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+        )
+
+        with self.assertNumQueries(1):
+            response = self.client.get(
+                f"/api/v1.0/organizations/{organization.code}/contracts/{str(contract.id)}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertContains(response, str(contract.id), status_code=200)
+
+    def test_api_organizations_contracts_create_anonymous(self):
+        """Anonymous user cannot create an organization's contract."""
+        organization = factories.OrganizationFactory()
+
+        with self.assertNumQueries(0):
+            response = self.client.post(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/"
+            )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_organizations_contracts_create_authenticated(self):
+        """Authenticated user cannot create an organization's contract."""
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+
+        with self.assertNumQueries(0):
+            response = self.client.post(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+
+    def test_api_organizations_contracts_update_anonymous(self):
+        """Anonymous user cannot update an organization's contract."""
+        contract = factories.ContractFactory()
+        organization = contract.order.organization
+
+        with self.assertNumQueries(0):
+            response = self.client.put(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
+            )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_organizations_contracts_update_authenticated(self):
+        """Authenticated user cannot update an organization's contract."""
+        contract = factories.ContractFactory()
+        organization = contract.order.organization
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+
+        with self.assertNumQueries(0):
+            response = self.client.put(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+
+    def test_api_organizations_contracts_patch_anonymous(self):
+        """Anonymous user cannot patch an organization's contract."""
+        contract = factories.ContractFactory()
+        organization = contract.order.organization
+
+        with self.assertNumQueries(0):
+            response = self.client.patch(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
+            )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_organizations_contracts_patch_authenticated(self):
+        """Authenticated user cannot patch an organization's contract."""
+        contract = factories.ContractFactory()
+        organization = contract.order.organization
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+
+        with self.assertNumQueries(0):
+            response = self.client.patch(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+
+    def test_api_organizations_contracts_delete_anonymous(self):
+        """Anonymous user cannot delete an organization's contract."""
+        contract = factories.ContractFactory()
+        organization = contract.order.organization
+
+        with self.assertNumQueries(0):
+            response = self.client.delete(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
+            )
+
+        self.assertEqual(response.status_code, 401)
+
+    def test_api_organizations_contracts_delete_authenticated(self):
+        """Authenticated user cannot delete an organization's contract."""
+        contract = factories.ContractFactory()
+        organization = contract.order.organization
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+
+        with self.assertNumQueries(0):
+            response = self.client.delete(
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -70,6 +70,11 @@ course_related_router.register(
     basename="course_accesses",
 )
 course_related_router.register(
+    "contracts",
+    api_client.NestedCourseContractViewSet,
+    basename="course_contracts",
+)
+course_related_router.register(
     "course-runs",
     api_client.CourseRunViewSet,
     basename="course_course_runs",
@@ -86,6 +91,11 @@ organization_related_router.register(
     "accesses",
     api_client.OrganizationAccessViewSet,
     basename="organization_accesses",
+)
+organization_related_router.register(
+    "contracts",
+    api_client.NestedOrganizationContractViewSet,
+    basename="organization_contracts",
 )
 organization_related_router.register(
     "course-product-relations",
@@ -175,8 +185,8 @@ urlpatterns = [
                     r"^courses/(?P<course_id>[0-9a-z-]*)/",
                     include(course_related_router.urls),
                 ),
-                path(
-                    "organizations/<uuid:organization_id>/",
+                re_path(
+                    r"^organizations/(?P<organization_id>[0-9a-z-]*)/",
                     include(organization_related_router.urls),
                 ),
             ]


### PR DESCRIPTION
## Purpose

A user must be able to retrieve contracts in two scenarios. As a learner, they must be able to retrieve contract they own. Then as an organization administrator / owner, they should be able to retrieve organization contracts.
In order to do that we add three endpoints, a simple one to retrieve contracts by ownership, a second nested in organizations which allow to retrieve all contracts relying on the given organization and a last one, also nested under courses which allows to retrieve contracts relying on a course if the user is administrator or owner of an organization which manages this course.

The following endpoints have been created : 
- `/api/v1.0/contracts/<uuid:contract_id>/?is_signed=<bool>`
- `/api/v1.0/organizations/<uuid|[a-z0-9]:organization_id>/contracts/<uuid:contract_id>/?is_signed=<bool>`
- `/api/v1.0/courses/<uuid|[a-z0-9]:course_id>/contracts/<uuid:contract_id>/?is_signed=<bool>`

This PR is a rework of PR #428

## Proposal

- [x] Add endpoint to retrieve contract by ownership
- [x] Add endpoint to retrieve contract by organization access
- [x] Add endpoint to retrieve contract by course according to course organization access 
- [x] Allow to filter contracts by signature state
