### PR TITLE
✨(backend) add synchronize_course_runs management command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## Added
 
+- Add a management command to synchronize course run or product 
+  on a remote catalog
 - Install and configure celery with redis
 - Add CachedModelSerializer
 - Allow to leave organization empty while order is in draft

--- a/src/backend/joanie/core/management/commands/synchronize_course_runs.py
+++ b/src/backend/joanie/core/management/commands/synchronize_course_runs.py
@@ -1,0 +1,197 @@
+"""Management command to synchronize course runs or equivalent course runs."""
+import logging
+from uuid import UUID
+
+from django.core.management import BaseCommand
+from django.utils.translation import ngettext_lazy
+
+from joanie.core import enums
+from joanie.core.models import Course, CourseRun, Product
+from joanie.core.utils import webhooks
+
+logger = logging.getLogger("joanie.core.synchronize_course_run")
+
+
+class Command(BaseCommand):
+    """
+     A command to trigger course resources (course run or product) synchronization.
+
+     Only listed course runs and credential products can be synchronized. The targeted
+     resource(s) are synchronized with each platforms setup through the
+     `COURSE_WEB_HOOKS` settings.
+
+    Here is the list of available options:
+     --course, -c: a course id or a course code (required)
+     --product, -p: a product id or a list of product id.
+     --course-run, -cr: a course run id or a list of course run id.
+    """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--course",
+            "-c",
+            help="Accept a single course code or course id (This option is mandatory).",
+            required=True,
+        )
+
+        parser.add_argument(
+            "--course-runs",
+            "--course-run",
+            "-cr",
+            help=(
+                "Accept a single course run id or a list of course run id. "
+                "Only course runs with flag `is_listed` sets to `True` will be "
+                "synchronized. Furthermore, all course runs must be linked to the "
+                "provided course."
+            ),
+        )
+
+        parser.add_argument(
+            "--products",
+            "--product",
+            "-p",
+            help=(
+                "Accept a single product_id or a list of product_id. "
+                "Only products with `type` sets to `CREDENTIAL` will be synchronized. "
+                "Furthermore, all products must be linked to the provided course."
+            ),
+        )
+
+        parser.add_argument(
+            "--visibility",
+            help=(
+                "Enforce the visibility of the course run(s) or product(s) to synchronize. "
+                "It accepts all values from `joanie.core.enums.CATALOG_VISIBILITY_CHOICES`. "
+                '"course_and_search" - show on the course page and include in search results. '
+                '| "course_only" - show on the course page and hide from search results. '
+                '| "hidden" - hide on the course page and from search results.'
+            ),
+        )
+
+    def get_course_filter(self, course_reference: str):
+        """
+        Return the right lookup filter according to course_reference type is a valid
+        UUID or not. If course_reference is a valid UUID, we return a filter on
+        `id` else we return a filter on `code`.
+        """
+        try:
+            UUID(course_reference)
+        except ValueError:
+            lookup_filter = "code"
+        else:
+            lookup_filter = "id"
+
+        return {lookup_filter: course_reference}
+
+    def get_serialized_course_runs_to_synchronize(
+        self, course: Course, course_run_ids: list[str], visibility: str = None
+    ) -> list[dict]:
+        """
+        Return a list of serialized course runs to synchronize.
+
+        If course_run_ids is not provided, all listed course runs linked to the provided
+        course will be returned. Otherwise, only listed course runs with ids in
+        course_run_ids will be returned.
+
+        If visibility is provided, it will be taken in account during the serialization.
+        """
+        filters = {"course": course, "is_listed": True}
+
+        if course_run_ids:
+            filters["id__in"] = course_run_ids
+
+        return [
+            course_run.get_serialized(visibility=visibility)
+            for course_run in CourseRun.objects.filter(**filters)
+        ]
+
+    def get_serialized_products_to_synchronize(
+        self, course: Course, product_ids: list[str] = None, visibility: str = None
+    ) -> list[dict]:
+        """
+        Return a list of serialized products to synchronize.
+
+        If product_ids is not provided, all credential products linked to the provided
+        course will be returned. Otherwise, only credential products matching ids in
+        product_ids will be returned.
+
+        If visibility is provided, it will be taken in account during the serialization.
+        """
+        filters = {"type": enums.PRODUCT_TYPE_CREDENTIAL}
+
+        if product_ids:
+            filters["id__in"] = product_ids
+
+        return Product.get_equivalent_serialized_course_runs_for_products(
+            products=Product.objects.filter(**filters),
+            courses=[course],
+            visibility=visibility,
+        )
+
+    def handle(self, *args, **options):
+        """
+        Retrieve all synchronizable course runs and/or products according to provided
+        options then synchronize them on all platforms setup through the
+        `COURSE_WEB_HOOKS` settings.
+        """
+        course_reference = options["course"]
+        course_run_ids = None
+        product_ids = None
+        visibility = options.get("visibility")
+
+        try:
+            filters = self.get_course_filter(course_reference)
+            course = Course.objects.get(**filters)
+        except Course.DoesNotExist as error:
+            filter_key = list(filters.keys())[0]
+            raise KeyError(
+                f'Course with {filter_key} "{course_reference}" does not exist.'
+            ) from error
+
+        if options.get("course_runs"):
+            course_run_ids = (
+                options["course_runs"]
+                if isinstance(options["course_runs"], list)
+                else [options["course_runs"]]
+            )
+
+        if options.get("products"):
+            product_ids = (
+                options["products"]
+                if isinstance(options["products"], list)
+                else [options["products"]]
+            )
+
+        serialized_course_runs = []
+
+        if course_run_ids or not product_ids:
+            course_runs = self.get_serialized_course_runs_to_synchronize(
+                course, course_run_ids, visibility
+            )
+            serialized_course_runs += course_runs
+            logger.info(
+                ngettext_lazy(
+                    "%d course run to synchronize.",
+                    "%d course runs to synchronize.",
+                    len(course_runs),
+                ),
+                len(course_runs),
+            )
+
+        if product_ids or not course_run_ids:
+            products = self.get_serialized_products_to_synchronize(
+                course, product_ids, visibility
+            )
+            serialized_course_runs += products
+            logger.info(
+                ngettext_lazy(
+                    "%d product to synchronize.",
+                    "%d products to synchronize.",
+                    len(products),
+                ),
+                len(products),
+            )
+
+        webhooks.synchronize_course_runs(serialized_course_runs)

--- a/src/backend/joanie/tests/core/test_commands_synchronize_course_runs.py
+++ b/src/backend/joanie/tests/core/test_commands_synchronize_course_runs.py
@@ -1,0 +1,223 @@
+"""Test suite for the management command `synchronize_course_runs`."""
+import random
+import uuid
+from unittest import mock
+
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from joanie.core import enums, factories
+from joanie.core.models import Product
+from joanie.core.utils import webhooks
+
+
+class SynchronizeCourseRunsTestCase(TestCase):
+    """Test case for the management command `synchronize_course_runs`."""
+
+    def test_commands_synchronize_course_runs_option_course_mandatory(self):
+        """
+        This command takes one mandatory argument 'course' which must match an existing
+        course.
+        """
+
+        # If a course option is missing, a CommandError should be raised.
+        with self.assertRaisesMessage(
+            CommandError, "Error: the following arguments are required: --course/-c"
+        ):
+            call_command("synchronize_course_runs")
+
+        # If a course code is provided but does not match an existing course, a
+        # KeyError should be raised
+        with self.assertRaisesMessage(
+            KeyError, 'Course with code "00000" does not exist.'
+        ):
+            call_command("synchronize_course_runs", course="00000")
+
+        # If a course id is provided but does not match an existing course, a
+        # KeyError should be raised
+        course_id = str(uuid.uuid4())
+        with self.assertRaisesMessage(
+            KeyError, f'Course with id "{course_id}" does not exist.'
+        ):
+            call_command("synchronize_course_runs", course=course_id)
+
+    def test_commands_synchronize_course_runs_has_options(self):
+        """
+        This command should accept one required argument course then three optional
+        arguments `course_runs`, `products` and `visibility`.
+        """
+        factories.CourseFactory(code="00000")
+
+        options = {
+            "course": "00000",
+            "course_runs": uuid.uuid4(),
+            "products": uuid.uuid4(),
+            "visibility": "course_and_search",
+        }
+
+        call_command("synchronize_course_runs", **options)
+
+    @mock.patch.object(webhooks, "synchronize_course_runs")
+    def test_commands_synchronize_course_runs_without_resources(self, webhook_mock):
+        """
+        If any course run or product are provided, the command should retrieve
+        listed course runs and credential products related to the provided course.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(course=course, is_listed=True)
+        factories.CourseRunFactory(course=course, is_listed=False)
+
+        product = factories.ProductFactory(
+            courses=[course], type=enums.PRODUCT_TYPE_CREDENTIAL
+        )
+        factories.ProductFactory(courses=[course], type=enums.PRODUCT_TYPE_CERTIFICATE)
+        factories.ProductFactory(courses=[course], type=enums.PRODUCT_TYPE_ENROLLMENT)
+        webhook_mock.reset_mock()
+
+        call_command("synchronize_course_runs", course=course.code)
+
+        webhook_mock.assert_called_once_with(
+            [
+                course_run.get_serialized(),
+                *Product.get_equivalent_serialized_course_runs_for_products(
+                    [product], courses=[course]
+                ),
+            ]
+        )
+
+    @mock.patch.object(webhooks, "synchronize_course_runs")
+    def test_commands_synchronize_course_runs_with_course_runs(self, webhook_mock):
+        """
+        If course runs ids are provided, the command should synchronize only
+        listed course runs matching ids.
+        """
+        course = factories.CourseFactory()
+        listed_course_run = factories.CourseRunFactory(course=course, is_listed=True)
+        not_listed_course_run = factories.CourseRunFactory(
+            course=course, is_listed=False
+        )
+
+        factories.ProductFactory.create_batch(3, courses=[course])
+        webhook_mock.reset_mock()
+
+        call_command(
+            "synchronize_course_runs",
+            course=course.code,
+            course_runs=[
+                listed_course_run.id,
+                not_listed_course_run.id,
+                str(uuid.uuid4()),
+            ],
+        )
+
+        webhook_mock.assert_called_once_with([listed_course_run.get_serialized()])
+
+    @mock.patch.object(webhooks, "synchronize_course_runs")
+    def test_commands_synchronize_course_runs_with_single_course_run_id(
+        self, webhook_mock
+    ):
+        """
+        This command should accept a single course run id as argument instead of a list.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(course=course, is_listed=True)
+
+        webhook_mock.reset_mock()
+
+        call_command(
+            "synchronize_course_runs", course=course.code, course_run=course_run.id
+        )
+
+        webhook_mock.assert_called_once_with([course_run.get_serialized()])
+
+    @mock.patch.object(webhooks, "synchronize_course_runs")
+    def test_commands_synchronize_course_runs_with_products(self, webhook_mock):
+        """
+        If product ids are provided, the command should synchronize only
+        credential products matching ids.
+        """
+        course = factories.CourseFactory()
+        credential_product = factories.ProductFactory(
+            courses=[course], type=enums.PRODUCT_TYPE_CREDENTIAL
+        )
+        certificate_product = factories.ProductFactory(
+            courses=[course], type=enums.PRODUCT_TYPE_CERTIFICATE
+        )
+        enrollment_product = factories.ProductFactory(
+            courses=[course], type=enums.PRODUCT_TYPE_ENROLLMENT
+        )
+        factories.CourseRunFactory.create_batch(3, course=course, is_listed=True)
+
+        webhook_mock.reset_mock()
+
+        call_command(
+            "synchronize_course_runs",
+            course=course.code,
+            products=[
+                credential_product.id,
+                certificate_product.id,
+                enrollment_product.id,
+                str(uuid.uuid4()),
+            ],
+        )
+
+        webhook_mock.assert_called_once_with(
+            Product.get_equivalent_serialized_course_runs_for_products(
+                [credential_product], courses=[course]
+            )
+        )
+
+    @mock.patch.object(webhooks, "synchronize_course_runs")
+    def test_commands_synchronize_course_runs_with_single_product_id(
+        self, webhook_mock
+    ):
+        """
+        This command should accept a single product id as argument instead of a list.
+        """
+        course = factories.CourseFactory()
+        credential_product = factories.ProductFactory(
+            courses=[course], type=enums.PRODUCT_TYPE_CREDENTIAL
+        )
+
+        webhook_mock.reset_mock()
+
+        call_command(
+            "synchronize_course_runs", course=course.code, product=credential_product.id
+        )
+
+        webhook_mock.assert_called_once_with(
+            Product.get_equivalent_serialized_course_runs_for_products(
+                [credential_product], courses=[course]
+            )
+        )
+
+    @mock.patch.object(webhooks, "synchronize_course_runs")
+    def test_commands_synchronize_course_runs_with_visibility(self, webhook_mock):
+        """
+        The command should accept a visibility option to enforce the visibility
+        of synchronized resources.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(course=course, is_listed=True)
+        factories.CourseRunFactory(course=course, is_listed=False)
+
+        product = factories.ProductFactory(
+            courses=[course], type=enums.PRODUCT_TYPE_CREDENTIAL
+        )
+        factories.ProductFactory(courses=[course], type=enums.PRODUCT_TYPE_CERTIFICATE)
+        factories.ProductFactory(courses=[course], type=enums.PRODUCT_TYPE_ENROLLMENT)
+        webhook_mock.reset_mock()
+
+        visibility = random.choice(enums.CATALOG_VISIBILITY_CHOICES)
+        call_command(
+            "synchronize_course_runs", course=course.code, visibility=visibility
+        )
+
+        webhook_mock.assert_called_once_with(
+            [
+                course_run.get_serialized(visibility),
+                *Product.get_equivalent_serialized_course_runs_for_products(
+                    [product], courses=[course], visibility=visibility
+                ),
+            ]
+        )


### PR DESCRIPTION
## Purpose

In some case, we could need to manually trigger course run or product synchronization. We are now able to do that through this management command. Furthermore, in the hypothesis, later we would want to remove automatic synchronization logic based on signals, we were able to trigger synchronization by invoking this management command.

## Proposal

- [x] Create a command `synchronize_course_runs`
