### PR TITLE
💚(ci) fix tray job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,7 +400,7 @@ jobs:
     working_directory: ~/joanie
     resource_class: large
     environment:
-      DJANGO_CONFIGURATION: ContinuousIntegration
+      DJANGO_CONFIGURATION: Staging
     steps:
       - checkout:
           path: ~/joanie

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,6 @@ jobs:
       - image: cimg/python:3.10
         environment:
           DJANGO_SETTINGS_MODULE: joanie.settings
-          DJANGO_CONFIGURATION: Test
           DJANGO_SECRET_KEY: ThisIsAnExampleKeyForTestPurposeOnly
           DJANGO_JWT_PRIVATE_SIGNING_KEY: ThisIsAnExampleKeyForDevPurposeOnly
           PYTHONPATH: /home/circleci/joanie/src/backend
@@ -163,6 +162,8 @@ jobs:
           POSTGRES_USER: fun
           POSTGRES_PASSWORD: pass
     working_directory: ~/joanie/src/backend
+    environment:
+        DJANGO_CONFIGURATION: Test
     steps:
       - checkout:
           path: ~/joanie

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -497,9 +497,14 @@ class Build(Base):
     """
 
     SECRET_KEY = values.Value("DummyKey")
-    STORAGES_STATICFILES_BACKEND = values.Value(
-        "whitenoise.storage.CompressedManifestStaticFilesStorage"
-    )
+    STORAGES = {
+        "staticfiles": {
+            "BACKEND": values.Value(
+                "whitenoise.storage.CompressedManifestStaticFilesStorage",
+                environ_name="STORAGES_STATICFILES_BACKEND",
+            ),
+        }
+    }
 
 
 class Development(Base):
@@ -610,18 +615,22 @@ class Production(Base):
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
 
-    # For static files in production, we want to use a backend that includes a hash in
-    # the filename, that is calculated from the file content, so that browsers always
-    # get the updated version of each file.
-    STORAGES_STATICFILES_BACKEND = values.Value(
-        "whitenoise.storage.CompressedManifestStaticFilesStorage"
-    )
-
     # Privacy
     SECURE_REFERRER_POLICY = "same-origin"
 
     # Media
-    DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+    STORAGES = {
+        "default": {"BACKEND": "storages.backends.s3.S3Storage"},
+        "staticfiles": {
+            # For static files in production, we want to use a backend that includes a hash in
+            # the filename, that is calculated from the file content, so that browsers always
+            # get the updated version of each file.
+            "BACKEND": values.Value(
+                "whitenoise.storage.CompressedManifestStaticFilesStorage",
+                environ_name="STORAGES_STATICFILES_BACKEND",
+            )
+        },
+    }
     AWS_S3_ENDPOINT_URL = values.Value()
     AWS_S3_ACCESS_KEY_ID = values.Value()
     AWS_S3_SECRET_ACCESS_KEY = values.Value()

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -37,7 +37,7 @@ joanie_image_pull_secret_name: ""
 joanie_django_port: 8000
 joanie_app_replicas: 1
 joanie_django_settings_module: "joanie.settings"
-joanie_django_configuration: "Development"
+joanie_django_configuration: "Staging"
 joanie_secret_name: "joanie-{{ joanie_vault_checksum | default('undefined_joanie_vault_checksum') }}"
 joanie_activate_http_basic_auth: false
 


### PR DESCRIPTION
## Purpose

We recently installed a dev dependencies installed only in Development
environment. That's break the tray, as this one is using a joanie docker image
build with a production target. As dev dependencies are not installed, some job
fails with a ModuleNotFoundError. So in order to fix that, we decide to use
Staging django enviromnent as default value instead of Development.


## Proposal

- [x] Use `Staging` environment instead of `Development` in the tray configuration
- [x] Migrate to new Django `STORAGES` setting
- [x] Fix a misconfiguration related to ci job `test-back`
