### PR TITLE
Update serializers attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ and this project adheres to
   - OrderSerializer
   - OrderLightSerializer
   - CourseSerializer
+  - CourseAccessSerializer
+  - OrganizationAccessSerializer
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ and this project adheres to
 - Rename nested order serializer attributes to be more descriptive
 - Update nested order serializer to return enrollment
 - Update order serializer to return enrollment
+- Rename serializers attributes to be more descriptive:
+  - EnrollmentSerializer
+  - OrderSerializer
+  - OrderLightSerializer
+  - CourseSerializer
 
 ### Removed
 

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -692,7 +692,7 @@ class OrganizationAccessViewSet(
     lookup_field = "pk"
     pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
-    queryset = models.OrganizationAccess.objects.all()
+    queryset = models.OrganizationAccess.objects.all().select_related("user")
     serializer_class = serializers.OrganizationAccessSerializer
 
     def get_permissions(self):
@@ -767,7 +767,7 @@ class CourseAccessViewSet(
     lookup_field = "pk"
     pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
-    queryset = models.CourseAccess.objects.all()
+    queryset = models.CourseAccess.objects.all().select_related("user")
     serializer_class = serializers.CourseAccessSerializer
 
     def get_permissions(self):

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -341,7 +341,7 @@ class OrderViewSet(
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        course_code = serializer.initial_data.get("course")
+        course_code = serializer.initial_data.get("course_code")
 
         product = serializer.validated_data.get("product")
 

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -77,9 +77,15 @@ class CourseLightSerializer(AbilitiesModelSerializer):
 class CourseAccessSerializer(AbilitiesModelSerializer):
     """Serialize course accesses for the API."""
 
+    user_id = serializers.SlugRelatedField(
+        queryset=models.User.objects.all(),
+        slug_field="id",
+        source="user",
+    )
+
     class Meta:
         model = models.CourseAccess
-        fields = ["id", "role", "user"]
+        fields = ["id", "role", "user_id"]
         read_only_fields = ["id"]
 
     def update(self, instance, validated_data):
@@ -162,9 +168,15 @@ class OrganizationSerializer(AbilitiesModelSerializer):
 class OrganizationAccessSerializer(AbilitiesModelSerializer):
     """Serialize Organization accesses for the API."""
 
+    user_id = serializers.SlugRelatedField(
+        queryset=models.User.objects.all(),
+        slug_field="id",
+        source="user",
+    )
+
     class Meta:
         model = models.OrganizationAccess
-        fields = ["id", "role", "user"]
+        fields = ["id", "role", "user_id"]
         read_only_fields = ["id"]
 
     def update(self, instance, validated_data):

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -461,7 +461,9 @@ class EnrollmentSerializer(serializers.ModelSerializer):
     """
 
     id = serializers.CharField(read_only=True, required=False)
-    certificate = serializers.SlugRelatedField(read_only=True, slug_field="id")
+    certificate_id = serializers.SlugRelatedField(
+        read_only=True, slug_field="id", source="certificate"
+    )
     course_run = CourseRunSerializer(read_only=True)
     product_relations = serializers.SerializerMethodField(read_only=True)
     orders = serializers.SerializerMethodField(read_only=True)
@@ -471,7 +473,7 @@ class EnrollmentSerializer(serializers.ModelSerializer):
         model = models.Enrollment
         fields = [
             "id",
-            "certificate",
+            "certificate_id",
             "course_run",
             "created_on",
             "is_active",
@@ -584,37 +586,47 @@ class OrderSerializer(serializers.ModelSerializer):
         required=False,
     )
     total_currency = serializers.SerializerMethodField(read_only=True)
-    organization = serializers.SlugRelatedField(
-        queryset=models.Organization.objects.all(), slug_field="id", required=False
+    organization_id = serializers.SlugRelatedField(
+        queryset=models.Organization.objects.all(),
+        slug_field="id",
+        required=False,
+        source="organization",
     )
-    product = serializers.SlugRelatedField(
-        queryset=models.Product.objects.all(), slug_field="id"
+    product_id = serializers.SlugRelatedField(
+        queryset=models.Product.objects.all(), slug_field="id", source="product"
     )
     target_enrollments = serializers.SerializerMethodField(read_only=True)
-    order_group = serializers.SlugRelatedField(
-        queryset=models.OrderGroup.objects.all(), slug_field="id", required=False
+    order_group_id = serializers.SlugRelatedField(
+        queryset=models.OrderGroup.objects.all(),
+        slug_field="id",
+        required=False,
+        source="order_group",
     )
     target_courses = OrderTargetCourseRelationSerializer(
         read_only=True, many=True, source="course_relations"
     )
-    main_invoice = serializers.SlugRelatedField(read_only=True, slug_field="reference")
-    certificate = serializers.SlugRelatedField(read_only=True, slug_field="id")
+    main_invoice_reference = serializers.SlugRelatedField(
+        read_only=True, slug_field="reference", source="main_invoice"
+    )
+    certificate_id = serializers.SlugRelatedField(
+        read_only=True, slug_field="id", source="certificate"
+    )
     contract = ContractSerializer(read_only=True)
 
     class Meta:
         model = models.Order
         fields = [
-            "certificate",
+            "certificate_id",
             "contract",
             "course",
             "created_on",
             "enrollment",
             "id",
-            "main_invoice",
-            "order_group",
-            "organization",
+            "main_invoice_reference",
+            "order_group_id",
+            "organization_id",
             "owner",
-            "product",
+            "product_id",
             "state",
             "target_courses",
             "target_enrollments",
@@ -655,12 +667,19 @@ class OrderSerializer(serializers.ModelSerializer):
 class OrderLightSerializer(serializers.ModelSerializer):
     """Order model light serializer."""
 
+    product_id = serializers.SlugRelatedField(
+        queryset=models.Product.objects.all(), slug_field="id", source="product"
+    )
+    certificate_id = serializers.SlugRelatedField(
+        queryset=models.Certificate.objects.all(), slug_field="id", source="certificate"
+    )
+
     class Meta:
         model = models.Order
         fields = [
             "id",
-            "certificate",
-            "product",
+            "certificate_id",
+            "product_id",
             "state",
         ]
         read_only_fields = fields
@@ -749,9 +768,11 @@ class CourseSerializer(AbilitiesModelSerializer):
 
     cover = ThumbnailDetailField()
     organizations = OrganizationSerializer(many=True, read_only=True)
-    products = serializers.SlugRelatedField(many=True, read_only=True, slug_field="id")
-    course_runs = serializers.SlugRelatedField(
-        many=True, read_only=True, slug_field="id"
+    product_ids = serializers.SlugRelatedField(
+        many=True, read_only=True, slug_field="id", source="products"
+    )
+    course_run_ids = serializers.SlugRelatedField(
+        many=True, read_only=True, slug_field="id", source="course_runs"
     )
 
     class Meta:
@@ -759,11 +780,11 @@ class CourseSerializer(AbilitiesModelSerializer):
         fields = [
             "created_on",
             "code",
-            "course_runs",
+            "course_run_ids",
             "cover",
             "id",
             "organizations",
-            "products",
+            "product_ids",
             "state",
             "title",
         ]

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -507,7 +507,11 @@ class EnrollmentSerializer(serializers.ModelSerializer):
         # create/update an enrollment, we do not want the frontend has to provide the
         # whole course run resource but only its id. So we retrieve the course run id
         # from request body and use it to retrieve the course run resource.
-        course_run_id = self.initial_data["course_run"]
+        try:
+            course_run_id = self.initial_data["course_run_id"]
+        except KeyError as exception:
+            message = "You must provide a course_run_id to create an enrollment."
+            raise serializers.ValidationError({"__all__": [message]}) from exception
 
         try:
             course_run = models.CourseRun.objects.get(id=course_run_id)

--- a/src/backend/joanie/payment/backends/dummy.py
+++ b/src/backend/joanie/payment/backends/dummy.py
@@ -133,7 +133,7 @@ class DummyPaymentBackend(BasePaymentBackend):
 
         return {
             "payment_id": payment_id,
-            "provider": self.name,
+            "provider_name": self.name,
             "url": notification_url,
         }
 

--- a/src/backend/joanie/payment/backends/payplug/__init__.py
+++ b/src/backend/joanie/payment/backends/payplug/__init__.py
@@ -145,7 +145,7 @@ class PayplugBackend(BasePaymentBackend):
 
         return {
             "payment_id": payment.id,
-            "provider": self.name,
+            "provider_name": self.name,
             "url": payment.hosted_payment.payment_url,
         }
 
@@ -171,7 +171,7 @@ class PayplugBackend(BasePaymentBackend):
 
         return {
             "payment_id": payment.id,
-            "provider": self.name,
+            "provider_name": self.name,
             "url": payment.hosted_payment.payment_url,
             "is_paid": payment.is_paid,
         }

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -105,10 +105,10 @@ class CourseApiTest(BaseAPITestCase):
                             }
                             for organization in course.organizations.all()
                         ],
-                        "products": [
+                        "product_ids": [
                             str(product.id) for product in course.products.all()
                         ],
-                        "course_runs": [
+                        "course_run_ids": [
                             str(course_run.id)
                             for course_run in course.course_runs.all()
                         ],
@@ -301,8 +301,8 @@ class CourseApiTest(BaseAPITestCase):
                     }
                     for organization in course.organizations.all()
                 ],
-                "products": [str(product.id) for product in course.products.all()],
-                "course_runs": [
+                "product_ids": [str(product.id) for product in course.products.all()],
+                "course_run_ids": [
                     str(course_run.id) for course_run in course.course_runs.all()
                 ],
                 "state": course.state,

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -14,6 +14,8 @@ class CourseApiTest(BaseAPITestCase):
     Test suite for Course API endpoint.
     """
 
+    maxDiff = None
+
     def test_api_course_list_anonymous(self):
         """
         Anonymous users should not be able to list courses.
@@ -22,7 +24,7 @@ class CourseApiTest(BaseAPITestCase):
         response = self.client.get("/api/v1.0/courses/")
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
@@ -78,7 +80,7 @@ class CourseApiTest(BaseAPITestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "count": 1,
@@ -230,7 +232,7 @@ class CourseApiTest(BaseAPITestCase):
         response = self.client.get(f"/api/v1.0/courses/{course.id}/")
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
@@ -250,7 +252,7 @@ class CourseApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 404)
-        self.assertEqual(response.json(), {"detail": "Not found."})
+        self.assertDictEqual(response.json(), {"detail": "Not found."})
 
     @mock.patch.object(
         fields.ThumbnailDetailField,
@@ -282,7 +284,7 @@ class CourseApiTest(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertTrue(content.pop("abilities")["get"])
-        self.assertEqual(
+        self.assertDictEqual(
             content,
             {
                 "created_on": course.created_on.isoformat().replace("+00:00", "Z"),
@@ -390,7 +392,7 @@ class CourseApiTest(BaseAPITestCase):
         response = self.client.put(f"/api/v1.0/courses/{course.id}/", data=data)
 
         self.assertEqual(response.status_code, 401)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
@@ -422,7 +424,7 @@ class CourseApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 405)
-        self.assertEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
+        self.assertDictEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
         course.refresh_from_db()
         for key, value in data.items():
@@ -457,7 +459,7 @@ class CourseApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 405)
-        self.assertEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
+        self.assertDictEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
         course.refresh_from_db()
         for key, value in data.items():

--- a/src/backend/joanie/tests/core/test_api_course_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_course_accesses.py
@@ -488,7 +488,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             {
-                "user": str(user.id),
+                "user_id": str(user.id),
                 "role": random.choice(
                     ["administrator", "instructor", "manager", "owner"]
                 ),
@@ -658,8 +658,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory().id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -684,8 +684,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "instructor")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "instructor")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -715,8 +715,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "instructor")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "instructor")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -746,8 +746,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "manager")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "manager")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -780,8 +780,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(["administrator", "instructor", "manager"]),
         }
 
@@ -826,8 +826,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -861,8 +861,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": "owner",
         }
 
@@ -901,8 +901,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -946,8 +946,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
         for field, value in new_values.items():
@@ -1010,8 +1010,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory().id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -1036,8 +1036,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "instructor")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "instructor")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -1067,8 +1067,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "instructor")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "instructor")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -1098,8 +1098,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "manager")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "manager")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -1132,8 +1132,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(["administrator", "instructor", "manager"]),
         }
 
@@ -1158,7 +1158,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                     updated_values, {**old_values, "role": new_values["role"]}
                 )
             else:
-                self.assertEqual(updated_values, old_values)
+                self.assertDictEqual(updated_values, old_values)
 
     def test_api_course_accesses_patch_administrator_from_owner(self):
         """
@@ -1176,8 +1176,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -1212,8 +1212,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": "owner",
         }
 
@@ -1249,8 +1249,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
 
@@ -1292,8 +1292,8 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "course": factories.CourseFactory(users=[(user, "administrator")]).id,
-            "user": factories.UserFactory().id,
+            "course_id": factories.CourseFactory(users=[(user, "administrator")]).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(CourseAccess.ROLE_CHOICES)[0],
         }
         for field, value in new_values.items():

--- a/src/backend/joanie/tests/core/test_api_course_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_course_accesses.py
@@ -364,7 +364,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content,
                 {
                     "id": str(access.id),
-                    "user": str(access.user.id),
+                    "user_id": str(access.user.id),
                     "role": access.role,
                 },
             )
@@ -396,7 +396,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content,
                 {
                     "id": str(access.id),
-                    "user": str(access.user.id),
+                    "user_id": str(access.user.id),
                     "role": access.role,
                 },
             )
@@ -426,7 +426,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content,
                 {
                     "id": str(access.id),
-                    "user": str(access.user.id),
+                    "user_id": str(access.user.id),
                     "role": access.role,
                 },
             )
@@ -456,7 +456,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content,
                 {
                     "id": str(access.id),
-                    "user": str(access.user.id),
+                    "user_id": str(access.user.id),
                     "role": access.role,
                 },
             )
@@ -510,7 +510,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": random.choice(
                     ["administrator", "instructor", "manager", "owner"]
                 ),
@@ -537,7 +537,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": random.choice(
                     ["administrator", "instructor", "manager", "owner"]
                 ),
@@ -565,7 +565,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": random.choice(
                     ["administrator", "instructor", "manager", "owner"]
                 ),
@@ -594,7 +594,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": random.choice(["instructor", "manager", "administrator"]),
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -616,7 +616,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": "owner",
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -639,7 +639,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             response = self.client.post(
                 f"/api/v1.0/courses/{course.id!s}/accesses/",
                 {
-                    "user": str(other_user.id),
+                    "user_id": str(other_user.id),
                     "role": role,
                 },
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -726,8 +726,8 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.post(
             "/api/v1.0/courses/products/",
             data={
-                "course": str(course.id),
-                "product": str(product.id),
+                "course_id": str(course.id),
+                "product_id": str(product.id),
             },
         )
 
@@ -754,8 +754,8 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             "/api/v1.0/courses/products/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "course": str(course.id),
-                "product": str(product.id),
+                "course_id": str(course.id),
+                "product_id": str(product.id),
             },
         )
 
@@ -779,8 +779,8 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id}/products/{product.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "course": str(course.id),
-                "product": str(product.id),
+                "course_id": str(course.id),
+                "product_id": str(product.id),
             },
         )
 
@@ -802,8 +802,8 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.put(
             f"/api/v1.0/courses/{course.id}/products/{product.id}/",
             data={
-                "course": "abc",
-                "product": "def",
+                "course_id": "abc",
+                "product_id": "def",
             },
         )
 
@@ -829,8 +829,8 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id}/products/{product.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "course": str(course.id),
-                "product": str(product.id),
+                "course_id": str(course.id),
+                "product_id": str(product.id),
             },
         )
 
@@ -857,8 +857,8 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id}/products/{product.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "course": str(course.id),
-                "product": str(product.id),
+                "course_id": str(course.id),
+                "product_id": str(product.id),
             },
         )
 
@@ -880,7 +880,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.patch(
             f"/api/v1.0/courses/{course.id}/products/{product.id}/",
             data={
-                "product": "def",
+                "product_id": "def",
             },
         )
 
@@ -906,7 +906,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id}/products/{product.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "product": "def",
+                "product_id": "def",
             },
         )
 
@@ -933,7 +933,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id}/products/{product.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "product": "def",
+                "product_id": "def",
             },
         )
 

--- a/src/backend/joanie/tests/core/test_api_course_run.py
+++ b/src/backend/joanie/tests/core/test_api_course_run.py
@@ -246,7 +246,7 @@ class CourseRunApiTest(BaseAPITestCase):
         course = factories.CourseFactory()
         data = {
             "resource_link": "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "course": course.id,
+            "course_id": course.id,
         }
 
         response = self.client.post("/api/v1.0/course-runs/", data=data)
@@ -266,7 +266,7 @@ class CourseRunApiTest(BaseAPITestCase):
         course = factories.CourseFactory()
         data = {
             "resource_link": "https://example.edx:8073/courses/course-v1:edX+DemoX+01/course/",
-            "course": course.id,
+            "course_id": course.id,
         }
 
         response = self.client.post(
@@ -289,7 +289,7 @@ class CourseRunApiTest(BaseAPITestCase):
 
         data = {
             "resource_link": "https://perdu.com",
-            "course": course.id,
+            "course_id": course.id,
             "languages": ["en", "fr"],
             "start": "2020-12-09T09:31:59.417817Z",
             "end": "2021-03-14T09:31:59.417895Z",
@@ -317,7 +317,7 @@ class CourseRunApiTest(BaseAPITestCase):
 
         data = {
             "resource_link": "https://perdu.com",
-            "course": course.id,
+            "course_id": course.id,
             "languages": ["en", "fr"],
             "start": "2020-12-09T09:31:59.417817Z",
             "end": "2021-03-14T09:31:59.417895Z",

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -127,7 +127,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(enrollment.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "course_run": {
                             "id": str(enrollment.course_run.id),
                             "course": {
@@ -200,7 +200,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(other_enrollment.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "course_run": {
                             "id": str(other_enrollment.course_run.id),
                             "course": {
@@ -419,7 +419,7 @@ class EnrollmentApiTest(BaseAPITestCase):
 
         self.assertEqual(len(content["results"]), 1)
         self.assertEqual(
-            content["results"][0]["certificate"],
+            content["results"][0]["certificate_id"],
             str(certificate.pk),
         )
 
@@ -511,7 +511,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(enrollment_1.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "course_run": {
                             "id": str(course_run_1.id),
                             "resource_link": course_run_1.resource_link,
@@ -678,7 +678,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(enrollment.course_run.id),
                     "course": {
@@ -752,8 +752,8 @@ class EnrollmentApiTest(BaseAPITestCase):
             [
                 {
                     "id": str(order.id),
-                    "certificate": str(certificate.id),
-                    "product": str(product.id),
+                    "certificate_id": str(certificate.id),
+                    "product_id": str(product.id),
                     "state": "draft",
                 }
             ],
@@ -865,7 +865,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content,
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -998,7 +998,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -1092,7 +1092,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -1341,7 +1341,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -1529,7 +1529,8 @@ class EnrollmentApiTest(BaseAPITestCase):
             self.assertEqual(response.status_code, 401)
 
             self.assertDictEqual(
-                response.json(), {"detail": "Authentication credentials were not provided."}
+                response.json(),
+                {"detail": "Authentication credentials were not provided."},
             )
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment")
@@ -1605,7 +1606,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 response.json(),
                 {
                     "id": str(enrollment.id),
-                    "certificate": None,
+                    "certificate_id": None,
                     "course_run": {
                         "id": str(enrollment.course_run.id),
                         "course": {
@@ -1841,7 +1842,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -1926,7 +1927,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -2004,7 +2005,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -2102,7 +2103,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {
@@ -2172,7 +2173,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(enrollment.id),
-                "certificate": None,
+                "certificate_id": None,
                 "course_run": {
                     "id": str(course_run.id),
                     "course": {

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -34,6 +34,8 @@ from joanie.tests.base import BaseAPITestCase
 class EnrollmentApiTest(BaseAPITestCase):
     """Test the API of the Enrollment object."""
 
+    maxDiff = None
+
     def setUp(self):
         super().setUp()
         self.now = timezone.now()
@@ -90,7 +92,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         self.assertEqual(response.status_code, 401)
         content = json.loads(response.content)
 
-        self.assertEqual(
+        self.assertDictEqual(
             content, {"detail": "Authentication credentials were not provided."}
         )
 
@@ -116,10 +118,8 @@ class EnrollmentApiTest(BaseAPITestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
-
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "count": 1,
                 "next": None,
@@ -190,10 +190,9 @@ class EnrollmentApiTest(BaseAPITestCase):
             )
 
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
 
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "count": 1,
                 "next": None,
@@ -313,7 +312,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         content = json.loads(response.content)
         self.assertEqual(len(content["results"]), 3)
 
-        self.assertEqual(
+        self.assertListEqual(
             content["results"][2]["product_relations"],
             [
                 {
@@ -503,7 +502,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "count": 1,
@@ -576,7 +575,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(response.json(), {"course_run": ["Enter a valid UUID."]})
+        self.assertDictEqual(response.json(), {"course_run": ["Enter a valid UUID."]})
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment")
     def test_api_enrollment_read_list_filtered_by_was_created_by_order(self, _mock_set):
@@ -634,9 +633,8 @@ class EnrollmentApiTest(BaseAPITestCase):
         response = self.client.get(f"/api/v1.0/enrollments/{enrollment.id}/")
         self.assertEqual(response.status_code, 401)
 
-        content = json.loads(response.content)
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {"detail": "Authentication credentials were not provided."},
         )
 
@@ -675,10 +673,9 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
-        content = json.loads(response.content)
 
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "id": str(enrollment.id),
                 "certificate": None,
@@ -750,7 +747,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         self.assertEqual(response.status_code, 200)
         content = response.json()
 
-        self.assertEqual(
+        self.assertListEqual(
             content["orders"],
             [
                 {
@@ -761,7 +758,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 }
             ],
         )
-        self.assertEqual(
+        self.assertListEqual(
             content["product_relations"],
             [
                 {
@@ -812,8 +809,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 404)
 
-        content = json.loads(response.content)
-        self.assertEqual(content, {"detail": "Not found."})
+        self.assertDictEqual(response.json(), {"detail": "Not found."})
 
     def test_api_enrollment_create_anonymous(self):
         """Anonymous users should not be able to create an enrollment."""
@@ -824,9 +820,8 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 401)
 
-        content = json.loads(response.content)
-        self.assertEqual(
-            content, {"detail": "Authentication credentials were not provided."}
+        self.assertDictEqual(
+            response.json(), {"detail": "Authentication credentials were not provided."}
         )
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment")
@@ -861,12 +856,12 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 201)
-        content = json.loads(response.content)
+        content = response.json()
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
         enrollment = models.Enrollment.objects.get()
         mock_set.assert_called_once_with(enrollment)
-        self.assertEqual(
+        self.assertDictEqual(
             content,
             {
                 "id": str(enrollment.id),
@@ -953,10 +948,9 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 400)
-        content = json.loads(response.content)
 
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "user": [
                     "You are already enrolled to an opened course run "
@@ -996,13 +990,12 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 201)
-        content = json.loads(response.content)
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
         self.assertFalse(mock_set.called)
         enrollment = models.Enrollment.objects.get()
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "id": str(enrollment.id),
                 "certificate": None,
@@ -1091,13 +1084,12 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 201)
-        content = json.loads(response.content)
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
         enrollment = models.Enrollment.objects.get()
         mock_set.assert_called_once_with(enrollment)
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "id": str(enrollment.id),
                 "certificate": None,
@@ -1161,10 +1153,9 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 400)
-        content = json.loads(response.content)
 
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {"is_active": ["This field is required."]},
         )
         self.assertFalse(models.Enrollment.objects.exists())
@@ -1185,10 +1176,9 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 400)
-        content = json.loads(response.content)
 
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {"was_created_by_order": ["This field is required."]},
         )
         self.assertFalse(models.Enrollment.objects.exists())
@@ -1218,10 +1208,9 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 400)
-        content = json.loads(response.content)
 
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "__all__": [
                     f'Course run "{course_run.id}" requires a valid order to enroll.'
@@ -1259,11 +1248,10 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 400)
-        content = json.loads(response.content)
 
         course_run_id = target_course_runs[0].id
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "__all__": [
                     f'Course run "{course_run_id}" requires a valid order to enroll.'
@@ -1294,11 +1282,10 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 400)
-        content = json.loads(response.content)
 
         course_run_id = target_course_runs[0].id
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "__all__": [
                     f'Course run "{course_run_id}" requires a valid order to enroll.'
@@ -1342,7 +1329,6 @@ class EnrollmentApiTest(BaseAPITestCase):
             data=data,
         )
         self.assertEqual(response.status_code, 201)
-        content = json.loads(response.content)
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
         enrollment = models.Enrollment.objects.get()
@@ -1351,8 +1337,8 @@ class EnrollmentApiTest(BaseAPITestCase):
         # - Enrollment uid has been generated and state has been set according
         #   to LMSHandler.set_enrollment response
         self.assertNotEqual(enrollment.id, data["id"])
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {
                 "id": str(enrollment.id),
                 "certificate": None,
@@ -1421,7 +1407,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
         self.assertEqual(response.status_code, 400)
 
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "__all__": [
@@ -1451,7 +1437,7 @@ class EnrollmentApiTest(BaseAPITestCase):
 
         self.assertEqual(response.status_code, 400)
 
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "__all__": [
@@ -1471,9 +1457,8 @@ class EnrollmentApiTest(BaseAPITestCase):
 
         self.assertEqual(response.status_code, 401)
 
-        content = json.loads(response.content)
-        self.assertEqual(
-            content,
+        self.assertDictEqual(
+            response.json(),
             {"detail": "Authentication credentials were not provided."},
         )
 
@@ -1542,10 +1527,9 @@ class EnrollmentApiTest(BaseAPITestCase):
                 content_type="application/json",
             )
             self.assertEqual(response.status_code, 401)
-            content = json.loads(response.content)
 
-            self.assertEqual(
-                content, {"detail": "Authentication credentials were not provided."}
+            self.assertDictEqual(
+                response.json(), {"detail": "Authentication credentials were not provided."}
             )
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment")
@@ -1581,9 +1565,8 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
             self.assertEqual(response.status_code, 404)
-            content = json.loads(response.content)
 
-            self.assertEqual(content, {"detail": "Not found."})
+            self.assertDictEqual(response.json(), {"detail": "Not found."})
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment", return_value=True)
     @mock.patch.object(
@@ -1617,10 +1600,9 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
             self.assertEqual(response.status_code, 200)
-            content = json.loads(response.content)
 
-            self.assertEqual(
-                content,
+            self.assertDictEqual(
+                response.json(),
                 {
                     "id": str(enrollment.id),
                     "certificate": None,
@@ -1855,7 +1837,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "id": str(enrollment.id),
@@ -1940,7 +1922,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "id": str(enrollment.id),
@@ -2018,7 +2000,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "id": str(enrollment.id),
@@ -2116,7 +2098,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "id": str(enrollment.id),
@@ -2186,7 +2168,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
+        self.assertDictEqual(
             response.json(),
             {
                 "id": str(enrollment.id),

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -1149,7 +1149,7 @@ class OrderApiTest(BaseAPITestCase):
         """Anonymous users should not be able to create an order."""
         product = factories.ProductFactory()
         data = {
-            "course": product.courses.first().code,
+            "course_code": product.courses.first().code,
             "product_id": str(product.id),
         }
         response = self.client.post(
@@ -1177,7 +1177,7 @@ class OrderApiTest(BaseAPITestCase):
         )
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
         }
@@ -1484,7 +1484,7 @@ class OrderApiTest(BaseAPITestCase):
         )
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
@@ -1525,7 +1525,7 @@ class OrderApiTest(BaseAPITestCase):
         course = product.courses.first()
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
@@ -1593,7 +1593,7 @@ class OrderApiTest(BaseAPITestCase):
                 counter[str(order.organization.id)] += 1
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
@@ -1638,7 +1638,7 @@ class OrderApiTest(BaseAPITestCase):
         )
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
             "id": uuid.uuid4(),
@@ -1754,7 +1754,7 @@ class OrderApiTest(BaseAPITestCase):
         )
         course = factories.CourseFactory(title="mathématiques")
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
         }
@@ -1802,7 +1802,7 @@ class OrderApiTest(BaseAPITestCase):
             courses=[course], title="balançoire", price=0.00
         )
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
         }
@@ -1890,7 +1890,7 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "product_id": str(product.id),
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
         }
 
@@ -1932,7 +1932,7 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "product_id": str(product.id),
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
         }
 
@@ -1975,7 +1975,7 @@ class OrderApiTest(BaseAPITestCase):
         billing_address = BillingAddressDictFactory()
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
             "billing_address": billing_address,
@@ -2117,7 +2117,7 @@ class OrderApiTest(BaseAPITestCase):
         billing_address = BillingAddressDictFactory()
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
             "billing_address": billing_address,
@@ -2190,7 +2190,7 @@ class OrderApiTest(BaseAPITestCase):
         billing_address = BillingAddressDictFactory()
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
             "billing_address": billing_address,
@@ -2241,7 +2241,7 @@ class OrderApiTest(BaseAPITestCase):
             order_group=order_group,
         )
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(relation.organizations.first().id),
             "order_group_id": str(order_group.id),
             "product_id": str(product.id),
@@ -2290,7 +2290,7 @@ class OrderApiTest(BaseAPITestCase):
             size=100, product=product, course=course, order_group=order_group
         )
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(relation.organizations.first().id),
             "order_group_id": str(order_group.id),
             "product_id": str(product.id),
@@ -2322,7 +2322,7 @@ class OrderApiTest(BaseAPITestCase):
         organization = product.course_relations.first().organizations.first()
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
         }
@@ -2358,7 +2358,7 @@ class OrderApiTest(BaseAPITestCase):
         organization = product.course_relations.first().organizations.first()
 
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(organization.id),
             "product_id": str(product.id),
         }
@@ -2405,7 +2405,7 @@ class OrderApiTest(BaseAPITestCase):
         models.OrderGroup.objects.create(course_product_relation=relation, nb_seats=1)
         billing_address = BillingAddressDictFactory()
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(relation.organizations.first().id),
             "product_id": str(product.id),
             "billing_address": billing_address,
@@ -2447,7 +2447,7 @@ class OrderApiTest(BaseAPITestCase):
         order_group = factories.OrderGroupFactory()
 
         data = {
-            "course": relation.course.code,
+            "course_code": relation.course.code,
             "order_group_id": str(order_group.id),
             "organization_id": str(organization.id),
             "product_id": str(relation.product.id),
@@ -2496,7 +2496,7 @@ class OrderApiTest(BaseAPITestCase):
             state=random.choice(["submitted", "validated"]),
         )
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(relation.organizations.first().id),
             "product_id": str(product.id),
             "billing_address": billing_address,
@@ -2550,7 +2550,7 @@ class OrderApiTest(BaseAPITestCase):
         )
         billing_address = BillingAddressDictFactory()
         data = {
-            "course": course.code,
+            "course_code": course.code,
             "organization_id": str(relation.organizations.first().id),
             "product_id": str(product.id),
             "billing_address": billing_address,
@@ -2954,7 +2954,7 @@ class OrderApiTest(BaseAPITestCase):
         data = {
             "organization_id": str(organization.id),
             "product_id": str(product.id),
-            "course": course.code,
+            "course_code": course.code,
             "billing_address": billing_address,
         }
         response = self.client.post(

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -84,7 +84,7 @@ class OrderApiTest(BaseAPITestCase):
                 "previous": None,
                 "results": [
                     {
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": {
                             "code": course.code,
@@ -97,11 +97,11 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollment": None,
                         "id": str(order.id),
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                         "target_enrollments": [],
@@ -130,7 +130,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(other_order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": {
                             "code": other_order.course.code,
@@ -143,13 +143,13 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(other_order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(other_order.organization.id),
                         "owner": other_order.owner.username,
                         "total": float(other_order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(other_order.product.id),
+                        "product_id": str(other_order.product.id),
                         "state": other_order.state,
                         "target_courses": [],
                     }
@@ -235,7 +235,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": {
                             "code": order.course.code,
@@ -248,13 +248,13 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
                         "total": float(order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                     }
@@ -329,7 +329,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": None,
                         "created_on": order.created_on.strftime(
@@ -397,13 +397,13 @@ class OrderApiTest(BaseAPITestCase):
                             "was_created_by_order": enrollment_1.was_created_by_order,
                         },
                         "target_enrollments": [],
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
                         "total": float(order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                     }
@@ -465,7 +465,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": {
                             "code": order.course.code,
@@ -478,13 +478,13 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
                         "total": float(order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                     }
@@ -538,7 +538,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": None,
                         "created_on": order.created_on.strftime(
@@ -595,13 +595,13 @@ class OrderApiTest(BaseAPITestCase):
                             "state": enrollment.state,
                             "was_created_by_order": enrollment.was_created_by_order,
                         },
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
                         "total": float(order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                         "target_enrollments": [],
@@ -771,7 +771,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": {
                             "code": order.course.code,
@@ -784,13 +784,13 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
                         "total": float(order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                     }
@@ -833,7 +833,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": {
                             "code": order.course.code,
@@ -846,13 +846,13 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
                         "total": float(order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                     }
@@ -899,7 +899,7 @@ class OrderApiTest(BaseAPITestCase):
                 "results": [
                     {
                         "id": str(order.id),
-                        "certificate": None,
+                        "certificate_id": None,
                         "contract": None,
                         "course": {
                             "code": order.course.code,
@@ -912,13 +912,13 @@ class OrderApiTest(BaseAPITestCase):
                         ),
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice": None,
-                        "order_group": None,
-                        "organization": str(order.organization.id),
+                        "main_invoice_reference": None,
+                        "order_group_id": None,
+                        "organization_id": str(order.organization.id),
                         "owner": order.owner.username,
                         "total": float(order.total),
                         "total_currency": settings.DEFAULT_CURRENCY,
-                        "product": str(order.product.id),
+                        "product_id": str(order.product.id),
                         "state": order.state,
                         "target_courses": [],
                     }
@@ -1060,7 +1060,7 @@ class OrderApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(order.id),
-                "certificate": None,
+                "certificate_id": None,
                 "contract": None,
                 "course": {
                     "code": order.course.code,
@@ -1071,13 +1071,13 @@ class OrderApiTest(BaseAPITestCase):
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "enrollment": None,
                 "state": order.state,
-                "main_invoice": None,
-                "order_group": None,
-                "organization": str(order.organization.id),
+                "main_invoice_reference": None,
+                "order_group_id": None,
+                "organization_id": str(order.organization.id),
                 "owner": owner.username,
                 "total": float(product.price),
                 "total_currency": settings.DEFAULT_CURRENCY,
-                "product": str(product.id),
+                "product_id": str(product.id),
                 "target_enrollments": [],
                 "target_courses": [
                     {
@@ -1178,8 +1178,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
 
@@ -1198,7 +1198,7 @@ class OrderApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(order.id),
-                "certificate": None,
+                "certificate_id": None,
                 "contract": None,
                 "course": {
                     "code": course.code,
@@ -1208,11 +1208,11 @@ class OrderApiTest(BaseAPITestCase):
                 },
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "enrollment": None,
-                "main_invoice": None,
-                "order_group": None,
-                "organization": str(order.organization.id),
+                "main_invoice_reference": None,
+                "order_group_id": None,
+                "organization_id": str(order.organization.id),
                 "owner": "panoramix",
-                "product": str(product.id),
+                "product_id": str(product.id),
                 "state": "draft",
                 "total": float(product.price),
                 "total_currency": settings.DEFAULT_CURRENCY,
@@ -1303,8 +1303,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "enrollment_id": str(enrollment.id),
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
         token = self.generate_token_from_user(enrollment.user)
 
@@ -1330,7 +1330,7 @@ class OrderApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(order.id),
-                "certificate": None,
+                "certificate_id": None,
                 "contract": None,
                 "course": None,
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
@@ -1381,11 +1381,11 @@ class OrderApiTest(BaseAPITestCase):
                     "state": enrollment.state,
                     "was_created_by_order": enrollment.was_created_by_order,
                 },
-                "main_invoice": None,
-                "order_group": None,
-                "organization": str(order.organization.id),
+                "main_invoice_reference": None,
+                "order_group_id": None,
+                "organization_id": str(order.organization.id),
                 "owner": enrollment.user.username,
-                "product": str(product.id),
+                "product_id": str(product.id),
                 "state": "draft",
                 "total": float(product.price),
                 "total_currency": settings.DEFAULT_CURRENCY,
@@ -1404,8 +1404,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "enrollment_id": uuid.uuid4(),
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
         token = self.generate_token_from_user(enrollment.user)
 
@@ -1446,8 +1446,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "enrollment_id": str(enrollment.id),
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
 
@@ -1485,7 +1485,7 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "product": str(product.id),
+            "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
 
@@ -1526,7 +1526,7 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "product": str(product.id),
+            "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
 
@@ -1594,7 +1594,7 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "product": str(product.id),
+            "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
 
@@ -1639,8 +1639,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
             "id": uuid.uuid4(),
             "amount": 0.00,
         }
@@ -1672,7 +1672,7 @@ class OrderApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(order.id),
-                "certificate": None,
+                "certificate_id": None,
                 "contract": None,
                 "course": {
                     "code": course.code,
@@ -1682,11 +1682,11 @@ class OrderApiTest(BaseAPITestCase):
                 },
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "enrollment": None,
-                "main_invoice": None,
-                "order_group": None,
-                "organization": str(order.organization.id),
+                "main_invoice_reference": None,
+                "order_group_id": None,
+                "organization_id": str(order.organization.id),
                 "owner": "panoramix",
-                "product": str(product.id),
+                "product_id": str(product.id),
                 "target_enrollments": [],
                 "state": "validated",
                 "target_courses": [
@@ -1755,8 +1755,8 @@ class OrderApiTest(BaseAPITestCase):
         course = factories.CourseFactory(title="mathématiques")
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
 
@@ -1803,8 +1803,8 @@ class OrderApiTest(BaseAPITestCase):
         )
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
         token = self.get_user_token("panoramix")
 
@@ -1854,7 +1854,7 @@ class OrderApiTest(BaseAPITestCase):
         self.assertDictEqual(
             response.json(),
             {
-                "product": ["This field is required."],
+                "product_id": ["This field is required."],
             },
         )
 
@@ -1863,7 +1863,7 @@ class OrderApiTest(BaseAPITestCase):
             "/api/v1.0/orders/",
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
-            data={"product": str(product.id)},
+            data={"product_id": str(product.id)},
         )
 
         self.assertEqual(response.status_code, 400)
@@ -1889,9 +1889,9 @@ class OrderApiTest(BaseAPITestCase):
         order = factories.OrderFactory(owner=user, course=course, product=product)
 
         data = {
-            "product": str(product.id),
+            "product_id": str(product.id),
             "course": course.code,
-            "organization": str(organization.id),
+            "organization_id": str(organization.id),
         }
 
         response = self.client.post(
@@ -1931,9 +1931,9 @@ class OrderApiTest(BaseAPITestCase):
         organization = product.course_relations.first().organizations.first()
 
         data = {
-            "product": str(product.id),
+            "product_id": str(product.id),
             "course": course.code,
-            "organization": str(organization.id),
+            "organization_id": str(organization.id),
         }
 
         response = self.client.post(
@@ -1976,8 +1976,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
         }
 
@@ -1997,7 +1997,7 @@ class OrderApiTest(BaseAPITestCase):
             response.json(),
             {
                 "id": str(order.id),
-                "certificate": None,
+                "certificate_id": None,
                 "contract": None,
                 "course": {
                     "code": course.code,
@@ -2007,11 +2007,11 @@ class OrderApiTest(BaseAPITestCase):
                 },
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "enrollment": None,
-                "main_invoice": None,
-                "order_group": None,
-                "organization": str(order.organization.id),
+                "main_invoice_reference": None,
+                "order_group_id": None,
+                "organization_id": str(order.organization.id),
                 "owner": user.username,
-                "product": str(product.id),
+                "product_id": str(product.id),
                 "total": float(product.price),
                 "total_currency": settings.DEFAULT_CURRENCY,
                 "state": "draft",
@@ -2019,7 +2019,7 @@ class OrderApiTest(BaseAPITestCase):
                 "target_courses": [
                     {
                         "code": target_course.code,
-                        "organization": {
+                        "organization_id": {
                             "code": target_course.organization.code,
                             "title": target_course.organization.title,
                         },
@@ -2118,8 +2118,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
             "credit_card_id": str(credit_card.id),
         }
@@ -2135,7 +2135,7 @@ class OrderApiTest(BaseAPITestCase):
         order = models.Order.objects.get(product=product, course=course, owner=user)
         expected_json = {
             "id": str(order.id),
-            "certificate": None,
+            "certificate_id": None,
             "contract": None,
             "course": {
                 "code": course.code,
@@ -2145,11 +2145,11 @@ class OrderApiTest(BaseAPITestCase):
             },
             "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             "enrollment": None,
-            "main_invoice": None,
-            "order_group": None,
-            "organization": str(order.organization.id),
+            "main_invoice_reference": None,
+            "order_group_id": None,
+            "organization_id": str(order.organization.id),
             "owner": user.username,
-            "product": str(product.id),
+            "product_id": str(product.id),
             "total": float(product.price),
             "total_currency": settings.DEFAULT_CURRENCY,
             "state": "draft",
@@ -2191,8 +2191,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
         }
 
@@ -2242,9 +2242,9 @@ class OrderApiTest(BaseAPITestCase):
         )
         data = {
             "course": course.code,
-            "organization": str(relation.organizations.first().id),
-            "order_group": str(order_group.id),
-            "product": str(product.id),
+            "organization_id": str(relation.organizations.first().id),
+            "order_group_id": str(order_group.id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
         }
         token = self.generate_token_from_user(user)
@@ -2291,9 +2291,9 @@ class OrderApiTest(BaseAPITestCase):
         )
         data = {
             "course": course.code,
-            "organization": str(relation.organizations.first().id),
-            "order_group": str(order_group.id),
-            "product": str(product.id),
+            "organization_id": str(relation.organizations.first().id),
+            "order_group_id": str(order_group.id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
         }
         token = self.generate_token_from_user(user)
@@ -2323,8 +2323,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
         response = self.client.post(
             "/api/v1.0/orders/",
@@ -2359,8 +2359,8 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": course.code,
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
         }
 
         response = self.client.post(
@@ -2406,8 +2406,8 @@ class OrderApiTest(BaseAPITestCase):
         billing_address = BillingAddressDictFactory()
         data = {
             "course": course.code,
-            "organization": str(relation.organizations.first().id),
-            "product": str(product.id),
+            "organization_id": str(relation.organizations.first().id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
         }
         token = self.generate_token_from_user(user)
@@ -2448,9 +2448,9 @@ class OrderApiTest(BaseAPITestCase):
 
         data = {
             "course": relation.course.code,
-            "order_group": str(order_group.id),
-            "organization": str(organization.id),
-            "product": str(relation.product.id),
+            "order_group_id": str(order_group.id),
+            "organization_id": str(organization.id),
+            "product_id": str(relation.product.id),
             "billing_address": billing_address,
         }
 
@@ -2497,8 +2497,8 @@ class OrderApiTest(BaseAPITestCase):
         )
         data = {
             "course": course.code,
-            "organization": str(relation.organizations.first().id),
-            "product": str(product.id),
+            "organization_id": str(relation.organizations.first().id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
         }
         token = self.generate_token_from_user(user)
@@ -2506,7 +2506,7 @@ class OrderApiTest(BaseAPITestCase):
         # Order group 1 should already be full
         response = self.client.post(
             "/api/v1.0/orders/",
-            data={"order_group": str(order_group1.id), **data},
+            data={"order_group_id": str(order_group1.id), **data},
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -2526,7 +2526,7 @@ class OrderApiTest(BaseAPITestCase):
         # Order group 2 should still have place
         response = self.client.post(
             "/api/v1.0/orders/",
-            data={"order_group": str(order_group2.id), **data},
+            data={"order_group_id": str(order_group2.id), **data},
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
@@ -2551,8 +2551,8 @@ class OrderApiTest(BaseAPITestCase):
         billing_address = BillingAddressDictFactory()
         data = {
             "course": course.code,
-            "organization": str(relation.organizations.first().id),
-            "product": str(product.id),
+            "organization_id": str(relation.organizations.first().id),
+            "product_id": str(product.id),
             "billing_address": billing_address,
         }
         token = self.generate_token_from_user(user)
@@ -2602,17 +2602,17 @@ class OrderApiTest(BaseAPITestCase):
         self.assertListEqual(
             list(data.keys()),
             [
-                "certificate",
+                "certificate_id",
                 "contract",
                 "course",
                 "created_on",
                 "enrollment",
                 "id",
-                "main_invoice",
-                "order_group",
-                "organization",
+                "main_invoice_reference",
+                "order_group_id",
+                "organization_id",
                 "owner",
-                "product",
+                "product_id",
                 "state",
                 "target_courses",
                 "target_enrollments",
@@ -2952,8 +2952,8 @@ class OrderApiTest(BaseAPITestCase):
         # - Create an order and its related payment
         token = self.generate_token_from_user(user)
         data = {
-            "organization": str(organization.id),
-            "product": str(product.id),
+            "organization_id": str(organization.id),
+            "product_id": str(product.id),
             "course": course.code,
             "billing_address": billing_address,
         }

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -2081,7 +2081,7 @@ class OrderApiTest(BaseAPITestCase):
             {
                 "payment_info": {
                     "payment_id": f"pay_{order.id}",
-                    "provider": "dummy",
+                    "provider_name": "dummy",
                     "url": "http://testserver/api/v1.0/payments/notifications",
                 }
             },
@@ -2169,7 +2169,7 @@ class OrderApiTest(BaseAPITestCase):
         expected_json = {
             "payment_info": {
                 "payment_id": f"pay_{order.id}",
-                "provider": "dummy",
+                "provider_name": "dummy",
                 "url": "http://testserver/api/v1.0/payments/notifications",
                 "is_paid": True,
             },

--- a/src/backend/joanie/tests/core/test_api_organization_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_organization_accesses.py
@@ -358,7 +358,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content,
                 {
                     "id": str(access.id),
-                    "user": str(access.user.id),
+                    "user_id": str(access.user.id),
                     "role": access.role,
                 },
             )
@@ -390,7 +390,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content,
                 {
                     "id": str(access.id),
-                    "user": str(access.user.id),
+                    "user_id": str(access.user.id),
                     "role": access.role,
                 },
             )
@@ -423,7 +423,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 {
                     "id": str(access.id),
                     "role": access.role,
-                    "user": str(access.user.id),
+                    "user_id": str(access.user.id),
                 },
             )
 
@@ -476,7 +476,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": random.choice(["member", "administrator", "owner"]),
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -505,7 +505,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": random.choice(["member", "administrator", "owner"]),
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -536,7 +536,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": random.choice(["member", "administrator"]),
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -558,7 +558,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             {
-                "user": str(other_user.id),
+                "user_id": str(other_user.id),
                 "role": "owner",
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
@@ -581,7 +581,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             response = self.client.post(
                 f"/api/v1.0/organizations/{organization.id!s}/accesses/",
                 {
-                    "user": str(other_user.id),
+                    "user_id": str(other_user.id),
                     "role": role,
                 },
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",

--- a/src/backend/joanie/tests/core/test_api_organization_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_organization_accesses.py
@@ -456,7 +456,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             {
-                "user": str(user.id),
+                "user_id": str(user.id),
                 "role": random.choice(["member", "administrator", "owner"]),
             },
         )
@@ -600,8 +600,8 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory().id,
-            "user": factories.UserFactory().id,
+            "organization_id": factories.OrganizationFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -626,8 +626,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(users=[(user, "member")]).id,
-            "user": factories.UserFactory().id,
+            "organization_id": factories.OrganizationFactory(
+                users=[(user, "member")]
+            ).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -657,8 +659,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(users=[(user, "member")]).id,
-            "user": factories.UserFactory().id,
+            "organization_id": factories.OrganizationFactory(
+                users=[(user, "member")]
+            ).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -690,10 +694,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(["member", "administrator"]),
         }
 
@@ -738,10 +742,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -775,10 +779,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": "owner",
         }
 
@@ -816,10 +820,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -865,10 +869,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
         for field, value in new_values.items():
@@ -931,8 +935,8 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory().id,
-            "user": factories.UserFactory().id,
+            "organization_id": factories.OrganizationFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -957,8 +961,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(users=[(user, "member")]).id,
-            "user": factories.UserFactory().id,
+            "organization_id": factories.OrganizationFactory(
+                users=[(user, "member")]
+            ).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -988,8 +994,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(users=[(user, "member")]).id,
-            "user": factories.UserFactory().id,
+            "organization_id": factories.OrganizationFactory(
+                users=[(user, "member")]
+            ).id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -1021,10 +1029,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(["member", "administrator"]),
         }
 
@@ -1067,10 +1075,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -1104,10 +1112,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": "owner",
         }
 
@@ -1142,10 +1150,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
 
@@ -1189,10 +1197,10 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
         new_values = {
             "id": uuid4(),
-            "organization": factories.OrganizationFactory(
+            "organization_id": factories.OrganizationFactory(
                 users=[(user, "administrator")]
             ).id,
-            "user": factories.UserFactory().id,
+            "user_id": factories.UserFactory().id,
             "role": random.choice(OrganizationAccess.ROLE_CHOICES)[0],
         }
         for field, value in new_values.items():

--- a/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
@@ -219,8 +219,8 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/course-product-relations/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "course": str(course.id),
-                "product": str(product.id),
+                "course_id": str(course.id),
+                "product_id": str(product.id),
             },
         )
 
@@ -239,8 +239,8 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.post(
             f"/api/v1.0/organizations/{organization.id}/course-product-relations/",
             data={
-                "course": str(course.id),
-                "product": str(product.id),
+                "course_id": str(course.id),
+                "product_id": str(product.id),
             },
         )
 
@@ -265,8 +265,8 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/course-product-relations/{relation.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "course": "notacourseid",
-                "product": str(product.id),
+                "course_id": "notacourseid",
+                "product_id": str(product.id),
             },
         )
 
@@ -290,8 +290,8 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.put(
             f"/api/v1.0/organizations/{organization.id}/course-product-relations/{relation.id}/",
             data={
-                "course": "notacourseid",
-                "product": str(product.id),
+                "course_id": "notacourseid",
+                "product_id": str(product.id),
             },
         )
 
@@ -317,7 +317,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/course-product-relations/{relation.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={
-                "course": "notacourseid",
+                "course_id": "notacourseid",
             },
         )
 
@@ -341,7 +341,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.patch(
             f"/api/v1.0/organizations/{organization.id}/course-product-relations/{relation.id}/",
             data={
-                "course": "notacourseid",
+                "course_id": "notacourseid",
             },
         )
 

--- a/src/backend/joanie/tests/core/test_serializers_course_access.py
+++ b/src/backend/joanie/tests/core/test_serializers_course_access.py
@@ -18,7 +18,7 @@ class CourseAccessSerializerTestCase(TestCase):
         user = factories.UserFactory()
 
         data = {
-            "user": str(user.id),
+            "user_id": str(user.id),
             "role": random.choice(models.CourseAccess.ROLE_CHOICES)[0],
         }
         serializer = serializers.CourseAccessSerializer(data=data)
@@ -42,7 +42,7 @@ class CourseAccessSerializerTestCase(TestCase):
         course = factories.CourseFactory()
 
         data = {
-            "user": str(user.id),
+            "user_id": str(user.id),
             "role": random.choice(models.CourseAccess.ROLE_CHOICES)[0],
         }
         serializer = serializers.CourseAccessSerializer(

--- a/src/backend/joanie/tests/core/test_serializers_organization_access.py
+++ b/src/backend/joanie/tests/core/test_serializers_organization_access.py
@@ -19,7 +19,7 @@ class OrganizationAccessSerializerTestCase(TestCase):
         user = factories.UserFactory()
 
         data = {
-            "user": str(user.id),
+            "user_id": str(user.id),
             "role": random.choice(models.OrganizationAccess.ROLE_CHOICES)[0],
         }
         serializer = serializers.OrganizationAccessSerializer(data=data)
@@ -40,7 +40,7 @@ class OrganizationAccessSerializerTestCase(TestCase):
         organization = factories.OrganizationFactory()
 
         data = {
-            "user": str(user.id),
+            "user_id": str(user.id),
             "role": random.choice(models.OrganizationAccess.ROLE_CHOICES)[0],
         }
         serializer = serializers.OrganizationAccessSerializer(

--- a/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
+++ b/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
@@ -62,7 +62,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):
         self.assertEqual(
             payment_payload,
             {
-                "provider": "dummy",
+                "provider_name": "dummy",
                 "payment_id": payment_id,
                 "url": "http://testserver/api/v1.0/payments/notifications",
             },
@@ -121,7 +121,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):
         self.assertEqual(
             payment_payload,
             {
-                "provider": "dummy",
+                "provider_name": "dummy",
                 "payment_id": payment_id,
                 "url": "http://testserver/api/v1.0/payments/notifications",
                 "is_paid": True,

--- a/src/backend/joanie/tests/payment/test_backend_payplug.py
+++ b/src/backend/joanie/tests/payment/test_backend_payplug.py
@@ -146,7 +146,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
             }
         )
         self.assertEqual(len(payload), 3)
-        self.assertEqual(payload["provider"], "payplug")
+        self.assertEqual(payload["provider_name"], "payplug")
         self.assertIsNotNone(re.fullmatch(r"pay_\d{5}", payload["payment_id"]))
         self.assertIsNotNone(payload["url"])
 
@@ -171,7 +171,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
         mock_backend_create_payment.return_value = {
             "order_id": str(order.id),
             "payment_id": "pay_00001",
-            "provider": "payplug",
+            "provider_name": "payplug",
             "url": "https://payplug.test/00001",
         }
 
@@ -211,7 +211,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
             {
                 "order_id": str(order.id),
                 "payment_id": "pay_00001",
-                "provider": "payplug",
+                "provider_name": "payplug",
                 "url": "https://payplug.test/00001",
             },
         )
@@ -263,7 +263,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
         )
 
         self.assertEqual(len(payload), 4)
-        self.assertEqual(payload["provider"], "payplug")
+        self.assertEqual(payload["provider_name"], "payplug")
         self.assertIsNotNone(re.fullmatch(r"pay_\d{5}", payload["payment_id"]))
         self.assertIsNotNone(payload["url"])
         self.assertFalse(payload["is_paid"])
@@ -315,7 +315,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
         )
 
         self.assertEqual(len(payload), 4)
-        self.assertEqual(payload["provider"], "payplug")
+        self.assertEqual(payload["provider_name"], "payplug")
         self.assertIsNotNone(re.fullmatch(r"pay_\d{5}", payload["payment_id"]))
         self.assertIsNotNone(payload["url"])
         self.assertTrue(payload["is_paid"])


### PR DESCRIPTION
## Purpose

Some serializer attribute name are misleading.
ie: if product attribute contains only a product id, it should be renamed to product_id


## Proposal

Rename serializers attributes to be more descriptive:

- [x] EnrollmentSerializer
- [x] OrderSerializer
- [x] OrderLightSerializer
- [x] CourseSerializer