### PR TITLE
✅(backend) decrease testing time

### DIFF
--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -95,14 +95,6 @@ class OrganizationFactory(factory.django.DjangoModelFactory):
         filename="logo.png", format="png", width=1, height=1
     )
 
-    @classmethod
-    def _after_postgeneration(cls, instance, create, results=None):
-        """
-        Generate thumbnails for logo after organization has been created.
-        """
-        if create:
-            generate_thumbnails_for_field(instance.logo)
-
     @factory.post_generation
     def users(self, create, extracted, **kwargs):
         """Add users to organization from a given list of users with or without roles."""
@@ -114,6 +106,18 @@ class OrganizationFactory(factory.django.DjangoModelFactory):
                     UserOrganizationAccessFactory(
                         organization=self, user=item[0], role=item[1]
                     )
+
+
+class OrganizationFactoryWithThumbnails(OrganizationFactory):
+    """A factory to create an organization, with thumbnails generation"""
+
+    @classmethod
+    def _after_postgeneration(cls, instance, create, results=None):
+        """
+        Generate thumbnails for logo after organization has been created.
+        """
+        if create:
+            generate_thumbnails_for_field(instance.logo)
 
 
 class UserOrganizationAccessFactory(factory.django.DjangoModelFactory):
@@ -141,14 +145,6 @@ class CourseFactory(factory.django.DjangoModelFactory):
     cover = factory.django.ImageField(
         filename="cover.png", format="png", width=1, height=1
     )
-
-    @classmethod
-    def _after_postgeneration(cls, instance, create, results=None):
-        """
-        Generate thumbnails for cover after course has been created.
-        """
-        if create:
-            generate_thumbnails_for_field(instance.cover)
 
     @factory.post_generation
     # pylint: disable=unused-argument,no-member
@@ -196,6 +192,18 @@ class CourseFactory(factory.django.DjangoModelFactory):
                     UserCourseAccessFactory(course=self, user=item)
                 else:
                     UserCourseAccessFactory(course=self, user=item[0], role=item[1])
+
+
+class CourseFactoryWithThumbnails(CourseFactory):
+    """A factory to create a course, with thumbnails generation"""
+
+    @classmethod
+    def _after_postgeneration(cls, instance, create, results=None):
+        """
+        Generate thumbnails for cover after course has been created.
+        """
+        if create:
+            generate_thumbnails_for_field(instance.cover)
 
 
 class UserCourseAccessFactory(factory.django.DjangoModelFactory):

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -544,6 +544,9 @@ class Test(Base):
             },
         }
     )
+    PASSWORD_HASHERS = [
+        "django.contrib.auth.hashers.MD5PasswordHasher",
+    ]
 
     def __init__(self):
         # pylint: disable=invalid-name

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -154,7 +154,7 @@ class ContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
 
         # - List without filter should return 6 contracts
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(266):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -38,7 +38,7 @@ class CourseApiTest(BaseAPITestCase):
         factories.UserCourseAccessFactory(user=user, course=courses[0])
         factories.UserCourseAccessFactory(user=user, course=courses[1])
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(51):
             response = self.client.get(
                 "/api/v1.0/courses/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -329,7 +329,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             course=course, product=product
         )
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(53):
             self.client.get(f"/api/v1.0/courses/{course.code}/products/{product.id}/")
 
         # A second call to the url should benefit from caching on the product serializer
@@ -599,7 +599,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 product=product, order_group=order_group1, state=state
             )
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(51):
             self.client.get(
                 f"/api/v1.0/course-product-relations/{relation.id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_courses_contract.py
+++ b/src/backend/joanie/tests/core/test_api_courses_contract.py
@@ -234,7 +234,7 @@ class CourseContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 6 contracts
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(46):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(course.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -456,7 +456,7 @@ class CourseContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(45):
             response = self.client.get(
                 f"/api/v1.0/courses/{course.code}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -403,7 +403,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         # The user can see his/her enrollment
         token = self.generate_token_from_user(enrollment.user)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(27):
             response = self.client.get(
                 "/api/v1.0/enrollments/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -598,7 +598,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             user=user, course_run=cr3, was_created_by_order=True
         )
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(49):
             response = self.client.get(
                 "/api/v1.0/enrollments/?was_created_by_order=false",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -608,7 +608,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         content = response.json()
         self.assertEqual(content["count"], 2)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(27):
             response = self.client.get(
                 "/api/v1.0/enrollments/?was_created_by_order=true",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -536,7 +536,7 @@ class OrderApiTest(BaseAPITestCase):
         token = self.generate_token_from_user(user)
 
         # Retrieve user's orders without any filter
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(59):
             response = self.client.get(
                 "/api/v1.0/orders/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -2104,7 +2104,7 @@ class OrderApiTest(BaseAPITestCase):
         }
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(46):
             response = self.client.post(
                 "/api/v1.0/orders/",
                 data=data,

--- a/src/backend/joanie/tests/core/test_api_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations.py
@@ -42,7 +42,7 @@ class OrganizationApiTest(BaseAPITestCase):
             user=user, organization=organizations[1]
         )
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(47):
             response = self.client.get(
                 "/api/v1.0/organizations/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -224,7 +224,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 6 contracts
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(46):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -435,7 +435,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(45):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organization.code}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
@@ -54,7 +54,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                     course=course, product=product, organizations=[organizations[0]]
                 )
             )
-        with self.assertNumQueries(18):
+        with self.assertNumQueries(150):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -150,7 +150,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                     course=course, product=product, organizations=[organizations[0]]
                 )
             )
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(49):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/"

--- a/src/backend/joanie/tests/core/test_api_organizations_courses.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_courses.py
@@ -61,7 +61,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         )
 
         # Retrieve all courses from org with access
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(98):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/courses/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -153,7 +153,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         factories.UserOrganizationAccessFactory(
             organization=organizations[0], user=user
         )
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(51):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/courses/{courses[0].id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -237,7 +237,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         )
 
         # Retrieve all courses from org with listed course runs
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(52):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{organizations[0].id}"


### PR DESCRIPTION
## Purpose

Our tests are really long to run (10 min locally), which causes a huge dev worflow problem.
It appears that we have many db request made for each of our data factories.
Also, default default password hasher is quite long to execute.

## Proposal

- [x] Remove eager data generation: generate_thumbnails_for_field
It appears that removing it doesn't change the expected output of the tests, so I purely deleted them.
- [x] Use MD5PasswordHasher in tests