### PR TITLE
Fix flacky backend test

### DIFF
--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -127,7 +127,9 @@ class CertificateApiTest(BaseAPITestCase):
                                             "datetime"
                                         )
                                         .isoformat()
-                                        .replace("+00:00", "Z"),
+                                        .replace("+00:00", "Z")
+                                        if enrollment.course_run.state.get("datetime")
+                                        else None,
                                         "priority": enrollment.course_run.state.get(
                                             "priority"
                                         ),

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -376,7 +376,9 @@ class OrderApiTest(BaseAPITestCase):
                                         "datetime"
                                     )
                                     .isoformat()
-                                    .replace("+00:00", "Z"),
+                                    .replace("+00:00", "Z")
+                                    if enrollment_1.course_run.state.get("datetime")
+                                    else None,
                                     "priority": enrollment_1.course_run.state.get(
                                         "priority"
                                     ),


### PR DESCRIPTION
## Purpose

A test using EnrollmentLightSerializer was flaky because of a random course run state which caused some date to be randomly null, and so fails the test.


## Proposal

Conditionally test for dates.
