### PR TITLE
Lint/setup ruff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,20 +127,14 @@ jobs:
           keys:
             - v1-back-dependencies-{{ .Revision }}
       - run:
-          name: Lint code with flake8
-          command: ~/.local/bin/flake8 .
-      - run:
-          name: Lint code with isort
-          command: ~/.local/bin/isort --check-only .
-      - run:
           name: Check code formatting with ruff
           command: ~/.local/bin/ruff format joanie --diff
       - run:
+          name: Lint code with ruff
+          command: ~/.local/bin/ruff check joanie
+      - run:
           name: Lint code with pylint
           command: ~/.local/bin/pylint joanie
-      - run:
-          name: Lint code with bandit
-          command: ~/.local/bin/bandit -c .banditrc -qr .
 
   test-back:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,8 @@ jobs:
           name: Lint code with isort
           command: ~/.local/bin/isort --check-only .
       - run:
-          name: Lint code with black
-          command: ~/.local/bin/black --check .
+          name: Check code formatting with ruff
+          command: ~/.local/bin/ruff format joanie --diff
       - run:
           name: Lint code with pylint
           command: ~/.local/bin/pylint joanie

--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,9 @@ lint-ruff-check: ## lint back-end python sources with ruff
 	@$(COMPOSE_RUN_APP) ruff check . --fix
 .PHONY: lint-ruff-check
 
-lint-pylint: ## lint back-end python sources with pylint
+lint-pylint: ## lint back-end python sources with pylint only on changed files from main
 	@echo 'lint:pylint started…'
-	@$(COMPOSE_RUN_APP) pylint joanie
+	bin/pylint --diff-only=origin/main
 .PHONY: lint-pylint
 
 test: ## run project tests

--- a/Makefile
+++ b/Makefile
@@ -133,22 +133,17 @@ demo-dev: ## flush db then create a dataset for dev purpose
 # Nota bene: Black should come after isort just in case they don't agree...
 lint: ## lint back-end python sources
 lint: \
+  lint-ruff-format \
   lint-isort \
-  lint-black \
   lint-flake8 \
   lint-pylint \
   lint-bandit
 .PHONY: lint
 
-lint-bandit: ## lint back-end python sources with bandit
-	@echo 'lint:bandit started…'
-	@$(COMPOSE_RUN_APP) bandit -c .banditrc -qr joanie
-.PHONY: lint-bandit
-
-lint-black: ## lint back-end python sources with black
-	@echo 'lint:black started…'
-	@$(COMPOSE_RUN_APP) black .
-.PHONY: lint-black
+lint-ruff-format: ## format back-end python sources with ruff
+	@echo 'lint:ruff-format started…'
+	@$(COMPOSE_RUN_APP) ruff format .
+.PHONY: lint-ruff-format
 
 lint-flake8: ## lint back-end python sources with flake8
 	@echo 'lint:flake8 started…'

--- a/Makefile
+++ b/Makefile
@@ -134,10 +134,8 @@ demo-dev: ## flush db then create a dataset for dev purpose
 lint: ## lint back-end python sources
 lint: \
   lint-ruff-format \
-  lint-isort \
-  lint-flake8 \
-  lint-pylint \
-  lint-bandit
+  lint-ruff-check \
+  lint-pylint
 .PHONY: lint
 
 lint-ruff-format: ## format back-end python sources with ruff
@@ -145,15 +143,10 @@ lint-ruff-format: ## format back-end python sources with ruff
 	@$(COMPOSE_RUN_APP) ruff format .
 .PHONY: lint-ruff-format
 
-lint-flake8: ## lint back-end python sources with flake8
-	@echo 'lint:flake8 started…'
-	@$(COMPOSE_RUN_APP) flake8 .
-.PHONY: lint-flake8
-
-lint-isort: ## automatically re-arrange python imports in back-end code base
-	@echo 'lint:isort started…'
-	@$(COMPOSE_RUN_APP) isort --atomic .
-.PHONY: lint-isort
+lint-ruff-check: ## lint back-end python sources with ruff
+	@echo 'lint:ruff-check started…'
+	@$(COMPOSE_RUN_APP) ruff check . --fix
+.PHONY: lint-ruff-check
 
 lint-pylint: ## lint back-end python sources with pylint
 	@echo 'lint:pylint started…'

--- a/bin/pylint
+++ b/bin/pylint
@@ -3,7 +3,37 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-# Fix docker vs local path when project sources are mounted as a volume
-params=$(echo $@ | sed "s|src/backend/||g")
+declare diff_from
+declare -a paths
+declare -a args
 
-_dc_run app-dev pylint "${params}"
+# Parse options
+for arg in "$@"
+do
+    case $arg in
+        --diff-only=*)
+            diff_from="${arg#*=}"
+            shift
+            ;;
+        -*)
+            args+=("$arg")
+            shift
+            ;;
+        *)
+            paths+=("$arg")
+            shift
+            ;;
+    esac
+done
+
+if [[ -n "${diff_from}" ]]; then
+    # Run pylint only on modified files located in src/backend/joanie
+    # (excluding deleted files and migration files)
+    # shellcheck disable=SC2207
+    paths=($(git diff "${diff_from}" --name-only --diff-filter=d -- src/backend/joanie ':!**/migrations/*.py' | grep -E '^src/backend/joanie/.*\.py$'))
+fi
+
+# Fix docker vs local path when project sources are mounted as a volume
+read -ra paths <<< "$(echo "${paths[@]}" | sed "s|src/backend/||g")"
+
+_dc_run app-dev pylint "${paths[@]}" "${args[@]}"

--- a/src/backend/.banditrc
+++ b/src/backend/.banditrc
@@ -1,1 +1,0 @@
-exclude_dirs: ["*/tests/*"]

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -460,9 +460,7 @@ class ProductAdmin(
 
         summarize_certification_to_user(request, certificate_generated_count)
 
-    def generate_certificates_for_course(
-        self, request, product_id, course_code
-    ):  # pylint: disable=no-self-use
+    def generate_certificates_for_course(self, request, product_id, course_code):  # pylint: disable=no-self-use
         """
         A custom action to generate certificates for a course - product couple.
         """

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -512,7 +512,7 @@ class ProductAdmin(
                     )
 
                     raw_html += (
-                        f'<a style="margin-left: 1rem" class="button" href="{generate_certificates_url}">'  # noqa pylint: disable=line-too-long
+                        f'<a style="margin-left: 1rem" class="button" href="{generate_certificates_url}">'  # pylint: disable=line-too-long
                         f'{_("Generate certificates")}'
                         "</a>"
                     )

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -276,9 +276,7 @@ class TargetCoursesViewSet(
         return Response(status=204)
 
     @action(detail=False, methods=["POST"])
-    def reorder(
-        self, request, *args, **kwargs
-    ):  # pylint: disable=no-self-use, unused-argument
+    def reorder(self, request, *args, **kwargs):  # pylint: disable=no-self-use, unused-argument
         """
         Allow to reorder target_courses for a product
         """

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -13,9 +13,8 @@ from django.http import FileResponse, HttpResponse, JsonResponse
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
-from rest_framework import mixins, pagination
+from rest_framework import mixins, pagination, viewsets
 from rest_framework import permissions as drf_permissions
-from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import ValidationError as DRFValidationError

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -387,9 +387,7 @@ class OrderViewSet(
         return Response(serializer.data, status=201)
 
     @action(detail=True, methods=["PATCH"])
-    def submit(
-        self, request, pk=None
-    ):  # pylint: disable=no-self-use, invalid-name, unused-argument
+    def submit(self, request, pk=None):  # pylint: disable=no-self-use, invalid-name, unused-argument
         """
         Submit a draft order if the conditions are filled
         """
@@ -409,9 +407,7 @@ class OrderViewSet(
         )
 
     @action(detail=True, methods=["POST"])
-    def abort(
-        self, request, pk=None
-    ):  # pylint: disable=no-self-use, invalid-name, unused-argument
+    def abort(self, request, pk=None):  # pylint: disable=no-self-use, invalid-name, unused-argument
         """Change the state of the order to pending"""
         payment_id = request.data.get("payment_id")
 
@@ -425,9 +421,7 @@ class OrderViewSet(
         return Response(status=204)
 
     @action(detail=True, methods=["POST"])
-    def cancel(
-        self, request, pk=None
-    ):  # pylint: disable=no-self-use, invalid-name, unused-argument
+    def cancel(self, request, pk=None):  # pylint: disable=no-self-use, invalid-name, unused-argument
         """Change the state of the order to cancelled"""
         order = self.get_object()
 
@@ -471,9 +465,7 @@ class OrderViewSet(
         return response
 
     @action(detail=True, methods=["PUT"])
-    def validate(
-        self, request, pk=None
-    ):  # pylint: disable=no-self-use, invalid-name, unused-argument
+    def validate(self, request, pk=None):  # pylint: disable=no-self-use, invalid-name, unused-argument
         """
         Validate the order
         """
@@ -482,9 +474,7 @@ class OrderViewSet(
         return Response(status=200)
 
     @action(detail=True, methods=["POST"])
-    def submit_for_signature(
-        self, request, pk=None
-    ):  # pylint: disable=no-self-use, unused-argument, invalid-name
+    def submit_for_signature(self, request, pk=None):  # pylint: disable=no-self-use, unused-argument, invalid-name
         """
         Create the contract of a product's order that has a contract definition and submit
         the contract to the signature provider. It returns a one-time use invitation link.
@@ -1025,9 +1015,7 @@ class ContractViewSet(GenericContractViewSet):
         detail=True,
         methods=["GET"],
     )
-    def download(
-        self, request, pk=None
-    ):  # pylint: disable=no-self-use, unused-argument, invalid-name
+    def download(self, request, pk=None):  # pylint: disable=no-self-use, unused-argument, invalid-name
         """
         Return the PDF in bytes to download of the contract's definition of an order.
         """
@@ -1195,9 +1183,7 @@ class ContractDefinitionViewset(viewsets.GenericViewSet):
         methods=["GET"],
         url_path="preview_template",
     )
-    def preview_template(
-        self, request, pk=None
-    ):  # pylint: disable=invalid-name, unused-argument
+    def preview_template(self, request, pk=None):  # pylint: disable=invalid-name, unused-argument
         """
         Return the contract definition in PDF in bytes.
         """

--- a/src/backend/joanie/core/authentication.py
+++ b/src/backend/joanie/core/authentication.py
@@ -65,7 +65,7 @@ class OpenApiJWTAuthenticationExtension(TokenScheme):
         """Return the security definition for JWT authentication."""
         return build_bearer_security_scheme_object(
             header_name="Authorization",
-            token_prefix="Bearer",  # nosec B106
+            token_prefix="Bearer",  # noqa S106
         )
 
 

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -246,7 +246,8 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         return {
             language[0]
             for language in random.sample(
-                enums.ALL_LANGUAGES, random.randint(1, 5)  # nosec
+                enums.ALL_LANGUAGES,
+                random.randint(1, 5),  # nosec
             )
         }
 

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -245,10 +245,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         """
         return {
             language[0]
-            for language in random.sample(
-                enums.ALL_LANGUAGES,
-                random.randint(1, 5),  # nosec
-            )
+            for language in random.sample(enums.ALL_LANGUAGES, random.randint(1, 5))
         }
 
     @factory.lazy_attribute_sequence
@@ -271,9 +268,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         if self.state == models.CourseState.TO_BE_SCHEDULED:
             return None
 
-        period = timedelta(
-            days=random.randrange(1, 365, 1)  # nosec
-        )  # between 1 and 365 days
+        period = timedelta(days=random.randrange(1, 365, 1))  # between 1 and 365 days
 
         if self.state in [
             models.CourseState.ONGOING_OPEN,
@@ -300,9 +295,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             max_date = self.ref_date + period
 
         return datetime.utcfromtimestamp(
-            random.randrange(  # nosec
-                int(min_date.timestamp()), int(max_date.timestamp())
-            )
+            random.randrange(int(min_date.timestamp()), int(max_date.timestamp()))
         ).replace(tzinfo=timezone.utc)
 
     @factory.lazy_attribute
@@ -314,9 +307,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         if not self.start:
             return None
 
-        period = timedelta(
-            days=random.randrange(1, 365, 1)  # nosec
-        )  # between 1 and 365 days
+        period = timedelta(days=random.randrange(1, 365, 1))  # between 1 and 365 days
 
         if self.state in [
             models.CourseState.ARCHIVED_OPEN,
@@ -347,9 +338,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             max_date = min_date + period
 
         return datetime.utcfromtimestamp(
-            random.randrange(  # nosec
-                int(min_date.timestamp()), int(max_date.timestamp())
-            )
+            random.randrange(int(min_date.timestamp()), int(max_date.timestamp()))
         ).replace(tzinfo=timezone.utc)
 
     @factory.lazy_attribute
@@ -362,9 +351,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         if not self.start:
             return None
 
-        period = timedelta(
-            days=random.randrange(1, 90, 1)  # nosec
-        )  # between 1 and 90 days
+        period = timedelta(days=random.randrange(1, 90, 1))  # between 1 and 90 days
 
         if self.state in [
             models.CourseState.FUTURE_OPEN,
@@ -387,9 +374,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             max_date = self.start
 
         return datetime.utcfromtimestamp(
-            random.randrange(  # nosec
-                int(min_date.timestamp()), int(max_date.timestamp())
-            )
+            random.randrange(int(min_date.timestamp()), int(max_date.timestamp()))
         ).replace(tzinfo=timezone.utc)
 
     @factory.lazy_attribute
@@ -408,9 +393,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             # The course run has ended but enrollment is still opened.
             return None
 
-        period = timedelta(
-            days=random.randrange(1, 90, 1)  # nosec
-        )  # between 1 and 90 days
+        period = timedelta(days=random.randrange(1, 90, 1))  # between 1 and 90 days
 
         if self.state in [
             models.CourseState.ONGOING_OPEN,
@@ -442,9 +425,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
             max_date = self.end or self.enrollment_start + period
 
         return datetime.utcfromtimestamp(
-            random.randrange(  # nosec
-                int(min_date.timestamp()), int(max_date.timestamp())
-            )
+            random.randrange(int(min_date.timestamp()), int(max_date.timestamp()))
         ).replace(tzinfo=timezone.utc)
 
 

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -1,3 +1,4 @@
+# ruff: noqa: S311
 """
 Core application factories
 """

--- a/src/backend/joanie/core/fields/multiselect.py
+++ b/src/backend/joanie/core/fields/multiselect.py
@@ -147,7 +147,7 @@ class MultiSelectField(models.CharField):
         """Convert a database value to a list value."""
         if not value:
             return None if value is None else []
-        return list((v.strip() for v in value.split(",")))
+        return [v.strip() for v in value.split(",")]
 
     def to_python(self, value):
         """Convert a string value to a list value. Used for deserialization and in clean forms."""
@@ -155,7 +155,7 @@ class MultiSelectField(models.CharField):
             return list(value)
         if not value:
             return None if value is None else []
-        return list((v.strip() for v in value.split(",")))
+        return [v.strip() for v in value.split(",")]
 
     def get_prep_value(self, value):
         """

--- a/src/backend/joanie/core/filters/__init__.py
+++ b/src/backend/joanie/core/filters/__init__.py
@@ -1,6 +1,5 @@
 """API Resource Filters of core application"""
 
-# flake8: noqa
 # pylint: disable=wildcard-import
 
 from .admin import *

--- a/src/backend/joanie/core/forms.py
+++ b/src/backend/joanie/core/forms.py
@@ -15,7 +15,8 @@ class CourseProductRelationAdminForm(forms.ModelForm):
     organizations = forms.ModelMultipleChoiceField(
         queryset=models.Organization.objects.all(),
         widget=widgets.FilteredSelectMultiple(
-            models.Organization._meta.verbose_name_plural, is_stacked=False
+            models.Organization._meta.verbose_name_plural,  # noqa: SLF001
+            is_stacked=False,
         ),
         required=True,
     )
@@ -36,7 +37,8 @@ class ProductTargetCourseRelationAdminForm(forms.ModelForm):
     course_runs = forms.ModelMultipleChoiceField(
         queryset=models.CourseRun.objects.none(),
         widget=widgets.FilteredSelectMultiple(
-            models.CourseRun._meta.verbose_name_plural, is_stacked=False
+            models.CourseRun._meta.verbose_name_plural,  # noqa: SLF001
+            is_stacked=False,
         ),
         required=False,
     )

--- a/src/backend/joanie/core/models/__init__.py
+++ b/src/backend/joanie/core/models/__init__.py
@@ -1,5 +1,4 @@
 """Make models.py a module containing one file per model as it was getting too long."""
-# flake8: noqa
 # pylint: disable=wildcard-import
 from .accounts import *
 from .certifications import *

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -726,6 +726,7 @@ class CourseRun(parler_models.TranslatableModel, BaseModel):
         )
 
     # pylint: disable=too-many-return-statements
+    # ruff: noqa: PLR0911
     @staticmethod
     def compute_state(start=None, end=None, enrollment_start=None, enrollment_end=None):
         """

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -970,9 +970,7 @@ class Order(BaseModel):
 
 
 @receiver(post_transition, sender=Order)
-def order_post_transition_callback(
-    sender, instance, **kwargs
-):  # pylint: disable=unused-argument
+def order_post_transition_callback(sender, instance, **kwargs):  # pylint: disable=unused-argument
     """
     Post transition callback for Order model. When an order is validated,
     it automatically enrolls user and when it is canceled, it automatically

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -174,7 +174,7 @@ class Product(parler_models.TranslatableModel, BaseModel):
             "languages", flat=True
         ).distinct()
         # Go through a set for uniqueness of each language then return an ordered list
-        return sorted(list(set(itertools.chain.from_iterable(languages))))
+        return sorted(set(itertools.chain.from_iterable(languages)))
 
     def get_equivalent_course_run_dates(self):
         """
@@ -623,6 +623,7 @@ class Order(BaseModel):
             return None
 
     # pylint: disable=too-many-branches
+    # ruff: noqa: PLR0912
     def clean(self):
         """Clean instance fields and raise a ValidationError in case of issue."""
         error_dict = defaultdict(list)

--- a/src/backend/joanie/core/serializers/__init__.py
+++ b/src/backend/joanie/core/serializers/__init__.py
@@ -1,5 +1,4 @@
 """Serializers for Joanie Core app."""
-# flake8: noqa
 # pylint: disable=wildcard-import
 
 from .admin import *

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -613,7 +613,7 @@ class AdminCourseRunSerializer(serializers.ModelSerializer):
             except models.Course.DoesNotExist as exception:
                 raise serializers.ValidationError(
                     {"course": "Resource {course_id} does not exist."}, exception
-                )
+                ) from exception
 
         return validated_data
 

--- a/src/backend/joanie/demo/management/commands/create_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_demo.py
@@ -1,4 +1,6 @@
+# ruff: noqa: S311, S106, PLR0915
 """Create_demo management command."""
+
 import logging
 import random
 import time
@@ -36,14 +38,14 @@ class BulkQueue:
         if not objects:
             return
 
-        objects[0]._meta.model.objects.bulk_create(objects, ignore_conflicts=True)
+        objects[0]._meta.model.objects.bulk_create(objects, ignore_conflicts=True)  # noqa: SLF001
         # In debug mode, Django keeps query cache which creates a memory leak in this case
         db.reset_queries()
-        self.queue[objects[0]._meta.model.__name__] = []
+        self.queue[objects[0]._meta.model.__name__] = []  # noqa: SLF001
 
     def push(self, obj):
         """Add a model instance to queue to that it gets created in bulk."""
-        objects = self.queue[obj._meta.model.__name__]
+        objects = self.queue[obj._meta.model.__name__]  # noqa: SLF001
         objects.append(obj)
         if len(objects) > self.BATCH_SIZE:
             self._bulk_create(objects)
@@ -211,7 +213,7 @@ def create_demo(stdout):
         )
         product_ids = models.Product.objects.order_by("?").values_list("id", flat=True)
 
-        for course_id, product_id in zip(course_ids, product_ids):
+        for course_id, product_id in zip(course_ids, product_ids, strict=True):
             queue.push(
                 models.CourseProductRelation(course_id=course_id, product_id=product_id)
             )

--- a/src/backend/joanie/demo/management/commands/create_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_demo.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("joanie.commands.demo.create_demo")
 
 def random_true_with_probability(probability):
     """return True with the requested probability, False otherwise."""
-    return random.random() < probability  # nosec
+    return random.random() < probability
 
 
 class BulkQueue:
@@ -112,10 +112,10 @@ def create_free_enrollments(queue):
     for _i in range(nb_enrollments):
         queue.push(
             models.Enrollment(
-                user_id=random.choice(users_ids),  # nosec
-                course_run_id=random.choice(course_runs_ids),  # nosec
+                user_id=random.choice(users_ids),
+                course_run_id=random.choice(course_runs_ids),
                 is_active=random_true_with_probability(0.7),
-                state=random.choice(state_choices),  # nosec
+                state=random.choice(state_choices),
                 was_created_by_order=False,
             )
         )
@@ -140,7 +140,7 @@ def create_demo(stdout):
                 models.User(
                     username=f"user{i:d}",
                     email=f"user{i:d}@example.com",
-                    password="!",  # nosec
+                    password="!",
                     is_superuser=False,
                     is_active=True,
                     is_staff=False,
@@ -181,7 +181,7 @@ def create_demo(stdout):
         ]:
             factories.CourseRunFactory.create_batch(
                 random.randint(1, 5),
-                course=course,  # nosec
+                course=course,
             )
 
     with Timeit(stdout, "Creating product target course relations"):
@@ -193,7 +193,7 @@ def create_demo(stdout):
         for product_id in models.Product.objects.values_list("id", flat=True):
             for target_course_id in random.sample(
                 ids_of_courses_with_runs,
-                random.randint(2, min(30, len(ids_of_courses_with_runs))),  # nosec
+                random.randint(2, min(30, len(ids_of_courses_with_runs))),
             ):
                 queue.push(
                     models.ProductTargetCourseRelation(
@@ -225,7 +225,7 @@ def create_demo(stdout):
         )
         for course_product_relation in models.CourseProductRelation.objects.iterator():
             course_product_relation.organizations.set(
-                random.sample(organization_ids, random.randint(1, 3))  # nosec
+                random.sample(organization_ids, random.randint(1, 3))
             )
         del organization_ids
 
@@ -241,14 +241,14 @@ def create_demo(stdout):
             min_orders = max(1, defaults.NB_OBJECTS["max_orders_per_product"] // 10)
             for user_id in random.sample(
                 users_ids,
-                random.randint(  # nosec
+                random.randint(
                     min_orders, defaults.NB_OBJECTS["max_orders_per_product"]
                 ),
             ):
-                course_id = random.choice(list(course_dict.keys()))  # nosec
+                course_id = random.choice(list(course_dict.keys()))
                 queue.push(
                     models.Order(
-                        organization_id=random.choice(course_dict[course_id]),  # nosec
+                        organization_id=random.choice(course_dict[course_id]),
                         course_id=course_id,
                         product_id=product.id,
                         owner_id=user_id,
@@ -280,11 +280,11 @@ def create_demo(stdout):
                     queue.push(
                         models.Enrollment(
                             user_id=order.owner_id,
-                            course_run_id=random.choice(  # nosec
+                            course_run_id=random.choice(
                                 course_runs_dict[relation.course_id]
                             ),
                             is_active=random_true_with_probability(0.7),
-                            state=random.choice(state_choices),  # nosec
+                            state=random.choice(state_choices),
                             was_created_by_order=True,
                         )
                     )
@@ -300,26 +300,26 @@ def create_demo(stdout):
             .distinct()
             .values_list("id", flat=True)
         ):
-            for i in range(random.randint(1, 3)):  # nosec
+            for i in range(random.randint(1, 3)):
                 queue.push(
                     models.Address(
                         title=f"Title {user_sequence:d}-{i:d}",
                         address=f"Address {user_sequence:d}-{i:d}",
                         postcode=f"Postcode {user_sequence:d}-{i:d}",
                         city=f"City {user_sequence:d}-{i:d}",
-                        country=random.choice(["fr", "de"]),  # nosec
+                        country=random.choice(["fr", "de"]),
                         first_name=f"Fistname {user_sequence:d}-{i:d}",
                         last_name=f"Lastname {user_sequence:d}-{i:d}",
                         owner_id=user_id,
                     )
                 )
-            for i in range(random.randint(1, 3)):  # nosec
+            for i in range(random.randint(1, 3)):
                 queue.push(
                     payment_models.CreditCard(
                         title=f"Title {user_sequence:d}-{i:d}",
                         token=f"Token {user_sequence:d}-{i:d}",
                         brand=f"Brand {i:d}",
-                        expiration_month=f"{random.randint(1, 12):02d}",  # nosec
+                        expiration_month=f"{random.randint(1, 12):02d}",
                         expiration_year="2024",
                         last_numbers="1234",
                         owner_id=user_id,

--- a/src/backend/joanie/demo/management/commands/create_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_demo.py
@@ -180,7 +180,8 @@ def create_demo(stdout):
             : defaults.NB_OBJECTS["courses"]
         ]:
             factories.CourseRunFactory.create_batch(
-                random.randint(1, 5), course=course  # nosec
+                random.randint(1, 5),
+                course=course,  # nosec
             )
 
     with Timeit(stdout, "Creating product target course relations"):

--- a/src/backend/joanie/demo/management/commands/create_dev_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_dev_demo.py
@@ -27,7 +27,7 @@ class Command(BaseCommand):
         want to use ALL_LANGUAGES to set course run languages to prevent synchronization
         issues between Joanie & Richie.
         """
-        return random.sample(["de", "en", "fr", "pt"], random.randint(1, 4))  # nosec
+        return random.sample(["de", "en", "fr", "pt"], random.randint(1, 4))
 
     def create_course(self, user, organization, batch_size=1, with_course_runs=False):
         """Create courses for given user and organization."""

--- a/src/backend/joanie/demo/management/commands/create_dev_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_dev_demo.py
@@ -1,3 +1,4 @@
+# ruff: noqa: S311
 """Management command to initialize some fake data (products, courses and course runs)"""
 import random
 

--- a/src/backend/joanie/lms_handler/serializers.py
+++ b/src/backend/joanie/lms_handler/serializers.py
@@ -14,7 +14,7 @@ class ListMultipleChoiceField(serializers.MultipleChoiceField):
     """
 
     def to_representation(self, value):
-        return sorted(list(super().to_representation(value)))
+        return sorted(super().to_representation(value))
 
 
 class SyncCourseRunSerializer(serializers.ModelSerializer):

--- a/src/backend/joanie/payment/admin.py
+++ b/src/backend/joanie/payment/admin.py
@@ -134,7 +134,7 @@ class InvoiceAdmin(admin.ModelAdmin):
             items = [
                 (
                     "<li>"
-                    f"<a href='{reverse('admin:payment_transaction_change', args=(transaction.id,),)}'>"  # noqa pylint: disable=line-too-long
+                    f"<a href='{reverse('admin:payment_transaction_change', args=(transaction.id,),)}'>"  # pylint: disable=line-too-long
                     f"{str(transaction)}"
                     "</a>"
                     "</li>"

--- a/src/backend/joanie/payment/apps.py
+++ b/src/backend/joanie/payment/apps.py
@@ -12,6 +12,6 @@ class PaymentConfig(AppConfig):
     # pylint: disable=import-outside-toplevel, unused-import
     def ready(self):
         """Import credit card post delete receiver."""
-        from joanie.payment.models import (  # noqa: F401,
+        from joanie.payment.models import (  # ,
             credit_card_post_delete_receiver,
         )

--- a/src/backend/joanie/payment/backends/dummy.py
+++ b/src/backend/joanie/payment/backends/dummy.py
@@ -113,7 +113,7 @@ class DummyPaymentBackend(BasePaymentBackend):
     @classmethod
     def _send_mail_payment_success(cls, order):
         logger.info("Mail is sent to %s from dummy payment", order.owner.email)
-        BasePaymentBackend._send_mail_payment_success(order)
+        super()._send_mail_payment_success(order)
 
     def create_payment(self, request, order, billing_address):
         """

--- a/src/backend/joanie/payment/backends/payplug/__init__.py
+++ b/src/backend/joanie/payment/backends/payplug/__init__.py
@@ -141,7 +141,7 @@ class PayplugBackend(BasePaymentBackend):
         try:
             payment = payplug.Payment.create(**payment_data)
         except BadRequest as error:
-            raise exceptions.CreatePaymentFailed(str(error))
+            raise exceptions.CreatePaymentFailed(str(error)) from error
 
         return {
             "payment_id": payment.id,
@@ -227,4 +227,4 @@ class PayplugBackend(BasePaymentBackend):
         try:
             payplug.Payment.abort(payment_id)
         except (Forbidden, NotFound) as error:
-            raise exceptions.AbortPaymentFailed(str(error))
+            raise exceptions.AbortPaymentFailed(str(error)) from error

--- a/src/backend/joanie/payment/models.py
+++ b/src/backend/joanie/payment/models.py
@@ -192,7 +192,7 @@ class Invoice(BaseModel):
                     "order": {
                         "product": {
                             "name": related_product.title,  # pylint: disable=no-member
-                            "description": related_product.description,  # noqa pylint: disable=no-member,line-too-long
+                            "description": related_product.description,  # pylint: disable=no-member,line-too-long
                         }
                     }
                 }

--- a/src/backend/joanie/tests/core/api/order/test_create.py
+++ b/src/backend/joanie/tests/core/api/order/test_create.py
@@ -120,10 +120,10 @@ class OrderCreateApiTest(BaseAPITestCase):
                                 "end": course_run.end.isoformat().replace(
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
                             }
@@ -596,10 +596,10 @@ class OrderCreateApiTest(BaseAPITestCase):
                                 "end": course_run.end.isoformat().replace(
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
                             }
@@ -923,10 +923,10 @@ class OrderCreateApiTest(BaseAPITestCase):
                                 "end": course_run.end.isoformat().replace(
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
                             }

--- a/src/backend/joanie/tests/core/api/order/test_read_detail.py
+++ b/src/backend/joanie/tests/core/api/order/test_read_detail.py
@@ -98,10 +98,10 @@ class OrderReadApiTest(BaseAPITestCase):
                                 "end": course_run.end.isoformat().replace(
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_start": course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
-                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                "enrollment_end": course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                     "+00:00", "Z"
                                 ),
                             }

--- a/src/backend/joanie/tests/core/test_api_admin_courses.py
+++ b/src/backend/joanie/tests/core/test_api_admin_courses.py
@@ -175,13 +175,13 @@ class CourseAdminApiTest(TestCase):
                     "size": course.cover.size,
                     "src": f"http://testserver{course.cover.url}.1x1_q85.webp",
                     "srcset": (
-                        f"http://testserver{course.cover.url}.1920x1080_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.1920x1080_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "1920w, "
-                        f"http://testserver{course.cover.url}.1280x720_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.1280x720_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "1280w, "
-                        f"http://testserver{course.cover.url}.768x432_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.768x432_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "768w, "
-                        f"http://testserver{course.cover.url}.384x216_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.384x216_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "384w"
                     ),
                     "height": course.cover.height,

--- a/src/backend/joanie/tests/core/test_api_admin_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_admin_organizations.py
@@ -227,13 +227,13 @@ class OrganizationAdminApiTest(TestCase):
                     "width": 1,
                     "size": organization.logo.size,
                     "srcset": (
-                        f"http://testserver{organization.logo.url}.1024x1024_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.1024x1024_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "1024w, "
-                        f"http://testserver{organization.logo.url}.512x512_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.512x512_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "512w, "
-                        f"http://testserver{organization.logo.url}.256x256_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.256x256_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "256w, "
-                        f"http://testserver{organization.logo.url}.128x128_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.128x128_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                         "128w"
                     ),
                     "filename": organization.logo.name,

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -172,10 +172,10 @@ class ProductAdminApiTest(TestCase):
                             "src": f"{relation.course.cover.url}.1x1_q85.webp",
                             "size": relation.course.cover.size,
                             "srcset": (
-                                f"{relation.course.cover.url}.1920x1080_q85_crop-smart_upscale.webp 1920w, "  # noqa pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.1280x720_q85_crop-smart_upscale.webp 1280w, "  # noqa pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.768x432_q85_crop-smart_upscale.webp 768w, "  # noqa pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.384x216_q85_crop-smart_upscale.webp 384w"  # noqa pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.1920x1080_q85_crop-smart_upscale.webp 1920w, "  # pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.1280x720_q85_crop-smart_upscale.webp 1280w, "  # pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.768x432_q85_crop-smart_upscale.webp 768w, "  # pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.384x216_q85_crop-smart_upscale.webp 384w"  # pylint: disable=line-too-long
                             ),
                         },
                         "title": relation.course.title,

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -177,11 +177,11 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                                     "end": course_run.end.isoformat().replace(
                                         "+00:00", "Z"
                                     ),
-                                    "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                    "enrollment_start": course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                         "+00:00",
                                         "Z",
                                     ),
-                                    "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                    "enrollment_end": course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                         "+00:00",
                                         "Z",
                                     ),
@@ -534,11 +534,11 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                                     "end": course_run.end.isoformat().replace(
                                         "+00:00", "Z"
                                     ),
-                                    "enrollment_start": course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                    "enrollment_start": course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                         "+00:00",
                                         "Z",
                                     ),
-                                    "enrollment_end": course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                                    "enrollment_end": course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                         "+00:00",
                                         "Z",
                                     ),

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -138,10 +138,10 @@ class EnrollmentApiTest(BaseAPITestCase):
                             },
                             "resource_link": enrollment.course_run.resource_link,
                             "title": enrollment.course_run.title,
-                            "enrollment_start": enrollment.course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                            "enrollment_start": enrollment.course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                 "+00:00", "Z"
                             ),
-                            "enrollment_end": enrollment.course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                            "enrollment_end": enrollment.course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                 "+00:00", "Z"
                             )
                             if enrollment.course_run.state["priority"]
@@ -211,10 +211,10 @@ class EnrollmentApiTest(BaseAPITestCase):
                             },
                             "resource_link": other_enrollment.course_run.resource_link,
                             "title": other_enrollment.course_run.title,
-                            "enrollment_start": other_enrollment.course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                            "enrollment_start": other_enrollment.course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                 "+00:00", "Z"
                             ),
-                            "enrollment_end": other_enrollment.course_run.enrollment_end.isoformat().replace(  # noqa pylint: disable=line-too-long
+                            "enrollment_end": other_enrollment.course_run.enrollment_end.isoformat().replace(  # pylint: disable=line-too-long
                                 "+00:00", "Z"
                             )
                             if other_enrollment.course_run.state["priority"]
@@ -522,7 +522,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                                 "cover": "_this_field_is_mocked",
                             },
                             "title": course_run_1.title,
-                            "enrollment_start": course_run_1.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                            "enrollment_start": course_run_1.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                                 "+00:00", "Z"
                             ),
                             "enrollment_end": course_run_1.enrollment_end.isoformat().replace(
@@ -1646,7 +1646,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                         },
                         "resource_link": enrollment.course_run.resource_link,
                         "title": enrollment.course_run.title,
-                        "enrollment_start": enrollment.course_run.enrollment_start.isoformat().replace(  # noqa pylint: disable=line-too-long
+                        "enrollment_start": enrollment.course_run.enrollment_start.isoformat().replace(  # pylint: disable=line-too-long
                             "+00:00", "Z"
                         ),
                         "enrollment_end": enrollment.course_run.enrollment_end.isoformat().replace(

--- a/src/backend/joanie/tests/core/test_api_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations.py
@@ -92,13 +92,13 @@ class OrganizationApiTest(BaseAPITestCase):
                             "filename": organization.logo.name,
                             "src": f"http://testserver{organization.logo.url}.1x1_q85.webp",
                             "srcset": (
-                                f"http://testserver{organization.logo.url}.1024x1024_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.1024x1024_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                                 "1024w, "
-                                f"http://testserver{organization.logo.url}.512x512_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.512x512_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                                 "512w, "
-                                f"http://testserver{organization.logo.url}.256x256_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.256x256_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                                 "256w, "
-                                f"http://testserver{organization.logo.url}.128x128_q85_crop-smart_upscale.webp "  # noqa pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.128x128_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
                                 "128w"
                             ),
                             "width": 1,

--- a/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
@@ -21,7 +21,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         products = factories.ProductFactory.create_batch(5)
         factories.UserOrganizationAccessFactory(organization=organizations[0])
         relations = []
-        for course, product in zip(courses, products):
+        for course, product in zip(courses, products, strict=True):
             relations.append(
                 factories.CourseProductRelationFactory(
                     course=course, product=product, organizations=[organizations[0]]
@@ -48,7 +48,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             organization=organizations[0], user=user
         )
         relations = []
-        for course, product in zip(courses, products):
+        for course, product in zip(courses, products, strict=True):
             relations.append(
                 factories.CourseProductRelationFactory(
                     course=course, product=product, organizations=[organizations[0]]
@@ -71,8 +71,8 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         content = response.json()
         self.assertEqual(content["count"], 5)
         self.assertEqual(
-            set(map(lambda x: str(x["id"]), content["results"])),
-            set(map(lambda x: str(x.id), relations)),
+            {str(x["id"]) for x in content["results"]},
+            {str(x.id) for x in relations},
         )
 
     def test_api_organizations_course_product_relations_read_list_without_access(self):
@@ -87,7 +87,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         products = factories.ProductFactory.create_batch(5)
 
         relations = []
-        for course, product in zip(courses, products):
+        for course, product in zip(courses, products, strict=True):
             relations.append(
                 factories.CourseProductRelationFactory(
                     course=course, product=product, organizations=[organizations[0]]
@@ -114,7 +114,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         products = factories.ProductFactory.create_batch(5)
         factories.UserOrganizationAccessFactory(organization=organizations[0])
         relations = []
-        for course, product in zip(courses, products):
+        for course, product in zip(courses, products, strict=True):
             relations.append(
                 factories.CourseProductRelationFactory(
                     course=course, product=product, organizations=[organizations[0]]
@@ -144,7 +144,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             organization=organizations[0], user=user
         )
         relations = []
-        for course, product in zip(courses, products):
+        for course, product in zip(courses, products, strict=True):
             relations.append(
                 factories.CourseProductRelationFactory(
                     course=course, product=product, organizations=[organizations[0]]
@@ -187,7 +187,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         products = factories.ProductFactory.create_batch(5)
 
         relations = []
-        for course, product in zip(courses, products):
+        for course, product in zip(courses, products, strict=True):
             relations.append(
                 factories.CourseProductRelationFactory(
                     course=course, product=product, organizations=[organizations[0]]

--- a/src/backend/joanie/tests/core/test_api_organizations_courses.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_courses.py
@@ -72,8 +72,8 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         content = response.json()
         self.assertEqual(content["count"], 3)
         self.assertEqual(
-            set(map(lambda x: str(x["id"]), content["results"])),
-            set(map(lambda x: str(x.id), courses)),
+            {str(x["id"]) for x in content["results"]},
+            {str(x.id) for x in courses},
         )
 
     def test_api_organizations_courses_read_list_without_access(self):

--- a/src/backend/joanie/tests/core/test_models_enrollment.py
+++ b/src/backend/joanie/tests/core/test_models_enrollment.py
@@ -500,7 +500,7 @@ class EnrollmentModelsTestCase(TestCase):
             ),
         )
 
-    def test_models_enrollment_forbid_for_listed_course_run_not_linked_to_product_in_scope_of_order(  # noqa pylint: disable=line-too-long
+    def test_models_enrollment_forbid_for_listed_course_run_not_linked_to_product_in_scope_of_order(  # pylint: disable=line-too-long
         self,
     ):
         """

--- a/src/backend/joanie/tests/core/test_models_product.py
+++ b/src/backend/joanie/tests/core/test_models_product.py
@@ -301,7 +301,7 @@ class ProductModelsTestCase(TestCase):
             ],
         )
 
-    def test_models_product_get_equivalent_serialized_course_runs_for_products_with_visibility(  # noqa pylint: disable=line-too-long
+    def test_models_product_get_equivalent_serialized_course_runs_for_products_with_visibility(  # pylint: disable=line-too-long
         self,
     ):
         """
@@ -343,7 +343,7 @@ class ProductModelsTestCase(TestCase):
             ],
         )
 
-    def test_models_product_get_equivalent_serialized_course_runs_for_products_without_course_relations(  # noqa pylint: disable=line-too-long
+    def test_models_product_get_equivalent_serialized_course_runs_for_products_without_course_relations(  # pylint: disable=line-too-long
         self,
     ):
         """

--- a/src/backend/joanie/tests/lms_handler/test_api_course_run_sync_edx.py
+++ b/src/backend/joanie/tests/lms_handler/test_api_course_run_sync_edx.py
@@ -427,7 +427,7 @@ class SyncCourseRunApiTestCase(TestCase):
         course_run = CourseRun.objects.get(course=course)
         serializer = SyncCourseRunSerializer(instance=course_run)
 
-        no_update_fields = getattr(settings, "JOANIE_LMS_BACKENDS")[0].get(
+        no_update_fields = settings.JOANIE_LMS_BACKENDS[0].get(
             "COURSE_RUN_SYNC_NO_UPDATE_FIELDS"
         )
         for field in serializer.fields:

--- a/src/backend/manage.py
+++ b/src/backend/manage.py
@@ -9,6 +9,6 @@ if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "joanie.settings")
     os.environ.setdefault("DJANGO_CONFIGURATION", "Development")
 
-    from configurations.management import execute_from_command_line  # noqa
+    from configurations.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -72,15 +72,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "bandit==1.7.5",
     "cssselect==1.2.0",
     "django-extensions==3.2.3",
     "drf-spectacular-sidecar==2023.10.1",
-    "flake8==6.1.0",
-    "flake8-pyproject==1.2.3",
     "ipdb==0.13.13",
     "ipython==8.18.0",
-    "isort==5.12.0",
     "lxml==4.9.3",
     "pdfminer.six==20221105",
     "pyfakefs==5.3.1",
@@ -112,17 +108,34 @@ exclude = [
     "__pycache__",
     "*/migrations/*",
 ]
+ignore= ["DJ001", "PLR2004"]
 line-length = 88
 
-[tool.isort]
-known_django = "django"
-known_joanie = "joanie"
-include_trailing_comma = true
-line_length = 88
-multi_line_output = 3
-use_parentheses = true
-sections = ["FUTURE","STDLIB","DJANGO","THIRDPARTY","JOANIE","FIRSTPARTY","LOCALFOLDER"]
-skip_glob = "venv"
+
+[tool.ruff.lint]
+select = [
+    "B", # flake8-bugbear
+    "BLE", # flake8-blind-except
+    "C4", # flake8-comprehensions
+    "DJ", # flake8-django
+    "I", # isort
+    "PLC", # pylint-convention
+    "PLE", # pylint-error
+    "PLR", # pylint-refactoring
+    "PLW", # pylint-warning
+    "RUF100", # Ruff unused-noqa
+    "RUF200", # Ruff check pyproject.toml
+    "S", # flake8-bandit
+    "SLF", # flake8-self
+    "T20", # flake8-print
+]
+
+[tool.ruff.lint.isort]
+section-order = ["future","standard-library","django","third-party","joanie","first-party","local-folder"]
+sections = { joanie=["joanie"], django=["django"] }
+
+[tool.ruff.per-file-ignores]
+"joanie/**/tests/*" = ["S", "SLF"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -73,7 +73,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "bandit==1.7.5",
-    "black==23.11.0",
     "cssselect==1.2.0",
     "django-extensions==3.2.3",
     "drf-spectacular-sidecar==2023.10.1",
@@ -93,6 +92,7 @@ dev = [
     "pytest-icdiff==0.8",
     "pytest-xdist==3.5.0",
     "responses==0.24.1",
+    "ruff==0.1.6",
     "types-requests==2.31.0.10",
 ]
 
@@ -103,7 +103,7 @@ zip-safe = true
 [tool.distutils.bdist_wheel]
 universal = true
 
-[tool.flake8]
+[tool.ruff]
 exclude = [
     ".git",
     ".venv",
@@ -112,7 +112,7 @@ exclude = [
     "__pycache__",
     "*/migrations/*",
 ]
-max-line-length = 99
+line-length = 88
 
 [tool.isort]
 known_django = "django"


### PR DESCRIPTION
## Purpose

Replace all linters and black formatter by ruff.

## Questions
- [x] Should we disable rule `ARG` globally or decide to prefix all unused positional arguments with a `_` ? Disable globaly
- [x] Do we want to enable pydocstyle to enforce format of your docstring ? Nope

## Todo
- [x] Read that : https://github.com/astral-sh/ruff/issues/970#issuecomment-1782549912
- [x] Then check this : https://github.com/mtshiba/pylyzer
