### PR TITLE
✨(backend) update admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to
 - Add some objects to demo-dev command. A credit card, a billing address and
   one order of each state. Also add some order target courses.
 - Add markdown editor inside the BO
+- Add admin endpoint to manage course product relations
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to
   - OrderViewSetFilter
   - ProductViewSetFilter
   - EnrollmentViewSetFilter
+- Update admin course serializer to return course runs
 
 ### Removed
 

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -311,6 +311,20 @@ class ContractDefinitionViewSet(viewsets.ModelViewSet):
     queryset = models.ContractDefinition.objects.all()
 
 
+class CourseProductRelationViewSet(viewsets.ModelViewSet):
+    """
+    CourseProductRelation ViewSet
+    """
+
+    authentication_classes = [SessionAuthenticationWithAuthenticateHeader]
+    permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
+    serializer_class = serializers.AdminCourseProductRelationsSerializer
+    queryset = models.CourseProductRelation.objects.all().select_related(
+        "course", "product"
+    )
+    ordering = "created_on"
+
+
 class NestedCourseProductRelationOrderGroupViewSet(
     mixins.CreateModelMixin,
     mixins.UpdateModelMixin,

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -309,6 +309,8 @@ class ContractDefinitionViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
     serializer_class = serializers.AdminContractDefinitionSerializer
     queryset = models.ContractDefinition.objects.all()
+    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
+    filterset_class = filters.ContractDefinitionAdminFilterSet
 
 
 class CourseProductRelationViewSet(viewsets.ModelViewSet):

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -243,12 +243,12 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         """
         Compute a random set of languages from the complete list of Django supported languages.
         """
-        return [
+        return {
             language[0]
             for language in random.sample(
                 enums.ALL_LANGUAGES, random.randint(1, 5)  # nosec
             )
-        ]
+        }
 
     @factory.lazy_attribute_sequence
     def resource_link(self, sequence):

--- a/src/backend/joanie/core/filters/admin.py
+++ b/src/backend/joanie/core/filters/admin.py
@@ -168,6 +168,27 @@ class CertificateDefinitionAdminFilterSet(filters.FilterSet):
         ).distinct()
 
 
+class ContractDefinitionAdminFilterSet(filters.FilterSet):
+    """
+    ContractDefinitionAdminFilter allows to filter this resource with a query
+    for name and title.
+    """
+
+    class Meta:
+        model = models.ContractDefinition
+        fields: List[str] = ["query"]
+
+    query = filters.CharFilter(method="filter_by_query")
+
+    def filter_by_query(self, queryset, _name, value):
+        """
+        Filter resource by looking for title which contains provided value in
+        "query" query parameter.
+        """
+
+        return queryset.filter(title__icontains=value).distinct()
+
+
 class UserAdminFilterSet(filters.FilterSet):
     """
     UserAdminFilter allows to filter this resource with a query for username,

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from datetime import MAXYEAR, datetime
 from datetime import timezone as tz
 
+from django.apps import apps
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.cache import cache
@@ -603,6 +604,14 @@ class CourseProductRelation(BaseModel):
         )
 
         return f"https://{site.domain:s}{resource_path:s}"
+
+    @property
+    def can_edit(self):
+        """Return True if the relation can be edited, False otherwise."""
+        Order = apps.get_model("core", "Order")  # pylint: disable=invalid-name
+        return not Order.objects.filter(
+            product=self.product, course=self.course
+        ).exists()
 
 
 class CourseRun(parler_models.TranslatableModel, BaseModel):

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -355,6 +355,11 @@ class OrderGroup(BaseModel):
             state__in=enums.BINDING_ORDER_STATES,
         ).count()
 
+    @property
+    def can_edit(self):
+        """Return True if the order group can be edited."""
+        return not self.orders.exists()
+
 
 class Order(BaseModel):
     """

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -309,11 +309,12 @@ class AdminProductRelationSerializer(serializers.ModelSerializer):
         model = models.CourseProductRelation
         fields = (
             "id",
+            "can_edit",
             "product",
             "order_groups",
             "organizations",
         )
-        read_only_fields = ["id", "order_groups"]
+        read_only_fields = ["id", "can_edit", "order_groups"]
 
 
 class AdminCourseAccessSerializer(serializers.ModelSerializer):
@@ -657,6 +658,7 @@ class AdminCourseRelationsSerializer(serializers.ModelSerializer):
         model = models.CourseProductRelation
         fields = [
             "id",
+            "can_edit",
             "course",
             "organizations",
             "order_groups",

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -108,6 +108,15 @@ class AdminUserCompleteSerializer(serializers.ModelSerializer):
         return {}
 
 
+class AdminOrganizationLightSerializer(serializers.ModelSerializer):
+    """Read-only light Serializer for Organization model."""
+
+    class Meta:
+        model = models.Organization
+        fields = ("code", "title", "id")
+        read_only_fields = ("code", "title", "id")
+
+
 class AdminOrganizationAccessSerializer(serializers.ModelSerializer):
     """Serializer for OrganizationAccess model."""
 
@@ -176,15 +185,6 @@ class AdminOrganizationSerializer(serializers.ModelSerializer):
             "accesses",
             "id",
         )
-
-
-class AdminOrganizationLightSerializer(serializers.ModelSerializer):
-    """Read-only light Serializer for Organization model."""
-
-    class Meta:
-        model = models.Organization
-        fields = ("code", "title", "id")
-        read_only_fields = ("code", "title", "id")
 
 
 class AdminProductSerializer(serializers.ModelSerializer):
@@ -297,6 +297,47 @@ class AdminOrderGroupCreateSerializer(AdminOrderGroupSerializer):
 
     class Meta(AdminOrderGroupSerializer.Meta):
         fields = [*AdminOrderGroupSerializer.Meta.fields, "course_product_relation"]
+
+
+class AdminCourseNestedSerializer(serializers.ModelSerializer):
+    """Serializer for Course model nested in product."""
+
+    title = serializers.CharField()
+    cover = ThumbnailDetailField(required=False)
+    organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = models.Course
+        fields = (
+            "id",
+            "code",
+            "cover",
+            "title",
+            "organizations",
+            "state",
+        )
+        read_only_fields = ["id", "state"]
+
+
+class AdminCourseRelationsSerializer(serializers.ModelSerializer):
+    """
+    Serialize all information about a course relation nested in a product.
+    """
+
+    course = AdminCourseNestedSerializer(read_only=True)
+    organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
+    order_groups = AdminOrderGroupSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = models.CourseProductRelation
+        fields = [
+            "id",
+            "can_edit",
+            "course",
+            "organizations",
+            "order_groups",
+        ]
+        read_only_fields = fields
 
 
 class AdminProductRelationSerializer(serializers.ModelSerializer):
@@ -624,47 +665,6 @@ class AdminProductTargetCourseRelationSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         serializer = AdminProductTargetCourseRelationDisplaySerializer(instance)
         return serializer.data
-
-
-class AdminCourseNestedSerializer(serializers.ModelSerializer):
-    """Serializer for Course model nested in product."""
-
-    title = serializers.CharField()
-    cover = ThumbnailDetailField(required=False)
-    organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = models.Course
-        fields = (
-            "id",
-            "code",
-            "cover",
-            "title",
-            "organizations",
-            "state",
-        )
-        read_only_fields = ["id", "state"]
-
-
-class AdminCourseRelationsSerializer(serializers.ModelSerializer):
-    """
-    Serialize all information about a course relation nested in a product.
-    """
-
-    course = AdminCourseNestedSerializer(read_only=True)
-    organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
-    order_groups = AdminOrderGroupSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = models.CourseProductRelation
-        fields = [
-            "id",
-            "can_edit",
-            "course",
-            "organizations",
-            "order_groups",
-        ]
-        read_only_fields = fields
 
 
 class AdminProductTargetCourseRelationNestedSerializer(serializers.ModelSerializer):

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -278,8 +278,9 @@ class AdminOrderGroupSerializer(serializers.ModelSerializer):
             "is_active",
             "nb_available_seats",
             "created_on",
+            "can_edit",
         ]
-        read_only_fields = ["id", "created_on"]
+        read_only_fields = ["id", "can_edit", "created_on"]
 
     def get_nb_available_seats(self, order_group):
         """Return the number of available seats for this order group."""

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -319,12 +319,13 @@ class AdminCourseNestedSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "state"]
 
 
-class AdminCourseRelationsSerializer(serializers.ModelSerializer):
+class AdminCourseProductRelationsSerializer(serializers.ModelSerializer):
     """
     Serialize all information about a course relation nested in a product.
     """
 
-    course = AdminCourseNestedSerializer(read_only=True)
+    course = AdminCourseNestedSerializer()
+    product = AdminProductSerializer()
     organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
     order_groups = AdminOrderGroupSerializer(many=True, read_only=True)
 
@@ -336,26 +337,34 @@ class AdminCourseRelationsSerializer(serializers.ModelSerializer):
             "course",
             "organizations",
             "order_groups",
+            "product",
+        ]
+        read_only_fields = ["id", "can_edit", "order_groups"]
+
+
+class AdminCourseRelationsSerializer(AdminCourseProductRelationsSerializer):
+    """
+    Serialize all information about a course relation nested in a product.
+    """
+
+    class Meta(AdminCourseProductRelationsSerializer.Meta):
+        fields = [
+            field
+            for field in AdminCourseProductRelationsSerializer.Meta.fields
+            if field != "product"
         ]
         read_only_fields = fields
 
 
-class AdminProductRelationSerializer(serializers.ModelSerializer):
+class AdminProductRelationSerializer(AdminCourseProductRelationsSerializer):
     """Serializer for CourseProductRelation model."""
 
-    organizations = AdminOrganizationLightSerializer(many=True)
-    product = AdminProductSerializer()
-    order_groups = AdminOrderGroupSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = models.CourseProductRelation
-        fields = (
-            "id",
-            "can_edit",
-            "product",
-            "order_groups",
-            "organizations",
-        )
+    class Meta(AdminCourseProductRelationsSerializer.Meta):
+        fields = [
+            field
+            for field in AdminCourseProductRelationsSerializer.Meta.fields
+            if field != "course"
+        ]
         read_only_fields = ["id", "can_edit", "order_groups"]
 
 

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -41,6 +41,29 @@ class AdminCourseLightSerializer(serializers.ModelSerializer):
         read_only_fields = ("code", "title", "id", "state")
 
 
+class AdminCourseRunLightSerializer(serializers.ModelSerializer):
+    """Serializer for CourseRun model."""
+
+    title = serializers.CharField()
+    languages = serializers.MultipleChoiceField(choices=ALL_LANGUAGES)
+
+    class Meta:
+        model = models.CourseRun
+        fields = [
+            "id",
+            "resource_link",
+            "title",
+            "is_gradable",
+            "is_listed",
+            "languages",
+            "start",
+            "end",
+            "enrollment_start",
+            "enrollment_end",
+        ]
+        read_only_fields = ["id"]
+
+
 class AdminUserSerializer(serializers.ModelSerializer):
     """Serializer for User model."""
 
@@ -340,6 +363,7 @@ class AdminCourseSerializer(serializers.ModelSerializer):
     organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
     product_relations = AdminProductRelationSerializer(many=True, read_only=True)
     accesses = AdminCourseAccessSerializer(many=True, read_only=True)
+    course_runs = AdminCourseRunLightSerializer(many=True, read_only=True)
 
     class Meta:
         model = models.Course
@@ -347,6 +371,7 @@ class AdminCourseSerializer(serializers.ModelSerializer):
             "accesses",
             "code",
             "cover",
+            "course_runs",
             "id",
             "organizations",
             "product_relations",
@@ -355,6 +380,7 @@ class AdminCourseSerializer(serializers.ModelSerializer):
         )
         read_only_fields = (
             "accesses",
+            "course_runs",
             "id",
             "state",
             "organizations",
@@ -636,29 +662,6 @@ class AdminCourseRelationsSerializer(serializers.ModelSerializer):
             "order_groups",
         ]
         read_only_fields = fields
-
-
-class AdminCourseRunLightSerializer(serializers.ModelSerializer):
-    """Serializer for CourseRun model."""
-
-    title = serializers.CharField()
-    languages = serializers.MultipleChoiceField(choices=ALL_LANGUAGES)
-
-    class Meta:
-        model = models.CourseRun
-        fields = [
-            "id",
-            "resource_link",
-            "title",
-            "is_gradable",
-            "is_listed",
-            "languages",
-            "start",
-            "end",
-            "enrollment_start",
-            "enrollment_end",
-        ]
-        read_only_fields = ["id"]
 
 
 class AdminProductTargetCourseRelationNestedSerializer(serializers.ModelSerializer):

--- a/src/backend/joanie/tests/core/api/admin/course-product-relations/test_create.py
+++ b/src/backend/joanie/tests/core/api/admin/course-product-relations/test_create.py
@@ -1,0 +1,438 @@
+"""
+Test suite for CourseProductRelation create Admin API.
+"""
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+from joanie.core import enums, factories, models
+from joanie.core.serializers import fields
+
+
+class CourseProductRelationCreateAdminApiTest(TestCase):
+    """
+    Test suite for CourseProductRelation create Admin API.
+    """
+
+    maxDiff = None
+
+    def test_admin_api_course_products_relation_create_anonymous(self):
+        """
+        Anonymous users should not be able to create a course product relation.
+        """
+        course = factories.CourseFactory()
+        product = factories.ProductFactory()
+        organization = factories.OrganizationFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/course-product-relations/",
+            {
+                "course_id": course.id,
+                "product_id": product.id,
+                "organization_id": organization.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertDictEqual(
+            response.json(), {"detail": "Authentication credentials were not provided."}
+        )
+
+    def test_admin_api_course_products_relation_create_authenticated(self):
+        """
+        Authenticated users should not be able to create a course product relation.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        course = factories.CourseFactory()
+        product = factories.ProductFactory()
+        organization = factories.OrganizationFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/course-product-relations/",
+            {
+                "course_id": course.id,
+                "product_id": product.id,
+                "organization_id": organization.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertDictEqual(
+            response.json(),
+            {"detail": "You do not have permission to perform this action."},
+        )
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_admin_api_course_products_relation_create_superuser(self, _):
+        """
+        Super admin user should be able to create a course product relation.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        product = factories.ProductFactory(
+            type=enums.PRODUCT_TYPE_CREDENTIAL, courses=[]
+        )
+        organization = factories.OrganizationFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/course-product-relations/",
+            {
+                "course_id": course.id,
+                "product_id": product.id,
+                "organization_id": organization.id,
+            },
+        )
+        self.assertEqual(response.status_code, 201)
+
+        relation = models.CourseProductRelation.objects.get(id=response.json()["id"])
+
+        self.assertDictEqual(
+            response.json(),
+            {
+                "id": str(relation.id),
+                "can_edit": relation.can_edit,
+                "course": {
+                    "code": course.code,
+                    "id": str(course.id),
+                    "cover": "_this_field_is_mocked",
+                    "title": course.title,
+                    "organizations": [],
+                    "state": {
+                        "priority": course.state["priority"],
+                        "datetime": course.state["datetime"]
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                        if course.state["datetime"]
+                        else None,
+                        "call_to_action": course.state["call_to_action"],
+                        "text": course.state["text"],
+                    },
+                },
+                "order_groups": [],
+                "product": {
+                    "id": str(product.id),
+                    "title": product.title,
+                    "description": product.description,
+                    "call_to_action": product.call_to_action,
+                    "price": float(product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
+                    "type": product.type,
+                    "certificate_definition": {
+                        "id": str(product.certificate_definition.id),
+                        "description": product.certificate_definition.description,
+                        "name": product.certificate_definition.name,
+                        "title": product.certificate_definition.title,
+                        "template": product.certificate_definition.template,
+                    },
+                    "target_courses": [
+                        {
+                            "code": target_course.code,
+                            "course_runs": [
+                                {
+                                    "id": course_run.id,
+                                    "title": course_run.title,
+                                    "resource_link": course_run.resource_link,
+                                    "state": {
+                                        "priority": course_run.state["priority"],
+                                        "datetime": course_run.state["datetime"]
+                                        .isoformat()
+                                        .replace("+00:00", "Z"),
+                                        "call_to_action": course_run.state[
+                                            "call_to_action"
+                                        ],
+                                        "text": course_run.state["text"],
+                                    },
+                                    "start": course_run.start.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "end": course_run.end.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_start": (
+                                        course_run.enrollment_start.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                    "enrollment_end": (
+                                        course_run.enrollment_end.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                }
+                                for course_run in target_course.course_runs.all().order_by(
+                                    "start"
+                                )
+                            ],
+                            "position": target_course.product_relations.get(
+                                product=product
+                            ).position,
+                            "is_graded": target_course.product_relations.get(
+                                product=product
+                            ).is_graded,
+                            "title": target_course.title,
+                        }
+                        for target_course in product.target_courses.all().order_by(
+                            "product_target_relations__position"
+                        )
+                    ],
+                    "course_relations": [
+                        {
+                            "can_edit": True,
+                            "course": {
+                                "code": course.code,
+                                "cover": "_this_field_is_mocked",
+                                "id": str(course.id),
+                                "organizations": [],
+                                "state": {
+                                    "priority": course.state["priority"],
+                                    "datetime": course.state["datetime"]
+                                    .isoformat()
+                                    .replace("+00:00", "Z")
+                                    if course.state["datetime"]
+                                    else None,
+                                    "call_to_action": course.state["call_to_action"],
+                                    "text": course.state["text"],
+                                },
+                                "title": course.title,
+                            },
+                            "id": str(relation.id),
+                            "order_groups": [],
+                            "organizations": [
+                                {
+                                    "code": organization.code,
+                                    "id": str(organization.id),
+                                    "title": organization.title,
+                                }
+                            ],
+                        }
+                    ],
+                    "instructions": "",
+                },
+                "organizations": [
+                    {
+                        "code": organization.code,
+                        "id": str(organization.id),
+                        "title": organization.title,
+                    }
+                ],
+            },
+        )
+
+    def test_admin_api_course_products_relation_create_no_course_id(self):
+        """
+        Create a course product relation without course id should fail.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        product = factories.ProductFactory(
+            type=enums.PRODUCT_TYPE_CREDENTIAL, courses=[]
+        )
+        organization = factories.OrganizationFactory()
+
+        response = self.client.post(
+            "/api/v1.0/admin/course-product-relations/",
+            {
+                "product_id": product.id,
+                "organization_id": organization.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(
+            response.json(),
+            {"course_id": "This field is required."},
+        )
+
+    def test_admin_api_course_products_relation_create_no_product_id(self):
+        """
+        Create a course product relation without product id should fail.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        organization = factories.OrganizationFactory()
+
+        response = self.client.post(
+            "/api/v1.0/admin/course-product-relations/",
+            {
+                "course_id": course.id,
+                "organization_id": organization.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(
+            response.json(),
+            {"product_id": "This field is required."},
+        )
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_admin_api_course_products_relation_create_no_organization_id(self, _):
+        """
+        Super admin user should be able to create a course product relation
+        without organization id.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        course = factories.CourseFactory()
+        product = factories.ProductFactory(
+            type=enums.PRODUCT_TYPE_CREDENTIAL, courses=[]
+        )
+        response = self.client.post(
+            "/api/v1.0/admin/course-product-relations/",
+            {
+                "course_id": course.id,
+                "product_id": product.id,
+            },
+        )
+        self.assertEqual(response.status_code, 201)
+
+        relation = models.CourseProductRelation.objects.get(id=response.json()["id"])
+
+        self.assertDictEqual(
+            response.json(),
+            {
+                "id": str(relation.id),
+                "can_edit": relation.can_edit,
+                "course": {
+                    "code": course.code,
+                    "id": str(course.id),
+                    "cover": "_this_field_is_mocked",
+                    "title": course.title,
+                    "organizations": [],
+                    "state": {
+                        "priority": course.state["priority"],
+                        "datetime": course.state["datetime"]
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                        if course.state["datetime"]
+                        else None,
+                        "call_to_action": course.state["call_to_action"],
+                        "text": course.state["text"],
+                    },
+                },
+                "order_groups": [],
+                "product": {
+                    "id": str(product.id),
+                    "title": product.title,
+                    "description": product.description,
+                    "call_to_action": product.call_to_action,
+                    "price": float(product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
+                    "type": product.type,
+                    "certificate_definition": {
+                        "id": str(product.certificate_definition.id),
+                        "description": product.certificate_definition.description,
+                        "name": product.certificate_definition.name,
+                        "title": product.certificate_definition.title,
+                        "template": product.certificate_definition.template,
+                    },
+                    "target_courses": [
+                        {
+                            "code": target_course.code,
+                            "course_runs": [
+                                {
+                                    "id": course_run.id,
+                                    "title": course_run.title,
+                                    "resource_link": course_run.resource_link,
+                                    "state": {
+                                        "priority": course_run.state["priority"],
+                                        "datetime": course_run.state["datetime"]
+                                        .isoformat()
+                                        .replace("+00:00", "Z"),
+                                        "call_to_action": course_run.state[
+                                            "call_to_action"
+                                        ],
+                                        "text": course_run.state["text"],
+                                    },
+                                    "start": course_run.start.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "end": course_run.end.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_start": (
+                                        course_run.enrollment_start.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                    "enrollment_end": (
+                                        course_run.enrollment_end.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                }
+                                for course_run in target_course.course_runs.all().order_by(
+                                    "start"
+                                )
+                            ],
+                            "position": target_course.product_relations.get(
+                                product=product
+                            ).position,
+                            "is_graded": target_course.product_relations.get(
+                                product=product
+                            ).is_graded,
+                            "title": target_course.title,
+                        }
+                        for target_course in product.target_courses.all().order_by(
+                            "product_target_relations__position"
+                        )
+                    ],
+                    "course_relations": [
+                        {
+                            "can_edit": True,
+                            "course": {
+                                "code": course.code,
+                                "cover": "_this_field_is_mocked",
+                                "id": str(course.id),
+                                "organizations": [],
+                                "state": {
+                                    "priority": course.state["priority"],
+                                    "datetime": course.state["datetime"]
+                                    .isoformat()
+                                    .replace("+00:00", "Z")
+                                    if course.state["datetime"]
+                                    else None,
+                                    "call_to_action": course.state["call_to_action"],
+                                    "text": course.state["text"],
+                                },
+                                "title": course.title,
+                            },
+                            "id": str(relation.id),
+                            "order_groups": [],
+                            "organizations": [],
+                        }
+                    ],
+                    "instructions": "",
+                },
+                "organizations": [],
+            },
+        )
+
+    def test_admin_api_course_products_relation_create_no_payload(self):
+        """
+        Super admin user should be able to create a course product relation
+        without payload.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        response = self.client.post(
+            "/api/v1.0/admin/course-product-relations/",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "course_id": "This field is required.",
+                "product_id": "This field is required.",
+            },
+        )

--- a/src/backend/joanie/tests/core/api/admin/course-product-relations/test_delete.py
+++ b/src/backend/joanie/tests/core/api/admin/course-product-relations/test_delete.py
@@ -1,0 +1,72 @@
+"""
+Test suite for CourseProductRelation delete Admin API.
+"""
+from unittest import mock
+
+from django.test import TestCase
+
+from joanie.core import factories, models
+from joanie.core.serializers import fields
+
+
+class CourseProductRelationDeleteAdminApiTest(TestCase):
+    """
+    Test suite for CourseProductRelation delete Admin API.
+    """
+
+    maxDiff = None
+
+    def test_admin_api_course_products_relation_delete_anonymous(self):
+        """
+        Anonymous users should not be able to delete a course product relation.
+        """
+        relation = factories.CourseProductRelationFactory()
+        response = self.client.delete(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertDictEqual(
+            response.json(), {"detail": "Authentication credentials were not provided."}
+        )
+        relation.refresh_from_db()
+        self.assertIsNotNone(relation)
+
+    def test_admin_api_course_products_relation_delete_authenticated(self):
+        """
+        Authenticated users should not be able to delete a course product relation.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        relation = factories.CourseProductRelationFactory()
+        response = self.client.delete(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertDictEqual(
+            response.json(),
+            {"detail": "You do not have permission to perform this action."},
+        )
+        relation.refresh_from_db()
+        self.assertIsNotNone(relation)
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_admin_api_course_products_relation_delete_superuser(self, _):
+        """
+        Super admin user should be able to delete a course product relation.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        relation = factories.CourseProductRelationFactory()
+        response = self.client.delete(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+        )
+
+        self.assertEqual(response.status_code, 204)
+        with self.assertRaises(models.CourseProductRelation.DoesNotExist):
+            relation.refresh_from_db()

--- a/src/backend/joanie/tests/core/api/admin/course-product-relations/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/course-product-relations/test_list.py
@@ -1,0 +1,227 @@
+"""
+Test suite for CourseProductRelation list Admin API.
+"""
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+from joanie.core import enums, factories
+from joanie.core.serializers import fields
+
+
+class CourseProductRelationListAdminApiTest(TestCase):
+    """
+    Test suite for CourseProductRelation list Admin API.
+    """
+
+    maxDiff = None
+
+    def test_admin_api_course_products_relation_list_anonymous(self):
+        """
+        Anonymous users should not be able to list a course product relation.
+        """
+        factories.CourseProductRelationFactory.create_batch(3)
+        response = self.client.get(
+            "/api/v1.0/admin/course-product-relations/",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertDictEqual(
+            response.json(), {"detail": "Authentication credentials were not provided."}
+        )
+
+    def test_admin_api_course_products_relation_list_authenticated(self):
+        """
+        Authenticated users should not be able to list a course product relation.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        factories.CourseProductRelationFactory.create_batch(3)
+        response = self.client.get(
+            "/api/v1.0/admin/course-product-relations/",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertDictEqual(
+            response.json(),
+            {"detail": "You do not have permission to perform this action."},
+        )
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_admin_api_course_products_relation_list_superuser(self, _):
+        """
+        Super admin user should be able to list a course product relation.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        relations = factories.CourseProductRelationFactory.create_batch(
+            3,
+            product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+            product__courses=[],
+        )
+        response = self.client.get(
+            "/api/v1.0/admin/course-product-relations/",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "count": 3,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": str(relation.id),
+                        "can_edit": relation.can_edit,
+                        "course": {
+                            "code": relation.course.code,
+                            "id": str(relation.course.id),
+                            "cover": "_this_field_is_mocked",
+                            "title": relation.course.title,
+                            "organizations": [],
+                            "state": {
+                                "priority": relation.course.state["priority"],
+                                "datetime": relation.course.state["datetime"]
+                                .isoformat()
+                                .replace("+00:00", "Z")
+                                if relation.course.state["datetime"]
+                                else None,
+                                "call_to_action": relation.course.state[
+                                    "call_to_action"
+                                ],
+                                "text": relation.course.state["text"],
+                            },
+                        },
+                        "order_groups": [],
+                        "product": {
+                            "id": str(relation.product.id),
+                            "title": relation.product.title,
+                            "description": relation.product.description,
+                            "call_to_action": relation.product.call_to_action,
+                            "price": float(relation.product.price),
+                            "price_currency": settings.DEFAULT_CURRENCY,
+                            "type": relation.product.type,
+                            "certificate_definition": {
+                                "id": str(relation.product.certificate_definition.id),
+                                "description": relation.product.certificate_definition.description,
+                                "name": relation.product.certificate_definition.name,
+                                "title": relation.product.certificate_definition.title,
+                                "template": relation.product.certificate_definition.template,
+                            },
+                            "target_courses": [
+                                {
+                                    "code": target_course.code,
+                                    "course_runs": [
+                                        {
+                                            "id": course_run.id,
+                                            "title": course_run.title,
+                                            "resource_link": course_run.resource_link,
+                                            "state": {
+                                                "priority": course_run.state[
+                                                    "priority"
+                                                ],
+                                                "datetime": course_run.state["datetime"]
+                                                .isoformat()
+                                                .replace("+00:00", "Z"),
+                                                "call_to_action": course_run.state[
+                                                    "call_to_action"
+                                                ],
+                                                "text": course_run.state["text"],
+                                            },
+                                            "start": course_run.start.isoformat().replace(
+                                                "+00:00", "Z"
+                                            ),
+                                            "end": course_run.end.isoformat().replace(
+                                                "+00:00", "Z"
+                                            ),
+                                            "enrollment_start": (
+                                                course_run.enrollment_start.isoformat().replace(
+                                                    "+00:00", "Z"
+                                                )
+                                            ),
+                                            "enrollment_end": (
+                                                course_run.enrollment_end.isoformat().replace(
+                                                    "+00:00", "Z"
+                                                )
+                                            ),
+                                        }
+                                        for course_run in target_course.course_runs.all().order_by(
+                                            "start"
+                                        )
+                                    ],
+                                    "position": target_course.product_relations.get(
+                                        product=relation.product
+                                    ).position,
+                                    "is_graded": target_course.product_relations.get(
+                                        product=relation.product
+                                    ).is_graded,
+                                    "title": target_course.title,
+                                }
+                                for target_course in (
+                                    relation.product.target_courses.all().order_by(
+                                        "product_target_relations__position"
+                                    )
+                                )
+                            ],
+                            "course_relations": [
+                                {
+                                    "can_edit": True,
+                                    "course": {
+                                        "code": relation.course.code,
+                                        "cover": "_this_field_is_mocked",
+                                        "id": str(relation.course.id),
+                                        "organizations": [],
+                                        "state": {
+                                            "priority": relation.course.state[
+                                                "priority"
+                                            ],
+                                            "datetime": relation.course.state[
+                                                "datetime"
+                                            ]
+                                            .isoformat()
+                                            .replace("+00:00", "Z")
+                                            if relation.course.state["datetime"]
+                                            else None,
+                                            "call_to_action": relation.course.state[
+                                                "call_to_action"
+                                            ],
+                                            "text": relation.course.state["text"],
+                                        },
+                                        "title": relation.course.title,
+                                    },
+                                    "id": str(relation.id),
+                                    "order_groups": [],
+                                    "organizations": [
+                                        {
+                                            "code": organization.code,
+                                            "id": str(organization.id),
+                                            "title": organization.title,
+                                        }
+                                        for organization in relation.organizations.all()
+                                    ],
+                                }
+                            ],
+                            "instructions": "",
+                        },
+                        "organizations": [
+                            {
+                                "code": organization.code,
+                                "id": str(organization.id),
+                                "title": organization.title,
+                            }
+                            for organization in relation.organizations.all().order_by(
+                                "created_on"
+                            )
+                        ],
+                    }
+                    for relation in reversed(relations)
+                ],
+            },
+        )

--- a/src/backend/joanie/tests/core/api/admin/course-product-relations/test_retrieve.py
+++ b/src/backend/joanie/tests/core/api/admin/course-product-relations/test_retrieve.py
@@ -1,0 +1,210 @@
+"""
+Test suite for CourseProductRelation retrieve Admin API.
+"""
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+from joanie.core import enums, factories
+from joanie.core.serializers import fields
+
+
+class CourseProductRelationRetrieveAdminApiTest(TestCase):
+    """
+    Test suite for CourseProductRelation retrieve Admin API.
+    """
+
+    maxDiff = None
+
+    def test_admin_api_course_products_relation_retrieve_anonymous(self):
+        """
+        Anonymous users should not be able to retrieve a course product relation.
+        """
+        relation = factories.CourseProductRelationFactory()
+        response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertDictEqual(
+            response.json(), {"detail": "Authentication credentials were not provided."}
+        )
+
+    def test_admin_api_course_products_relation_retrieve_authenticated(self):
+        """
+        Authenticated users should not be able to retrieve a course product relation.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        relation = factories.CourseProductRelationFactory()
+        response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertDictEqual(
+            response.json(),
+            {"detail": "You do not have permission to perform this action."},
+        )
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_admin_api_course_products_relation_retrieve_superuser(self, _):
+        """
+        Super admin user should be able to retrieve a course product relation.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        relation = factories.CourseProductRelationFactory(
+            product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+            product__courses=[],
+        )
+        response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(relation.id),
+                "can_edit": relation.can_edit,
+                "course": {
+                    "code": relation.course.code,
+                    "id": str(relation.course.id),
+                    "cover": "_this_field_is_mocked",
+                    "title": relation.course.title,
+                    "organizations": [],
+                    "state": {
+                        "priority": relation.course.state["priority"],
+                        "datetime": relation.course.state["datetime"]
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                        if relation.course.state["datetime"]
+                        else None,
+                        "call_to_action": relation.course.state["call_to_action"],
+                        "text": relation.course.state["text"],
+                    },
+                },
+                "order_groups": [],
+                "product": {
+                    "id": str(relation.product.id),
+                    "title": relation.product.title,
+                    "description": relation.product.description,
+                    "call_to_action": relation.product.call_to_action,
+                    "price": float(relation.product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
+                    "type": relation.product.type,
+                    "certificate_definition": {
+                        "id": str(relation.product.certificate_definition.id),
+                        "description": relation.product.certificate_definition.description,
+                        "name": relation.product.certificate_definition.name,
+                        "title": relation.product.certificate_definition.title,
+                        "template": relation.product.certificate_definition.template,
+                    },
+                    "target_courses": [
+                        {
+                            "code": target_course.code,
+                            "course_runs": [
+                                {
+                                    "id": course_run.id,
+                                    "title": course_run.title,
+                                    "resource_link": course_run.resource_link,
+                                    "state": {
+                                        "priority": course_run.state["priority"],
+                                        "datetime": course_run.state["datetime"]
+                                        .isoformat()
+                                        .replace("+00:00", "Z"),
+                                        "call_to_action": course_run.state[
+                                            "call_to_action"
+                                        ],
+                                        "text": course_run.state["text"],
+                                    },
+                                    "start": course_run.start.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "end": course_run.end.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_start": (
+                                        course_run.enrollment_start.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                    "enrollment_end": (
+                                        course_run.enrollment_end.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                }
+                                for course_run in target_course.course_runs.all().order_by(
+                                    "start"
+                                )
+                            ],
+                            "position": target_course.product_relations.get(
+                                product=relation.product
+                            ).position,
+                            "is_graded": target_course.product_relations.get(
+                                product=relation.product
+                            ).is_graded,
+                            "title": target_course.title,
+                        }
+                        for target_course in (
+                            relation.product.target_courses.all().order_by(
+                                "product_target_relations__position"
+                            )
+                        )
+                    ],
+                    "course_relations": [
+                        {
+                            "can_edit": True,
+                            "course": {
+                                "code": relation.course.code,
+                                "cover": "_this_field_is_mocked",
+                                "id": str(relation.course.id),
+                                "organizations": [],
+                                "state": {
+                                    "priority": relation.course.state["priority"],
+                                    "datetime": relation.course.state["datetime"]
+                                    .isoformat()
+                                    .replace("+00:00", "Z")
+                                    if relation.course.state["datetime"]
+                                    else None,
+                                    "call_to_action": relation.course.state[
+                                        "call_to_action"
+                                    ],
+                                    "text": relation.course.state["text"],
+                                },
+                                "title": relation.course.title,
+                            },
+                            "id": str(relation.id),
+                            "order_groups": [],
+                            "organizations": [
+                                {
+                                    "code": organization.code,
+                                    "id": str(organization.id),
+                                    "title": organization.title,
+                                }
+                                for organization in relation.organizations.all()
+                            ],
+                        }
+                    ],
+                    "instructions": "",
+                },
+                "organizations": [
+                    {
+                        "code": organization.code,
+                        "id": str(organization.id),
+                        "title": organization.title,
+                    }
+                    for organization in relation.organizations.all().order_by(
+                        "created_on"
+                    )
+                ],
+            },
+        )

--- a/src/backend/joanie/tests/core/api/admin/course-product-relations/test_update.py
+++ b/src/backend/joanie/tests/core/api/admin/course-product-relations/test_update.py
@@ -1,0 +1,440 @@
+"""
+Test suite for CourseProductRelation update Admin API.
+"""
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+from joanie.core import enums, factories
+from joanie.core.serializers import fields
+
+
+class CourseProductRelationUpdateAdminApiTest(TestCase):
+    """
+    Test suite for CourseProductRelation update Admin API.
+    """
+
+    maxDiff = None
+
+    def test_admin_api_course_products_relation_update_anonymous(self):
+        """
+        Anonymous users should not be able to update a course product relation.
+        """
+        relation = factories.CourseProductRelationFactory()
+        course = factories.CourseFactory()
+        product = factories.ProductFactory(
+            type=enums.PRODUCT_TYPE_CREDENTIAL, courses=[]
+        )
+        response = self.client.put(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+            content_type="application/json",
+            data={
+                "course_id": course.id,
+                "product_id": product.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertDictEqual(
+            response.json(), {"detail": "Authentication credentials were not provided."}
+        )
+
+    def test_admin_api_course_products_relation_update_authenticated(self):
+        """
+        Authenticated users should not be able to update a course product relation.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        relation = factories.CourseProductRelationFactory()
+        course = factories.CourseFactory()
+        product = factories.ProductFactory(
+            type=enums.PRODUCT_TYPE_CREDENTIAL, courses=[]
+        )
+        response = self.client.put(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+            content_type="application/json",
+            data={
+                "course_id": course.id,
+                "product_id": product.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertDictEqual(
+            response.json(),
+            {"detail": "You do not have permission to perform this action."},
+        )
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_admin_api_course_products_relation_update_superuser(self, _):
+        """
+        Super admin user should be able to update a course product relation.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        relation = factories.CourseProductRelationFactory(
+            product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+            product__courses=[],
+        )
+        course = factories.CourseFactory()
+        product = factories.ProductFactory(
+            type=enums.PRODUCT_TYPE_CREDENTIAL, courses=[]
+        )
+        response = self.client.put(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+            content_type="application/json",
+            data={
+                "course_id": course.id,
+                "product_id": product.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(relation.id),
+                "can_edit": relation.can_edit,
+                "course": {
+                    "code": course.code,
+                    "id": str(course.id),
+                    "cover": "_this_field_is_mocked",
+                    "title": course.title,
+                    "organizations": [],
+                    "state": {
+                        "priority": course.state["priority"],
+                        "datetime": course.state["datetime"]
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                        if course.state["datetime"]
+                        else None,
+                        "call_to_action": course.state["call_to_action"],
+                        "text": course.state["text"],
+                    },
+                },
+                "order_groups": [],
+                "product": {
+                    "id": str(product.id),
+                    "title": product.title,
+                    "description": product.description,
+                    "call_to_action": product.call_to_action,
+                    "price": float(product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
+                    "type": product.type,
+                    "certificate_definition": {
+                        "id": str(product.certificate_definition.id),
+                        "description": product.certificate_definition.description,
+                        "name": product.certificate_definition.name,
+                        "title": product.certificate_definition.title,
+                        "template": product.certificate_definition.template,
+                    },
+                    "target_courses": [
+                        {
+                            "code": target_course.code,
+                            "course_runs": [
+                                {
+                                    "id": course_run.id,
+                                    "title": course_run.title,
+                                    "resource_link": course_run.resource_link,
+                                    "state": {
+                                        "priority": course_run.state["priority"],
+                                        "datetime": course_run.state["datetime"]
+                                        .isoformat()
+                                        .replace("+00:00", "Z"),
+                                        "call_to_action": course_run.state[
+                                            "call_to_action"
+                                        ],
+                                        "text": course_run.state["text"],
+                                    },
+                                    "start": course_run.start.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "end": course_run.end.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_start": (
+                                        course_run.enrollment_start.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                    "enrollment_end": (
+                                        course_run.enrollment_end.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                }
+                                for course_run in target_course.course_runs.all().order_by(
+                                    "start"
+                                )
+                            ],
+                            "position": target_course.product_relations.get(
+                                product=product
+                            ).position,
+                            "is_graded": target_course.product_relations.get(
+                                product=product
+                            ).is_graded,
+                            "title": target_course.title,
+                        }
+                        for target_course in (
+                            product.target_courses.all().order_by(
+                                "product_target_relations__position"
+                            )
+                        )
+                    ],
+                    "course_relations": [
+                        {
+                            "can_edit": True,
+                            "course": {
+                                "code": course.code,
+                                "cover": "_this_field_is_mocked",
+                                "id": str(course.id),
+                                "organizations": [],
+                                "state": {
+                                    "priority": course.state["priority"],
+                                    "datetime": course.state["datetime"]
+                                    .isoformat()
+                                    .replace("+00:00", "Z")
+                                    if course.state["datetime"]
+                                    else None,
+                                    "call_to_action": course.state["call_to_action"],
+                                    "text": course.state["text"],
+                                },
+                                "title": course.title,
+                            },
+                            "id": str(relation.id),
+                            "order_groups": [],
+                            "organizations": [
+                                {
+                                    "code": organization.code,
+                                    "id": str(organization.id),
+                                    "title": organization.title,
+                                }
+                                for organization in relation.organizations.all()
+                            ],
+                        }
+                    ],
+                    "instructions": "",
+                },
+                "organizations": [
+                    {
+                        "code": organization.code,
+                        "id": str(organization.id),
+                        "title": organization.title,
+                    }
+                    for organization in relation.organizations.all().order_by(
+                        "created_on"
+                    )
+                ],
+            },
+        )
+
+    def test_admin_api_course_products_relation_partially_update_anonymous(self):
+        """
+        Anonymous users should not be able to partially update a course product relation.
+        """
+        relation = factories.CourseProductRelationFactory()
+        course = factories.CourseFactory()
+        response = self.client.patch(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+            content_type="application/json",
+            data={
+                "course_id": course.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertDictEqual(
+            response.json(), {"detail": "Authentication credentials were not provided."}
+        )
+
+    def test_admin_api_course_products_relation_partially_update_authenticated(self):
+        """
+        Authenticated users should not be able to partially update a course product relation.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        relation = factories.CourseProductRelationFactory()
+        course = factories.CourseFactory()
+        response = self.client.patch(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+            content_type="application/json",
+            data={
+                "course_id": course.id,
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertDictEqual(
+            response.json(),
+            {"detail": "You do not have permission to perform this action."},
+        )
+
+    @mock.patch.object(
+        fields.ThumbnailDetailField,
+        "to_representation",
+        return_value="_this_field_is_mocked",
+    )
+    def test_admin_api_course_products_relation_partially_update_superuser(self, _):
+        """
+        Super admin user should be able to partially update a course product relation.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        relation = factories.CourseProductRelationFactory(
+            product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+            product__courses=[],
+        )
+        course = factories.CourseFactory()
+        response = self.client.patch(
+            f"/api/v1.0/admin/course-product-relations/{relation.id}/",
+            content_type="application/json",
+            data={
+                "course_id": course.id,
+            },
+        )
+
+        # self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(relation.id),
+                "can_edit": relation.can_edit,
+                "course": {
+                    "code": course.code,
+                    "id": str(course.id),
+                    "cover": "_this_field_is_mocked",
+                    "title": course.title,
+                    "organizations": [],
+                    "state": {
+                        "priority": course.state["priority"],
+                        "datetime": course.state["datetime"]
+                        .isoformat()
+                        .replace("+00:00", "Z")
+                        if course.state["datetime"]
+                        else None,
+                        "call_to_action": course.state["call_to_action"],
+                        "text": course.state["text"],
+                    },
+                },
+                "order_groups": [],
+                "product": {
+                    "id": str(relation.product.id),
+                    "title": relation.product.title,
+                    "description": relation.product.description,
+                    "call_to_action": relation.product.call_to_action,
+                    "price": float(relation.product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
+                    "type": relation.product.type,
+                    "certificate_definition": {
+                        "id": str(relation.product.certificate_definition.id),
+                        "description": relation.product.certificate_definition.description,
+                        "name": relation.product.certificate_definition.name,
+                        "title": relation.product.certificate_definition.title,
+                        "template": relation.product.certificate_definition.template,
+                    },
+                    "target_courses": [
+                        {
+                            "code": target_course.code,
+                            "course_runs": [
+                                {
+                                    "id": course_run.id,
+                                    "title": course_run.title,
+                                    "resource_link": course_run.resource_link,
+                                    "state": {
+                                        "priority": course_run.state["priority"],
+                                        "datetime": course_run.state["datetime"]
+                                        .isoformat()
+                                        .replace("+00:00", "Z"),
+                                        "call_to_action": course_run.state[
+                                            "call_to_action"
+                                        ],
+                                        "text": course_run.state["text"],
+                                    },
+                                    "start": course_run.start.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "end": course_run.end.isoformat().replace(
+                                        "+00:00", "Z"
+                                    ),
+                                    "enrollment_start": (
+                                        course_run.enrollment_start.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                    "enrollment_end": (
+                                        course_run.enrollment_end.isoformat().replace(
+                                            "+00:00", "Z"
+                                        )
+                                    ),
+                                }
+                                for course_run in target_course.course_runs.all().order_by(
+                                    "start"
+                                )
+                            ],
+                            "position": target_course.product_relations.get(
+                                product=relation.product
+                            ).position,
+                            "is_graded": target_course.product_relations.get(
+                                product=relation.product
+                            ).is_graded,
+                            "title": target_course.title,
+                        }
+                        for target_course in (
+                            relation.product.target_courses.all().order_by(
+                                "product_target_relations__position"
+                            )
+                        )
+                    ],
+                    "course_relations": [
+                        {
+                            "can_edit": True,
+                            "course": {
+                                "code": course.code,
+                                "cover": "_this_field_is_mocked",
+                                "id": str(course.id),
+                                "organizations": [],
+                                "state": {
+                                    "priority": course.state["priority"],
+                                    "datetime": course.state["datetime"]
+                                    .isoformat()
+                                    .replace("+00:00", "Z")
+                                    if course.state["datetime"]
+                                    else None,
+                                    "call_to_action": course.state["call_to_action"],
+                                    "text": course.state["text"],
+                                },
+                                "title": course.title,
+                            },
+                            "id": str(relation.id),
+                            "order_groups": [],
+                            "organizations": [
+                                {
+                                    "code": organization.code,
+                                    "id": str(organization.id),
+                                    "title": organization.title,
+                                }
+                                for organization in relation.organizations.all()
+                            ],
+                        }
+                    ],
+                    "instructions": "",
+                },
+                "organizations": [
+                    {
+                        "code": organization.code,
+                        "id": str(organization.id),
+                        "title": organization.title,
+                    }
+                    for organization in relation.organizations.all().order_by(
+                        "created_on"
+                    )
+                ],
+            },
+        )

--- a/src/backend/joanie/tests/core/test_api_admin_order_group.py
+++ b/src/backend/joanie/tests/core/test_api_admin_order_group.py
@@ -43,7 +43,7 @@ class OrderGroupAdminApiTest(TestCase):
         )
         factories.OrderGroupFactory.create_batch(5)
 
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(10):
             response = self.client.get(f"{self.base_url}/{relation.id}/order-groups/")
         self.assertEqual(response.status_code, 200)
         content = response.json()
@@ -55,6 +55,7 @@ class OrderGroupAdminApiTest(TestCase):
                 "nb_available_seats": order_group.nb_seats
                 - order_group.get_nb_binding_orders(),
                 "created_on": order_group.created_on.isoformat().replace("+00:00", "Z"),
+                "can_edit": True,
             }
             for order_group in order_groups
         ]
@@ -108,7 +109,7 @@ class OrderGroupAdminApiTest(TestCase):
         relation = factories.CourseProductRelationFactory()
         order_group = factories.OrderGroupFactory(course_product_relation=relation)
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/"
             )
@@ -122,6 +123,7 @@ class OrderGroupAdminApiTest(TestCase):
             "nb_available_seats": order_group.nb_seats
             - order_group.get_nb_binding_orders(),
             "created_on": order_group.created_on.isoformat().replace("+00:00", "Z"),
+            "can_edit": True,
         }
         self.assertEqual(content, expected_return)
 
@@ -157,7 +159,7 @@ class OrderGroupAdminApiTest(TestCase):
             "is_active": True,
             "course_product_relation": str(relation.id),
         }
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.post(
                 f"{self.base_url}/{relation.id}/order-groups/",
                 content_type="application/json",
@@ -201,7 +203,7 @@ class OrderGroupAdminApiTest(TestCase):
             "nb_seats": 505,
             "is_active": True,
         }
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.put(
                 f"{self.base_url}/{relation.id}/order-groups/{str(order_group.id)}/",
                 content_type="application/json",
@@ -245,7 +247,7 @@ class OrderGroupAdminApiTest(TestCase):
         data = {
             "is_active": True,
         }
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.patch(
                 f"{self.base_url}/{relation.id}/order-groups/{str(order_group.id)}/",
                 content_type="application/json",

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -161,6 +161,7 @@ class ProductAdminApiTest(TestCase):
             "course_relations": [
                 {
                     "id": str(relation.id),
+                    "can_edit": relation.can_edit,
                     "course": {
                         "id": str(relation.course.id),
                         "code": relation.course.code,

--- a/src/backend/joanie/tests/core/test_models_course_product_relation.py
+++ b/src/backend/joanie/tests/core/test_models_course_product_relation.py
@@ -23,3 +23,17 @@ class CourseProductRelationModelTestCase(TestCase):
                 f"courses/{relation.course.code}/products/{relation.product.id}/"
             ),
         )
+
+    def test_model_course_product_relation_can_edit(self):
+        """
+        CourseProductRelation can_edit property should return True if the
+        relation is not linked to any order, False otherwise.
+        """
+        relation = factories.CourseProductRelationFactory()
+        self.assertTrue(relation.can_edit)
+
+        factories.OrderFactory(
+            product=relation.product,
+            course=relation.course,
+        )
+        self.assertFalse(relation.can_edit)

--- a/src/backend/joanie/tests/core/test_models_order_group.py
+++ b/src/backend/joanie/tests/core/test_models_order_group.py
@@ -1,0 +1,25 @@
+"""
+Test suite for OrderGroup model
+"""
+from django.test import TestCase
+
+from joanie.core import factories
+
+
+class OrderGroupModelTestCase(TestCase):
+    """Test suite for the OrderGroup model."""
+
+    def test_model_order_group_can_edit(self):
+        """
+        OrderGroup can_edit property should return True if the
+        relation is not linked to any order, False otherwise.
+        """
+        order_group = factories.OrderGroupFactory()
+        self.assertTrue(order_group.can_edit)
+
+        factories.OrderFactory(
+            order_group=order_group,
+            product=order_group.course_product_relation.product,
+            course=order_group.course_product_relation.course,
+        )
+        self.assertFalse(order_group.can_edit)

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -119,6 +119,11 @@ admin_router = DefaultRouter()
 admin_router.register(
     "organizations", api_admin.OrganizationViewSet, basename="admin_organizations"
 )
+admin_router.register(
+    "course-product-relations",
+    api_admin.CourseProductRelationViewSet,
+    basename="admin_products",
+)
 admin_router.register("products", api_admin.ProductViewSet, basename="admin_products")
 admin_router.register("courses", api_admin.CourseViewSet, basename="admin_courses")
 admin_router.register(

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -123,7 +123,13 @@ sections = ["FUTURE","STDLIB","DJANGO","THIRDPARTY","JOANIE","FIRSTPARTY","LOCAL
 skip_glob = "venv"
 
 [tool.pytest.ini_options]
-addopts = "-v --cov-report term-missing"
+addopts = [
+    "-v",
+    "--cov-report",
+    "term-missing",
+    # Allow test files to have the same name in different directories.
+    "--import-mode=importlib",
+]
 python_files = [
     "test_*.py",
     "tests.py",

--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -103,6 +103,6 @@
     "workerDirectory": "public"
   },
   "volta": {
-    "node": "16.15.1"
+    "node": "18.18.2"
   }
 }


### PR DESCRIPTION
## Purpose

We need to bind course_runs to the AdminCourseSerializer.

Add a CRUD to create a courseProductRelation directly to a course

Add a can_edit property to CourseProductRelation and OrderGroup models which are false if a related order exists.

This is the backend part needed for #460 

## Proposal

Description...

- [x] add course_runs to AdminCourseSerializer
- [x] Add CRUD endpoints to manage courseProductRelation directly to a course
  - post /api/v1.0/admin/course-product-relations/
  - get /api/v1.0/admin/course-product-relations/
  - get /api/v1.0/admin/course-product-relations/<course_product_relation_id>
  - put /api/v1.0/admin/course-product-relations/<course_product_relation_id>
  - delete /api/v1.0/admin/course-product-relations/<course_product_relation_id>
- [x] Add a can_edit property to CourseProductRelation
- [x] Add a can_edit property to OrderGroup
- [x] Add a filter on contract-definitions list API
