### PR TITLE
✨(backend/admin) add contract_definition field into product change view

### DIFF
--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -379,6 +379,7 @@ class ProductAdmin(
                     "call_to_action",
                     "price",
                     "certificate_definition",
+                    "contract_definition",
                     "related_courses",
                 )
             },


### PR DESCRIPTION
## Purpose

Currently this is not possible to update contract_definition from an existing product. So we add the missing `contract_definition` to the ProductAdmin view


## Proposal

- [x] Add the missing `contract_definition` to the ProductAdmin view
