### PR TITLE
✅(backend) fix flaky test

### DIFF
--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -7,7 +7,6 @@ from pdfminer.high_level import extract_text as pdf_extract_text
 from rest_framework.pagination import PageNumberPagination
 
 from joanie.core import enums, factories
-from joanie.core.models import CourseState
 from joanie.core.serializers import fields
 from joanie.tests.base import BaseAPITestCase
 
@@ -43,10 +42,7 @@ class CertificateApiTest(BaseAPITestCase):
         order = factories.OrderFactory(owner=user, product=factories.ProductFactory())
         certificate = factories.OrderCertificateFactory(order=order)
 
-        enrollment = factories.EnrollmentFactory(
-            user=user,
-            course_run__state=CourseState.ONGOING_OPEN,
-        )
+        enrollment = factories.EnrollmentFactory(user=user)
         factories.EnrollmentCertificateFactory(enrollment=enrollment)
         other_order = factories.OrderFactory(
             owner=user,
@@ -98,23 +94,31 @@ class CertificateApiTest(BaseAPITestCase):
                                     },
                                     "end": enrollment.course_run.end.isoformat().replace(
                                         "+00:00", "Z"
-                                    ),
+                                    )
+                                    if enrollment.course_run.end
+                                    else None,
                                     "enrollment_end": (
                                         enrollment.course_run.enrollment_end.isoformat().replace(
                                             "+00:00", "Z"
                                         )
+                                        if enrollment.course_run.enrollment_end
+                                        else None
                                     ),
                                     "enrollment_start": (
                                         enrollment.course_run.enrollment_start.isoformat().replace(
                                             "+00:00", "Z"
                                         )
+                                        if enrollment.course_run.enrollment_start
+                                        else None
                                     ),
                                     "id": str(enrollment.course_run.id),
                                     "languages": enrollment.course_run.languages,
                                     "resource_link": enrollment.course_run.resource_link,
                                     "start": enrollment.course_run.start.isoformat().replace(
                                         "+00:00", "Z"
-                                    ),
+                                    )
+                                    if enrollment.course_run.start
+                                    else None,
                                     "state": {
                                         "call_to_action": enrollment.course_run.state.get(
                                             "call_to_action"

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -343,23 +343,31 @@ class OrderApiTest(BaseAPITestCase):
                                 },
                                 "end": enrollment_1.course_run.end.isoformat().replace(
                                     "+00:00", "Z"
-                                ),
+                                )
+                                if enrollment_1.course_run.end
+                                else None,
                                 "enrollment_end": (
                                     enrollment_1.course_run.enrollment_end.isoformat().replace(
                                         "+00:00", "Z"
                                     )
-                                ),
+                                )
+                                if enrollment_1.course_run.enrollment_end
+                                else None,
                                 "enrollment_start": (
                                     enrollment_1.course_run.enrollment_start.isoformat().replace(
                                         "+00:00", "Z"
                                     )
-                                ),
+                                )
+                                if enrollment_1.course_run.enrollment_start
+                                else None,
                                 "id": str(enrollment_1.course_run.id),
                                 "languages": enrollment_1.course_run.languages,
                                 "resource_link": enrollment_1.course_run.resource_link,
                                 "start": enrollment_1.course_run.start.isoformat().replace(
                                     "+00:00", "Z"
-                                ),
+                                )
+                                if enrollment_1.course_run.start
+                                else None,
                                 "state": {
                                     "call_to_action": enrollment_1.course_run.state.get(
                                         "call_to_action"
@@ -1383,7 +1391,6 @@ class OrderApiTest(BaseAPITestCase):
     def test_api_order_create_authenticated_for_enrollment_invalid(self):
         """The enrollment id passed in payload to create an order should exist."""
         enrollment = factories.EnrollmentFactory(
-            course_run__state=models.CourseState.ONGOING_OPEN,
             course_run__is_listed=True,
         )
         product = factories.ProductFactory(price=0.00, type="certificate")


### PR DESCRIPTION
## Purpose

A test using EnrollmentLightSerializer was flaky because of a random course run state which caused some date to be randomly null, and so fails the test.



## Proposal

Conditionally test for dates.