### PR TITLE
Install and configure celery with redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Install and configure celery with redis
 - Add CachedModelSerializer
 - Allow to leave organization empty while order is in draft
 - Add API client signature provider to sign contract from an order

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ run: ## start the wsgi (production) and development server
 	@$(COMPOSE) up --force-recreate -d nginx
 	@$(COMPOSE) up --force-recreate -d app-dev
 	@$(COMPOSE) up --force-recreate -d admin-dev
+	@$(COMPOSE) up --force-recreate -d celery-dev
 	@echo "Wait for postgresql to be up..."
 	@$(WAIT_DB)
 .PHONY: run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     ports:
       - "15432:5432"
 
+  redis:
+    image: redis:5
+
   app-dev:
     build:
       context: .
@@ -31,6 +34,28 @@ services:
     depends_on:
       - postgresql
       - mailcatcher
+      - redis
+    networks:
+      default:
+      lms_outside:
+        aliases:
+          - joanie
+
+  celery-dev:
+    user: ${DOCKER_USER:-1000}
+    image: joanie:development
+    command: ["celery", "-A", "joanie.celery_app", "worker", "-l", "DEBUG"]
+    environment:
+      - DJANGO_CONFIGURATION=Development
+    env_file:
+      - env.d/development/common
+      - env.d/development/postgresql
+    volumes:
+      - ./src/backend:/app
+      - ./data/media:/data/media
+      - ./data/static:/data/static
+    depends_on:
+      - app-dev
     networks:
       default:
       lms_outside:
@@ -54,6 +79,24 @@ services:
       - ./data/media:/data/media
     depends_on:
       - postgresql
+      - redis
+    networks:
+      default:
+      lms_outside:
+        aliases:
+          - joanie
+
+  celery:
+    user: ${DOCKER_USER:-1000}
+    image: joanie:production
+    command: ["celery", "-A", "joanie.celery_app", "worker", "-l", "INFO"]
+    environment:
+      - DJANGO_CONFIGURATION=ContinuousIntegration
+    env_file:
+      - env.d/development/common
+      - env.d/development/postgresql
+    depends_on:
+      - app
     networks:
       default:
       lms_outside:

--- a/src/backend/joanie/celery_app.py
+++ b/src/backend/joanie/celery_app.py
@@ -1,0 +1,22 @@
+"""Joanie celery configuration file."""
+import os
+
+from celery import Celery
+from configurations.importer import install
+
+# Set the default Django settings module for the 'celery' program.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "joanie.settings")
+os.environ.setdefault("DJANGO_CONFIGURATION", "Development")
+
+install(check_options=True)
+
+app = Celery("joanie")
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object("django.conf:settings", namespace="CELERY")
+
+# Load task modules from all registered Django apps.
+app.autodiscover_tasks()

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -407,6 +407,10 @@ class Base(Configuration):
         None, environ_name="JOANIE_SIGNATURE_LEXPERSONA_TOKEN", environ_prefix=None
     )
 
+    # Celery
+    CELERY_BROKER_URL = values.Value("redis://redis:6379/0")
+    CELERY_BROKER_TRANSPORT_OPTIONS = values.DictValue({})
+
     # pylint: disable=invalid-name
     @property
     def ENVIRONMENT(self):

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -25,10 +25,10 @@ license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "Brotli==1.1.0",
-    "PyJWT==2.8.0",
     "arrow==1.3.0",
     "boto3==1.28.79",
+    "Brotli==1.1.0",
+    "celery[redis]==5.3.4",
     "django-admin-sortable2==2.1.10",
     "django-admin-autocomplete-filter==0.7.1",
     "django-configurations==2.5",
@@ -55,6 +55,7 @@ dependencies = [
     "payplug==1.4.0",
     "psycopg[binary]==3.1.12",
     "pydantic[email]>2",
+    "PyJWT==2.8.0",
     "requests==2.31.0",
     "sentry-sdk==1.34.0",
     "url-normalize==1.4.3",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -102,11 +102,11 @@ universal = true
 
 [tool.flake8]
 exclude = [
-    ".git,",
-    ".venv,",
-    "build,",
-    "venv,",
-    "__pycache__,",
+    ".git",
+    ".venv",
+    "build",
+    "venv",
+    "__pycache__",
     "*/migrations/*",
 ]
 max-line-length = 99

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -1,29 +1,31 @@
+{%- set dc_name = "joanie-%s" | format(service_variant) -%}
+
 apiVersion: v1
 kind: Deployment
 metadata:
   labels:
     app: joanie
-    service: joanie
+    service: "{{ service_variant }}"
     version: "{{ joanie_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
-  name: "joanie-app-{{ deployment_stamp }}"
+  name: "{{ dc_name }}-{{ deployment_stamp }}"
   namespace: "{{ namespace_name }}"
 spec:
-  replicas: {{ joanie_app_replicas }}
+  replicas: {{ joanie_replicas }}
   selector:
     matchLabels:
       app: joanie
-      service: joanie
+      service: "{{ service_variant }}"
       version: "{{ joanie_image_tag }}"
-      deployment: "joanie-app-{{ deployment_stamp }}"
+      deployment: "{{ dc_name }}-{{ deployment_stamp }}"
       deployment_stamp: "{{ deployment_stamp }}"
   template:
     metadata:
       labels:
         app: joanie
-        service: joanie
+        service: "{{ service_variant }}"
         version: "{{ joanie_image_tag }}"
-        deployment: "joanie-app-{{ deployment_stamp }}"
+        deployment: "{{ dc_name }}-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       # Prefer running pods on different nodes for redundancy
@@ -37,7 +39,7 @@ spec:
                     - key: deployment
                       operator: In
                       values:
-                        - "joanie-app-{{ deployment_stamp }}"
+                        - "{{ dc_name }}-{{ deployment_stamp }}"
                 topologyKey: kubernetes.io/hostname
 {% set image_pull_secret_name = joanie_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
 {% if image_pull_secret_name is not none %}
@@ -89,6 +91,9 @@ spec:
             - configMapRef:
                 name: "joanie-app-dotenv-{{ deployment_stamp }}"
           resources: {{ joanie_app_resources }}
+{% if service_variant=="celery" %}
+          command: {{ joanie_celery_command }}
+{% endif %}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/src/tray/templates/services/app/deploy_app.yml.j2
+++ b/src/tray/templates/services/app/deploy_app.yml.j2
@@ -1,0 +1,4 @@
+{% set service_variant = "app" %}
+{% set joanie_replicas = joanie_app_replicas %}
+
+{% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/templates/services/app/deploy_celery.yml.j2
+++ b/src/tray/templates/services/app/deploy_celery.yml.j2
@@ -1,0 +1,4 @@
+{% set service_variant = "celery" %}
+{% set joanie_replicas = joanie_celery_replicas %}
+
+{% include "./_deploy_base.yml.j2" with context %}

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -41,6 +41,16 @@ joanie_django_configuration: "Development"
 joanie_secret_name: "joanie-{{ joanie_vault_checksum | default('undefined_joanie_vault_checksum') }}"
 joanie_activate_http_basic_auth: false
 
+# -- joanie celery
+joanie_celery_replicas: 1
+joanie_celery_command: 
+  - celery
+  - -A
+  - joanie.celery_app
+  - worker
+  - -l
+  - INFO"
+
 # -- resources
 {% set app_resources = {
   "requests": {


### PR DESCRIPTION
## Purpose

We want to add long task management in joanie. For this, we chose to use
the celery application with redis. We need a redis server running in our
docker-compose configuration and then create a celery app launch by a
celery server also added in docker-compose


## Proposal

- [x] Install and configure celery with redis
- [x] refactor deployment to add a celery app 
