### PR TITLE
🐛(backend) allow to unroll to closed course run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to
 
 ### Fixed
 
+- Fix unenrollment issue on closed course runs
 - Fix auto enrollment with closed and specific course runs
 - Fix demo-dev command synchronization error.
 

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -914,8 +914,10 @@ class Enrollment(BaseModel):
         `was_created_by_order` cannot be set to True.
         """
 
-        # The related course run must be opened for enrollment
-        if self.course_run.state["priority"] > CourseState.ARCHIVED_OPEN:
+        # The related course run must be opened to create the enrollment or reactivate it.
+        if (not self.created_on or self.is_active) and self.course_run.state[
+            "priority"
+        ] > CourseState.ARCHIVED_OPEN:
             message = _(
                 "You are not allowed to enroll to a course run not opened for enrollment."
             )


### PR DESCRIPTION
## Purpose

Currently, the `full_clean` method check if the related course run of an enrollment is opened before saving any change on the enrollment.

This check aims to forbid that someone enrolls to a closed course runs but currently it blocks any modifications on this resource that is a bug ...


## Proposal

- [x] Prevent to set enrollment.is_active to True ONLY when a course run is not opened
