### PR TITLE
⬆️(backend) update psycopg to version 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to
 
 ### Changed
 
+- Update psycopg to version 3
 - Update contract api endpoint to retrieve contracts by ownership
 - Internalize degree template
 - Allow to download enrollment certificate from related download api endpoint

--- a/src/backend/setup.cfg
+++ b/src/backend/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     nested-multipart-parser==1.5.0
     obc<0.2.0 # Pinned until we upgrade to Pydantic 2.0
     payplug==1.4.0
-    psycopg2-binary==2.9.9
+    psycopg[binary]==3.1.12
     pydantic[email]>2
     requests==2.31.0
     sentry-sdk==1.32.0


### PR DESCRIPTION
## Purpose

Django 4.2 supports psycopg 3, and will remove support for version 2 in the future.


## Proposal

- [x]  update psycopg to version 3
