### PR TITLE
✨(backend) Route to create and get zip archive

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -7,9 +7,11 @@ import io
 import uuid
 
 from django.core.exceptions import ValidationError
+from django.core.files.storage import storages
 from django.db import IntegrityError, transaction
 from django.db.models import Count, OuterRef, Prefetch, Q, Subquery
 from django.http import FileResponse, HttpResponse, JsonResponse
+from django.urls import reverse
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema
@@ -23,10 +25,16 @@ from rest_framework.response import Response
 
 from joanie.core import enums, filters, models, permissions, serializers
 from joanie.core.api.base import NestedGenericViewSet
+from joanie.core.tasks import generate_zip_archive_task
+from joanie.core.utils import contract as contract_utility
 from joanie.core.utils import contract_definition, issuers
 from joanie.payment.models import Invoice
 
 # pylint: disable=too-many-ancestors, too-many-lines
+
+UUID_REGEX = (
+    "[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"
+)
 
 
 class Pagination(pagination.PageNumberPagination):
@@ -1014,7 +1022,7 @@ class ContractViewSet(GenericContractViewSet):
         detail=True,
         methods=["GET"],
     )
-    def download(self, request, pk=None):  # pylint: disable=no-self-use, unused-argument, invalid-name
+    def download(self, request, pk=None):  # pylint: disable=unused-argument, invalid-name
         """
         Return the PDF in bytes to download of the contract's definition of an order.
         """
@@ -1048,6 +1056,86 @@ class ContractViewSet(GenericContractViewSet):
             as_attachment=True,
             filename=f"{contract.definition.title}.pdf".replace(" ", "_"),
         )
+
+    @action(
+        methods=["GET"],
+        detail=False,
+        url_name="zip-archive",
+        url_path=rf"zip-archive/(?P<zip_id>{UUID_REGEX})",
+    )
+    def get_zip_archive(self, request, zip_id):
+        """
+        Return the ZIP archive once it has been generated and it exists into storages.
+
+        When the ZIP archive is not ready yet, we will return a response with the status code 404
+        until the ZIP is available to be served. Once available, we return the ZIP archive.
+        If the paired User UUID and the received ZIP UUID do not match any files in storage,
+        it return a response with the status code 404.
+        You must add the ZIP id as a payload.
+        """
+
+        storage = storages["contracts"]
+        zip_archive_name = f"{request.user.id}_{zip_id}.zip"
+        zip_archive_exists = storage.exists(zip_archive_name)
+
+        if not zip_archive_exists:
+            return Response(status=404)
+
+        return FileResponse(
+            storage.open(f"{storage.location}/{zip_archive_name}", mode="rb"),
+            as_attachment=True,
+            filename=zip_archive_name,
+            content_type="application/zip",
+        )
+
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_name="generate_zip_archive",
+        url_path="zip-archive",
+    )
+    def generate_zip_archive(self, request, **kwargs):  # pylint: disable=no-self-use, unused-argument,
+        """
+        This endpoint is exclusive to users that have access rights on a specific organization.
+
+        It triggers the generation of a ZIP archive if the requesting has the correct access rights
+        on the organization. If a course product relation UUID is given from key word arguments,
+        the user requires to have access to the organization that is attached to the specific
+        course product relation object.
+        We return in the response the URL for polling the ZIP archive once it has been generated.
+
+        Notes on possible `kwargs` as input parameters :
+            - string of an Organization UUID
+            OR
+            - string of an CourseProductRelation UUID
+        """
+        serializer = serializers.GenerateSignedContractsZipSerializer(data=request.data)
+
+        serializer.is_valid(raise_exception=True)
+
+        if not contract_utility.get_signature_beackend_references_exists(
+            course_product_relation=serializer.data.get("course_product_relation"),
+            organization=serializer.data.get("organization"),
+            extra_filters={"order__organization__accesses__user_id": request.user.id},
+        ):
+            raise ValidationError("No zip to generate")
+
+        # Generate here the zip uuid4 to generate ZIP archive for the requesting user
+        zip_id = uuid.uuid4()  # ZIP UUID to build the ZIP archive name
+        options = {
+            "user": request.user.id,
+            "organization_id": serializer.data.get("organization_id"),
+            "course_product_relation_id": serializer.data.get(
+                "course_product_relation_id"
+            ),
+            "zip": str(zip_id),
+        }
+
+        generate_zip_archive_task.delay(options)
+
+        url_base = reverse("contracts-zip-archive", kwargs={"zip_id": str(zip_id)})
+
+        return JsonResponse({"url": url_base}, status=202)
 
 
 class NestedOrganizationContractViewSet(NestedGenericViewSet, GenericContractViewSet):

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -880,8 +880,8 @@ class GenerateSignedContractsZipSerializer(serializers.Serializer):
     Serializer used by both view and command generating a zip containing signed contracts
     """
 
-    course_product_relation_id = serializers.UUIDField(required=False)
-    organization_id = serializers.UUIDField(required=False)
+    course_product_relation_id = serializers.UUIDField(allow_null=True, required=False)
+    organization_id = serializers.UUIDField(allow_null=True, required=False)
 
     def validate(self, attrs):
         """

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -873,3 +873,71 @@ class UserSerializer(serializers.ModelSerializer):
         if request:
             return request.user.get_abilities(user)
         return {}
+
+
+class GenerateSignedContractsZipSerializer(serializers.Serializer):
+    """
+    Serializer used by both view and command generating a zip containing signed contracts
+    """
+
+    course_product_relation_id = serializers.UUIDField(required=False)
+    organization_id = serializers.UUIDField(required=False)
+
+    def validate(self, attrs):
+        """
+        Validate that course_product_relation_id and organization_id are mutually exclusive
+        but at least one is required.
+
+        Also, it fetch in database the corresponding object to add them in the validated data.
+        """
+        course_product_relation_id = attrs.get("course_product_relation_id")
+        organization_id = attrs.get("organization_id")
+        if course_product_relation_id and organization_id:
+            raise serializers.ValidationError(
+                "You must set exactly one parameter for the method. It cannot be both. "
+                "You must choose between an Organization UUID or a Course Product Relation UUID."
+            )
+
+        if not course_product_relation_id and not organization_id:
+            raise serializers.ValidationError(
+                "You must set at least one parameter for the method."
+                "You must choose between an Organization UUID or a Course Product Relation UUID."
+            )
+
+        errors = {}
+        if course_product_relation_id:
+            try:
+                attrs[
+                    "course_product_relation"
+                ] = models.CourseProductRelation.objects.get(
+                    pk=course_product_relation_id
+                )
+            except models.CourseProductRelation.DoesNotExist:
+                errors["course_product_relation_id"] = (
+                    "Make sure to give an existing course product relation UUID. "
+                    "No CourseProductRelation was found with the given "
+                    f"UUID : {attrs.get('course_product_relation_id')}."
+                )
+
+        if organization_id:
+            try:
+                attrs["organization"] = models.Organization.objects.get(
+                    pk=organization_id
+                )
+            except models.Organization.DoesNotExist:
+                errors["organization_id"] = (
+                    "Make sure to give an existing organization UUID. "
+                    "No Organization was found with the givin UUID : "
+                    f"{attrs.get('organization_id')}."
+                )
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return attrs
+
+    def update(self, instance, validated_data):
+        pass
+
+    def create(self, validated_data):
+        pass

--- a/src/backend/joanie/core/tasks.py
+++ b/src/backend/joanie/core/tasks.py
@@ -1,0 +1,20 @@
+"""Celery tasks for the `core` app of Joanie"""
+from logging import getLogger
+
+from django.core.management import call_command
+
+from joanie.celery_app import app
+
+logger = getLogger(__name__)
+
+
+@app.task
+def generate_zip_archive_task(options):
+    """
+    Task to generate the ZIP archive of the signed contracts.
+    It calls the django custom command `generate_zip_archive_of_contracts` with the parsed
+    options.
+    """
+    logger.info("Starting Celery task, generating a ZIP Archive...")
+    call_command("generate_zip_archive_of_contracts", **options)
+    logger.info("Done executing Celery generating a ZIP Archive task...")

--- a/src/backend/joanie/core/utils/contract.py
+++ b/src/backend/joanie/core/utils/contract.py
@@ -13,20 +13,15 @@ from joanie.signature.backends import get_signature_backend
 logger = getLogger(__name__)
 
 
-def get_signature_backend_references(
+def _get_base_signature_backend_references(
     course_product_relation=None, organization=None, extra_filters=None
 ):
     """
-    Get a generator object with signature backend references from either a Course Product Relation
-    object or an Organization object when the contract is signed. Otherwise, it returns an empty
-    generator if there are no signed contracts yet.
+    Build the base query to get signature backend references from either a Course Product Relation
+    object or an Organization object when the contract is signed.
 
     You may use an additional parameter `extra_filters` if you need to filter out even more the
     base queryset of the Contract (check if the user has access to the organization for example).
-
-    We use the iterator method because it reduces memory consumption and improve the performance
-    when we work with large dataset. It processes the database records one at a time instead of
-    loading the entire QuerySet into memory all at once.
     """
     if not extra_filters:
         extra_filters = {}
@@ -48,6 +43,49 @@ def get_signature_backend_references(
 
     if organization:
         base_query = base_query.filter(order__organization_id=organization.pk)
+
+    return base_query
+
+
+def get_signature_beackend_references_exists(
+    course_product_relation=None, organization=None, extra_filters=None
+):
+    """
+    Check if signature backend references exist from either a Course Product Relation
+    object or an Organization object when the contract is signed.
+
+    You may use an additional parameter `extra_filters` if you need to filter out even more the
+    base queryset of the Contract (check if the user has access to the organization for example).
+    """
+    base_query = _get_base_signature_backend_references(
+        course_product_relation=course_product_relation,
+        organization=organization,
+        extra_filters=extra_filters,
+    )
+
+    return base_query.distinct().exists()
+
+
+def get_signature_backend_references(
+    course_product_relation=None, organization=None, extra_filters=None
+):
+    """
+    Get a generator object with signature backend references from either a Course Product Relation
+    object or an Organization object when the contract is signed. Otherwise, it returns an empty
+    generator if there are no signed contracts yet.
+
+    You may use an additional parameter `extra_filters` if you need to filter out even more the
+    base queryset of the Contract (check if the user has access to the organization for example).
+
+    We use the iterator method because it reduces memory consumption and improve the performance
+    when we work with large dataset. It processes the database records one at a time instead of
+    loading the entire QuerySet into memory all at once.
+    """
+    base_query = _get_base_signature_backend_references(
+        course_product_relation=course_product_relation,
+        organization=organization,
+        extra_filters=extra_filters,
+    )
 
     signature_backend_references = (
         base_query.values_list("signature_backend_reference", flat=True)

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -607,6 +607,22 @@ class Test(Base):
         },
     }
 
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+        "contracts": {
+            "BACKEND": "django.core.files.storage.InMemoryStorage",
+            "OPTIONS": {
+                "location": os.path.join(DATA_DIR, "contracts"),
+                "base_url": "/contracts/",
+            },
+        },
+    }
+
     def __init__(self):
         # pylint: disable=invalid-name
         self.INSTALLED_APPS += ["joanie.tests", "drf_spectacular_sidecar"]

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -623,6 +623,8 @@ class Test(Base):
         },
     }
 
+    CELERY_TASK_ALWAYS_EAGER = values.BooleanValue(True)
+
     def __init__(self):
         # pylint: disable=invalid-name
         self.INSTALLED_APPS += ["joanie.tests", "drf_spectacular_sidecar"]

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -1,15 +1,22 @@
 """Test suite for the Contract API"""
+import json
 import random
 from io import BytesIO
 from unittest import mock
+from uuid import uuid4
 
+from django.core.files.storage import storages
 from django.utils import timezone
 
 from pdfminer.high_level import extract_text as pdf_extract_text
 
 from joanie.core import enums, factories
 from joanie.core.serializers import fields
+from joanie.core.utils import contract as contract_utility
+from joanie.core.utils import contract_definition
 from joanie.tests.base import BaseAPITestCase
+
+# pylint: disable=too-many-lines
 
 
 class ContractApiTest(BaseAPITestCase):
@@ -620,4 +627,423 @@ class ContractApiTest(BaseAPITestCase):
             response,
             "Cannot download a contract when it is not yet fully signed.",
             status_code=400,
+        )
+
+    def test_api_contract_generate_zip_archive_anonymous(self):
+        """
+        Anonymous user should not be able to generate ZIP archive.
+        """
+        response = self.client.get(
+            "/api/v1.0/contracts/zip-archive/",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_api_contract_generate_zip_archive_authenticated_get_method_not_allowed(
+        self,
+    ):
+        """
+        Authenticated user should not be able to use GET method on the viewset generate ZIP
+        archive.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            "/api/v1.0/contracts/zip-archive/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(response, 'Method \\"GET\\" not allowed.', status_code=405)
+
+    def test_api_contract_generate_zip_archive_authenticated_put_method_not_allowed(
+        self,
+    ):
+        """
+        Authenticated user should not be able to use PUT method on the viewset generate ZIP
+        archive.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.put(
+            "/api/v1.0/contracts/zip-archive/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+
+    def test_api_contract_generate_zip_archive_authenticated_patch_method_not_allowed(
+        self,
+    ):
+        """
+        Authenticated user should not be able to use PATCH method on the viewset generate ZIP
+        archive.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.patch(
+            "/api/v1.0/contracts/zip-archive/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+
+    def test_api_contract_generate_zip_archive_authenticated_delete_method_not_allowed(
+        self,
+    ):
+        """
+        Authenticated user should not be able to use DELETE method on the viewset generate ZIP
+        archive.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.delete(
+            "/api/v1.0/contracts/zip-archive/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )
+
+    def test_api_contract_generate_zip_archive_authenticated_post_without_parsing_parameters(
+        self,
+    ):
+        """
+        Authenticated user should be able to use POST method on the viewset to generate ZIP
+        archive but it will raise an error if both parsing arguments are missing : an existing
+        Organization UUID or a Course Product Relation. You need to set one at least.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization, user=user)
+        token = self.get_user_token(user.username)
+
+        response = self.client.post(
+            "/api/v1.0/contracts/zip-archive/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "non_field_errors": [
+                    (
+                        "You must set at least one parameter for the method."
+                        "You must choose between an Organization UUID or a Course Product Relation"
+                        " UUID."
+                    ),
+                ]
+            },
+        )
+
+    def test_api_contract_generate_zip_archive_authenticated_post_parsing_both_parameters(
+        self,
+    ):
+        """
+        Authenticated user should be able to use POST method on the viewset to generate ZIP
+        archive but it will raise an error if both parsing arguments are set. You must choose
+        one out of the two parameters to parse.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization, user=user)
+        token = self.get_user_token(user.username)
+
+        response = self.client.post(
+            "/api/v1.0/contracts/zip-archive/",
+            data={
+                "organization_id": organization.id,
+                "course_product_relation_id": uuid4(),
+            },
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(
+            response.json(),
+            {
+                "non_field_errors": [
+                    (
+                        "You must set exactly one parameter for the method. It cannot be both."
+                        " You must choose between an Organization UUID or a Course Product"
+                        " Relation UUID."
+                    ),
+                ]
+            },
+        )
+
+    def test_api_contract_generate_zip_archive_authenticated_post_with_no_signed_contracts(
+        self,
+    ):
+        """
+        Authenticated user should be able to use POST method on the viewset to generate ZIP
+        archive when parsing an existing Organization UUID where the user has the rights to access,
+        but it won't generate a ZIP archive because there are no signed contracts.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization, user=user)
+        token = self.get_user_token(user.username)
+
+        response = self.client.post(
+            "/api/v1.0/contracts/zip-archive/",
+            data={"organization_id": organization.id},
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(response.json(), ["No zip to generate"])
+
+    # pylint: disable=too-many-locals
+    def test_api_contract_generate_zip_archive_authenticated_post_method_allowed(self):
+        """
+        Authenticated user should be able to use POST method on the viewset to generate ZIP
+        archive when parsing an existing Organization UUID where the user has the rights to access,
+        and it will generate a ZIP archive with the signed contracts.
+        """
+        storage = storages["contracts"]
+        requesting_user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(
+            organization=organization, user=requesting_user
+        )
+        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        learners = factories.UserFactory.create_batch(3)
+        signature_reference_choices = [
+            "wfl_fake_dummy_1",
+        ]
+        for index, reference in enumerate(signature_reference_choices):
+            user = learners[index]
+            order = factories.OrderFactory(
+                owner=user,
+                product=relation.product,
+                course=relation.course,
+                state=enums.ORDER_STATE_VALIDATED,
+            )
+            context = contract_definition.generate_document_context(
+                order.product.contract_definition, user, order
+            )
+            factories.ContractFactory(
+                order=order,
+                signature_backend_reference=reference,
+                definition_checksum="1234",
+                context=context,
+                signed_on=timezone.now(),
+            )
+        expected_endpoint_polling = "/api/v1.0/contracts/zip-archive/"
+        token = self.get_user_token(requesting_user.username)
+
+        response = self.client.post(
+            "/api/v1.0/contracts/zip-archive/",
+            data={"organization_id": organization.id},
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 202)
+
+        content = response.content.decode("utf-8")
+        content_json = json.loads(content)
+        polling_url = content_json["url"]
+        generated_zip_uuid = polling_url[-37:-1]
+
+        self.assertEqual(
+            content_json["url"], f"{expected_endpoint_polling}{generated_zip_uuid}/"
+        )
+        self.assertEqual(len(generated_zip_uuid), 36)
+        self.assertTrue(
+            storage.exists(f"{requesting_user.id}_{generated_zip_uuid}.zip")
+        )
+
+    def test_api_contract_get_zip_archive_anonymous(self):
+        """
+        Anonymous user should not be able to get ZIP archive.
+        """
+        response = self.client.get(f"/api/v1.0/contracts/zip-archive/{uuid4()}/")
+
+        self.assertEqual(response.status_code, 401)
+
+        content = response.json()
+        self.assertEqual(
+            content["detail"], "Authentication credentials were not provided."
+        )
+
+    def test_api_contract_get_zip_archive_authenticated_put_method_not_allowed(
+        self,
+    ):
+        """
+        Authenticated user should not be able to use PUT method on the viewset get ZIP
+        archive.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.put(
+            f"/api/v1.0/contracts/zip-archive/{uuid4()}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+
+    def test_api_contract_get_zip_archive_authenticated_patch_method_not_allowed(
+        self,
+    ):
+        """
+        Authenticated user should not be able to use PATCH method on the viewset get ZIP
+        archive.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.patch(
+            f"/api/v1.0/contracts/zip-archive/{uuid4()}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+
+    def test_api_contract_get_zip_archive_authenticated_delete_method_not_allowed(
+        self,
+    ):
+        """
+        Authenticated user should not be able to use DELETE method on the viewset get ZIP
+        archive.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.delete(
+            f"/api/v1.0/contracts/zip-archive/{uuid4()}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )
+
+    def test_api_contract_get_zip_archive_authenticated_get_method_but_zip_archive_not_ready(
+        self,
+    ):
+        """
+        Authenticated user should be able to GET method on the viewset get ZIP archive if the
+        ZIP archive exists in storages. In the case where the ZIP archive has not been generated,
+        it should return a status code 404 in the response.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization, user=user)
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            f"/api/v1.0/contracts/zip-archive/{uuid4()}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_api_contract_get_zip_archive_authenticated_invalid_zip_id(
+        self,
+    ):
+        """
+        Accessing a zip archive using an invalid zip_id should return a 404
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization, user=user)
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            "/api/v1.0/contracts/zip-archive/foo",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_api_contract_get_zip_archive_authenticated_get_method_zip_archive_is_ready(
+        self,
+    ):
+        """
+        Authenticated user should be able to GET method on the viewset get ZIP archive when
+        the ZIP archive exists in storages.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization, user=user)
+        token = self.get_user_token(user.username)
+        # Prepare ZIP archive in storage
+        zip_uuid = uuid4()
+        zip_archive_name = contract_utility.generate_zip_archive(
+            pdf_bytes_list=[b"content_1", b"content_2"],
+            user_uuid=user.id,
+            zip_uuid=zip_uuid,
+        )
+
+        response = self.client.get(
+            f"/api/v1.0/contracts/zip-archive/{zip_uuid}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/zip")
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            f'attachment; filename="{zip_archive_name}"',
+        )
+        # Clear the storage
+        storage = storages["contracts"]
+        storage.delete(zip_archive_name)
+
+    def test_api_contract_get_zip_archive_authenticated_simulate_waiting_for_zip_archive_ready(
+        self,
+    ):
+        """
+        Authenticated user should be able to GET his ZIP archive once it is ready.
+        We simulate in this test that the user requested his ZIP archive but it not yet
+        ready. First the response will return a 400 status code, and once it is ready, it
+        will return a status code 200 with the ZIP archive in the response.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization, user=user)
+        zip_uuid = uuid4()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            f"/api/v1.0/contracts/zip-archive/{zip_uuid}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+        # Prepare ZIP archive in storage
+        zip_archive_name = contract_utility.generate_zip_archive(
+            pdf_bytes_list=[b"content_1", b"content_2"],
+            user_uuid=user.id,
+            zip_uuid=zip_uuid,
+        )
+        response = self.client.get(
+            f"/api/v1.0/contracts/zip-archive/{zip_uuid}/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["Content-Type"], "application/zip")
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            f'attachment; filename="{zip_archive_name}"',
         )

--- a/src/backend/joanie/tests/core/test_commands_generate_zip_archive_of_contracts.py
+++ b/src/backend/joanie/tests/core/test_commands_generate_zip_archive_of_contracts.py
@@ -18,6 +18,8 @@ from joanie.core.utils import contract_definition
 class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
     """Test case for the management command `generate_zip_archive_of_contracts`"""
 
+    maxDiff = None
+
     def test_commands_generate_zip_archive_contracts_fails_without_parameters(self):
         """
         The command must have a User UUID to be executed, else the command aborts.
@@ -39,7 +41,7 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         """
         random_organization_uuid = uuid4()
         options = {
-            "organization": random_organization_uuid,
+            "organization_id": random_organization_uuid,
         }
 
         with self.assertRaises(CommandError) as context:
@@ -66,8 +68,15 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
 
         self.assertEqual(
             str(context.exception),
-            "You must to provide at least one of the two required parameters. "
-            "It can be a Course Product Relation UUID, or an Organization UUID.",
+            str(
+                {
+                    "non_field_errors": (
+                        "You must set at least one parameter for the method."
+                        "You must choose between an Organization UUID or a Course Product Relation"
+                        " UUID."
+                    )
+                }
+            ),
         )
 
     def test_commands_generate_zip_archive_contracts_fails_courseproductrelation_does_not_exist(
@@ -81,17 +90,22 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         random_course_product_relation_uuid = uuid4()
         options = {
             "user": user.pk,
-            "course_product_relation": random_course_product_relation_uuid,
+            "course_product_relation_id": random_course_product_relation_uuid,
         }
-
         with self.assertRaises(CommandError) as context:
             call_command("generate_zip_archive_of_contracts", **options)
 
         self.assertEqual(
             str(context.exception),
-            "Make sure to give an existing course product relation UUID. "
-            "No CourseProductRelation was found with the given "
-            f"UUID : {random_course_product_relation_uuid}.",
+            str(
+                {
+                    "course_product_relation_id": (
+                        "Make sure to give an existing course product relation UUID. "
+                        "No CourseProductRelation was found with the given "
+                        f"UUID : {random_course_product_relation_uuid}."
+                    ),
+                }
+            ),
         )
 
     def test_commands_generate_zip_archive_contracts_fails_organization_does_not_exist(
@@ -105,7 +119,7 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         random_organization_uuid = uuid4()
         options = {
             "user": user.pk,
-            "organization": random_organization_uuid,
+            "organization_id": random_organization_uuid,
         }
 
         with self.assertRaises(CommandError) as context:
@@ -113,8 +127,15 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
 
         self.assertEqual(
             str(context.exception),
-            "Make sure to give an existing organization UUID. "
-            f"No Organization was found with the givin UUID : {random_organization_uuid}.",
+            str(
+                {
+                    "organization_id": (
+                        "Make sure to give an existing organization UUID. "
+                        "No Organization was found with the givin UUID : "
+                        f"{random_organization_uuid}."
+                    )
+                }
+            ),
         )
 
     def test_commands_generate_zip_archive_contracts_fails_because_user_does_not_have_org_access(
@@ -137,11 +158,11 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
             [
                 {
                     "user": requesting_user.pk,
-                    "course_product_relation": relation.pk,
+                    "course_product_relation_id": relation.pk,
                 },
                 {
                     "user": requesting_user.pk,
-                    "organization": relation.organizations.first().pk,
+                    "organization_id": relation.organizations.first().pk,
                 },
             ]
         )
@@ -196,11 +217,11 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
             [
                 {
                     "user": requesting_user.pk,
-                    "course_product_relation": relation.pk,
+                    "course_product_relation_id": relation.pk,
                 },
                 {
                     "user": requesting_user.pk,
-                    "organization": relation.organizations.first().pk,
+                    "organization_id": relation.organizations.first().pk,
                 },
             ]
         )
@@ -260,7 +281,7 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         zip_uuid = uuid4()
         options = {
             "user": requesting_user.pk,
-            "course_product_relation": relation.pk,
+            "course_product_relation_id": relation.pk,
             "zip": zip_uuid,
         }
         signature_reference_choices = [
@@ -343,7 +364,7 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         zip_uuid = uuid4()
         options = {
             "user": requesting_user.pk,
-            "organization": organization.pk,
+            "organization_id": organization.pk,
             "zip": zip_uuid,
         }
         signature_reference_choices = [
@@ -432,12 +453,12 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
             [
                 {
                     "user": requesting_user.pk,
-                    "organization": organization.pk,
+                    "organization_id": organization.pk,
                     "zip": zip_uuid,
                 },
                 {
                     "user": requesting_user.pk,
-                    "course_product_relation": relation.pk,
+                    "course_product_relation_id": relation.pk,
                     "zip": zip_uuid,
                 },
             ]

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -602,6 +602,69 @@
                 }
             }
         },
+        "/api/v1.0/contracts/zip-archive/": {
+            "post": {
+                "operationId": "contracts_zip_archive_create",
+                "description": "This endpoint is exclusive to users that have access rights on a specific organization.\n\nIt triggers the generation of a ZIP archive if the requesting has the correct access rights\non the organization. If a course product relation UUID is given from key word arguments,\nthe user requires to have access to the organization that is attached to the specific\ncourse product relation object.\nWe return in the response the URL for polling the ZIP archive once it has been generated.\n\nNotes on possible `kwargs` as input parameters :\n    - string of an Organization UUID\n    OR\n    - string of an CourseProductRelation UUID",
+                "tags": [
+                    "contracts"
+                ],
+                "security": [
+                    {
+                        "DelegatedJWTAuthentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Contract"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1.0/contracts/zip-archive/{zip_id}/": {
+            "get": {
+                "operationId": "contracts_zip_archive_retrieve",
+                "description": "Return the ZIP archive once it has been generated and it exists into storages.\n\nWhen the ZIP archive is not ready yet, we will return a response with the status code 404\nuntil the ZIP is available to be served. Once available, we return the ZIP archive.\nIf the paired User UUID and the received ZIP UUID do not match any files in storage,\nit return a response with the status code 404.\nYou must add the ZIP id as a payload.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "zip_id",
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "contracts"
+                ],
+                "security": [
+                    {
+                        "DelegatedJWTAuthentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Contract"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/course-product-relations/": {
             "get": {
                 "operationId": "course_product_relations_list",


### PR DESCRIPTION
## Purpose
University representatives will be able to fetch their signed contracts in a ZIP archive through two actions.

The viewset to **generate the ZIP archive** (POST) requires : 

- a user that has access to a specific organization (required)
- an organization UUID
- OR a course product relation UUID

The other viewset will handle in **returning the ZIP archive** (GET) once it has been generated
in the response. It requires : 

- requesting user is the same that the one who requested the ZIP archive. It must have access to a specific organization.
- a valid ZIP UUID in order to build the ZIP archive name and seek for it in storages.

## Proposal

- [x] POST endpoint : to generate the ZIP archive with signed contract and save it in storages.
- [x] GET endpoint : to fetch the ZIP archive once it has been built and is accessible in storages.
- [x] add test suites for both endpoint.