### PR TITLE
💥(backend) rename client query attribute filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ and this project adheres to
   - CourseSerializer
   - CourseAccessSerializer
   - OrganizationAccessSerializer
+- Rename query parameters to be more descriptive:
+  - OrderViewSetFilter
+  - ProductViewSetFilter
+  - EnrollmentViewSetFilter
 
 ### Removed
 

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -13,20 +13,20 @@ class OrderViewSetFilter(filters.FilterSet):
     OrderFilter allows to filter this resource with a product id or its state.
     """
 
-    product = filters.UUIDFilter(field_name="product")
-    enrollment = filters.UUIDFilter(field_name="enrollment")
-    course = filters.CharFilter(field_name="course__code")
+    product_id = filters.UUIDFilter(field_name="product")
+    enrollment_id = filters.UUIDFilter(field_name="enrollment")
+    course_code = filters.CharFilter(field_name="course__code")
     state = filters.MultipleChoiceFilter(
         field_name="state", choices=enums.ORDER_STATE_CHOICES
     )
-    state__exclude = filters.MultipleChoiceFilter(
+    state_exclude = filters.MultipleChoiceFilter(
         field_name="state", choices=enums.ORDER_STATE_CHOICES, exclude=True
     )
-    product__type = filters.MultipleChoiceFilter(
+    product_type = filters.MultipleChoiceFilter(
         field_name="product__type",
         choices=enums.PRODUCT_TYPE_CHOICES,
     )
-    product__type__exclude = filters.MultipleChoiceFilter(
+    product_type_exclude = filters.MultipleChoiceFilter(
         field_name="product__type",
         choices=enums.PRODUCT_TYPE_CHOICES,
         exclude=True,
@@ -42,7 +42,7 @@ class ProductViewSetFilter(filters.FilterSet):
     ProductViewSetFilter allows to filter this resource with a course code.
     """
 
-    course = filters.CharFilter(field_name="courses__code")
+    course_code = filters.CharFilter(field_name="courses__code")
 
     class Meta:
         model = models.Product
@@ -54,7 +54,7 @@ class EnrollmentViewSetFilter(filters.FilterSet):
     EnrollmentViewSetFilter allows to filter this resource with a course run id.
     """
 
-    course_run = filters.UUIDFilter(field_name="course_run__id")
+    course_run_id = filters.UUIDFilter(field_name="course_run__id")
     was_created_by_order = filters.BooleanFilter(field_name="was_created_by_order")
 
     class Meta:

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -497,7 +497,7 @@ class EnrollmentApiTest(BaseAPITestCase):
 
         # Retrieve user's enrollment related to the first course_run
         response = self.client.get(
-            f"/api/v1.0/enrollments/?course_run={str(course_run_1.id)}",
+            f"/api/v1.0/enrollments/?course_run_id={str(course_run_1.id)}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -570,12 +570,14 @@ class EnrollmentApiTest(BaseAPITestCase):
 
         # Retrieve user's enrollment related to the first course_run
         response = self.client.get(
-            "/api/v1.0/enrollments/?course_run=invalid_course_run_id",
+            "/api/v1.0/enrollments/?course_run_id=invalid_course_run_id",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json(), {"course_run": ["Enter a valid UUID."]})
+        self.assertDictEqual(
+            response.json(), {"course_run_id": ["Enter a valid UUID."]}
+        )
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment")
     def test_api_enrollment_read_list_filtered_by_was_created_by_order(self, _mock_set):

--- a/src/backend/joanie/tests/core/test_api_order.py
+++ b/src/backend/joanie/tests/core/test_api_order.py
@@ -221,7 +221,7 @@ class OrderApiTest(BaseAPITestCase):
 
         # Retrieve user's order related to the product 1
         response = self.client.get(
-            f"/api/v1.0/orders/?product={product_1.id}",
+            f"/api/v1.0/orders/?product_id={product_1.id}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -274,12 +274,12 @@ class OrderApiTest(BaseAPITestCase):
         # should return a 400 error
         with self.assertNumQueries(0):
             response = self.client.get(
-                "/api/v1.0/orders/?product=invalid_product_id",
+                "/api/v1.0/orders/?product_id=invalid_product_id",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json(), {"product": ["Enter a valid UUID."]})
+        self.assertDictEqual(response.json(), {"product_id": ["Enter a valid UUID."]})
 
     @mock.patch.object(
         fields.ThumbnailDetailField,
@@ -315,7 +315,7 @@ class OrderApiTest(BaseAPITestCase):
 
         # Retrieve user's order related to the enrollment 1
         response = self.client.get(
-            f"/api/v1.0/orders/?enrollment={enrollment_1.id}",
+            f"/api/v1.0/orders/?enrollment_id={enrollment_1.id}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -423,12 +423,14 @@ class OrderApiTest(BaseAPITestCase):
         # should return a 400 error
         with self.assertNumQueries(0):
             response = self.client.get(
-                "/api/v1.0/orders/?enrollment=invalid_enrollment_id",
+                "/api/v1.0/orders/?enrollment_id=invalid_enrollment_id",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
         self.assertEqual(response.status_code, 400)
-        self.assertDictEqual(response.json(), {"enrollment": ["Enter a valid UUID."]})
+        self.assertDictEqual(
+            response.json(), {"enrollment_id": ["Enter a valid UUID."]}
+        )
 
     @mock.patch.object(
         fields.ThumbnailDetailField,
@@ -451,7 +453,7 @@ class OrderApiTest(BaseAPITestCase):
         # Retrieve user's order related to the first course linked to the product 1
         with self.assertNumQueries(6):
             response = self.client.get(
-                f"/api/v1.0/orders/?course={product_1.courses.first().code}",
+                f"/api/v1.0/orders/?course_code={product_1.courses.first().code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
@@ -524,7 +526,7 @@ class OrderApiTest(BaseAPITestCase):
         # Retrieve user's order related to the first course linked to the product 1
         with self.assertNumQueries(5):
             response = self.client.get(
-                f"/api/v1.0/orders/?product__type={enums.PRODUCT_TYPE_CERTIFICATE}",
+                f"/api/v1.0/orders/?product_type={enums.PRODUCT_TYPE_CERTIFICATE}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
@@ -664,8 +666,8 @@ class OrderApiTest(BaseAPITestCase):
         with self.assertNumQueries(8):
             response = self.client.get(
                 (
-                    f"/api/v1.0/orders/?product__type={enums.PRODUCT_TYPE_CERTIFICATE}"
-                    f"&product__type={enums.PRODUCT_TYPE_CREDENTIAL}"
+                    f"/api/v1.0/orders/?product_type={enums.PRODUCT_TYPE_CERTIFICATE}"
+                    f"&product_type={enums.PRODUCT_TYPE_CREDENTIAL}"
                 ),
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
@@ -680,7 +682,7 @@ class OrderApiTest(BaseAPITestCase):
 
         # Retrieve user's orders filtered to exclude one product type
         response = self.client.get(
-            f"/api/v1.0/orders/?product__type__exclude={enums.PRODUCT_TYPE_CERTIFICATE}",
+            f"/api/v1.0/orders/?product_type_exclude={enums.PRODUCT_TYPE_CERTIFICATE}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -719,7 +721,7 @@ class OrderApiTest(BaseAPITestCase):
         # Retrieve user's order related to the first course linked to the product 1
         with self.assertNumQueries(0):
             response = self.client.get(
-                "/api/v1.0/orders/?product__type=invalid_product_type",
+                "/api/v1.0/orders/?product_type=invalid_product_type",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
@@ -727,7 +729,7 @@ class OrderApiTest(BaseAPITestCase):
         self.assertDictEqual(
             response.json(),
             {
-                "product__type": [
+                "product_type": [
                     (
                         "Select a valid choice. "
                         "invalid_product_type is not one of the available choices."
@@ -979,7 +981,7 @@ class OrderApiTest(BaseAPITestCase):
 
         # Retrieve user's orders filtered to exclude 2 states
         response = self.client.get(
-            "/api/v1.0/orders/?state__exclude=validated&state__exclude=pending",
+            "/api/v1.0/orders/?state_exclude=validated&state_exclude=pending",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 


### PR DESCRIPTION
## Purpose

Some query attributes are misleading ie: product was awaiting for a product_id.

Updated filters:
 - OrderViewSetFilter
 - ProductViewSetFilter
 - EnrollmentViewSetFilter

