### PR TITLE
🔥(backend) does not create contract definition for all product

### DIFF
--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -511,19 +511,6 @@ class ProductFactory(factory.django.DjangoModelFactory):
 
         return CertificateDefinitionFactory()
 
-    @factory.lazy_attribute
-    def contract_definition(self):
-        """
-        Return a ContractDefinition object with a random title
-        if the product type is credential or certificate.
-        """
-        if self.type in [
-            enums.PRODUCT_TYPE_CREDENTIAL,
-            enums.PRODUCT_TYPE_CERTIFICATE,
-        ]:
-            return ContractDefinitionFactory()
-        return None
-
 
 class CourseProductRelationFactory(factory.django.DjangoModelFactory):
     """A factory to create CourseProductRelation object"""
@@ -689,6 +676,7 @@ class ContractFactory(factory.django.DjangoModelFactory):
     order = factory.SubFactory(
         OrderFactory,
         product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+        product__contract_definition=factory.SubFactory(ContractDefinitionFactory),
     )
     signed_on = None
 

--- a/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
@@ -27,7 +27,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         Anonymous user should not be able to submit for signature an order.
         """
         order = factories.OrderFactory(
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory()
         )
         factories.ContractFactory(order=order)
 
@@ -95,7 +95,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
                     enums.ORDER_STATE_DRAFT,
                 ]
             ),
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         token = self.get_user_token(user.username)
 
@@ -153,7 +153,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order)
         token = self.get_user_token(user.username)
@@ -199,7 +199,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order)
         token = self.get_user_token(user.username)
@@ -251,7 +251,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order)
         token = self.get_user_token(user.username)

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -46,7 +46,10 @@ class ContractApiTest(BaseAPITestCase):
             role=random.choice([enums.ADMIN, enums.OWNER]),
         )
 
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         factories.ContractFactory.create_batch(
             5,
             order__product=relation.product,
@@ -230,7 +233,10 @@ class ContractApiTest(BaseAPITestCase):
             role=random.choice([enums.ADMIN, enums.OWNER]),
         )
 
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         contract = factories.ContractFactory(
             order__product=relation.product,
             order__course=relation.course,
@@ -421,7 +427,7 @@ class ContractApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         invoice = InvoiceFactory(order=order)
         address = invoice.recipient_address
@@ -477,7 +483,7 @@ class ContractApiTest(BaseAPITestCase):
                     enums.ORDER_STATE_SUBMITTED,
                 ]
             ),
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(order=order)
         token = self.get_user_token(user.username)
@@ -503,7 +509,7 @@ class ContractApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(order=order)
         token = self.get_user_token(user.username)
@@ -525,7 +531,7 @@ class ContractApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(order=order)
         token = self.get_user_token(user.username)
@@ -547,7 +553,7 @@ class ContractApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(order=order)
         token = self.get_user_token(user.username)
@@ -574,7 +580,7 @@ class ContractApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=owner,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(
             order=order,
@@ -608,7 +614,7 @@ class ContractApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=owner,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(
             order=order,
@@ -825,7 +831,10 @@ class ContractApiTest(BaseAPITestCase):
         factories.UserOrganizationAccessFactory(
             organization=organization, user=requesting_user
         )
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            product__contract_definition=factories.ContractDefinitionFactory(),
+            organizations=[organization],
+        )
         learners = factories.UserFactory.create_batch(3)
         signature_reference_choices = [
             "wfl_fake_dummy_1",

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -66,7 +66,10 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         courses = factories.CourseFactory.create_batch(2)
         for course in courses:
             factories.UserCourseAccessFactory(user=user, course=course)
-        product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CREDENTIAL)
+        product = factories.ProductFactory(
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            contract_definition=factories.ContractDefinitionFactory(),
+        )
         product.instructions = (
             "# An h1 header\n"
             "Paragraphs are separated by a blank line.\n"
@@ -449,9 +452,10 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         user = factories.UserFactory()
         token = self.generate_token_from_user(user)
         course = factories.CourseFactory()
-        product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CREDENTIAL)
         relation = factories.CourseProductRelationFactory(
-            course=course, product=product
+            course=course,
+            product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         factories.UserCourseAccessFactory(user=user, course=course)
 
@@ -492,20 +496,20 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                         "title": relation.product.certificate_definition.title,
                     },
                     "contract_definition": {
-                        "id": str(product.contract_definition.id),
-                        "description": product.contract_definition.description,
-                        "language": product.contract_definition.language,
-                        "title": product.contract_definition.title,
+                        "id": str(relation.product.contract_definition.id),
+                        "description": relation.product.contract_definition.description,
+                        "language": relation.product.contract_definition.language,
+                        "title": relation.product.contract_definition.title,
                     },
                     "state": {
-                        "priority": product.state["priority"],
-                        "datetime": product.state["datetime"]
+                        "priority": relation.product.state["priority"],
+                        "datetime": relation.product.state["datetime"]
                         .isoformat()
                         .replace("+00:00", "Z")
-                        if product.state["datetime"]
+                        if relation.product.state["datetime"]
                         else None,
-                        "call_to_action": product.state["call_to_action"],
-                        "text": product.state["text"],
+                        "call_to_action": relation.product.state["call_to_action"],
+                        "text": relation.product.state["text"],
                     },
                     "id": str(relation.product.id),
                     "price": float(relation.product.price),

--- a/src/backend/joanie/tests/core/test_api_courses_contract.py
+++ b/src/backend/joanie/tests/core/test_api_courses_contract.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """Test suite for the Courses Contract API"""
 import random
 from unittest import mock

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -326,12 +326,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                             "name": str(product2.certificate_definition.name),
                             "title": str(product2.certificate_definition.title),
                         },
-                        "contract_definition": {
-                            "id": str(product2.contract_definition.id),
-                            "description": product2.contract_definition.description,
-                            "language": product2.contract_definition.language,
-                            "title": product2.contract_definition.title,
-                        },
+                        "contract_definition": None,
                         "id": str(product2.id),
                         "price": float(product2.price),
                         "price_currency": "EUR",
@@ -361,12 +356,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                             "name": str(product1.certificate_definition.name),
                             "title": str(product1.certificate_definition.title),
                         },
-                        "contract_definition": {
-                            "id": str(product1.contract_definition.id),
-                            "description": product1.contract_definition.description,
-                            "language": product1.contract_definition.language,
-                            "title": product1.contract_definition.title,
-                        },
+                        "contract_definition": None,
                         "state": {
                             "priority": product1.state["priority"],
                             "datetime": product1.state["datetime"]
@@ -773,12 +763,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                             "name": product.certificate_definition.name,
                             "title": product.certificate_definition.title,
                         },
-                        "contract_definition": {
-                            "id": str(product.contract_definition.id),
-                            "description": product.contract_definition.description,
-                            "language": product.contract_definition.language,
-                            "title": product.contract_definition.title,
-                        },
+                        "contract_definition": None,
                         "id": str(product.id),
                         "instructions": "",
                         "price": float(product.price),

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """Test suite for the Organizations Contract API"""
 import random
 from unittest import mock

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -35,7 +35,10 @@ class OrganizationContractApiTest(BaseAPITestCase):
         organization = factories.OrganizationFactory()
         user = factories.UserFactory()
         token = self.generate_token_from_user(user)
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         factories.ContractFactory.create_batch(
             5,
             order__product=relation.product,
@@ -74,7 +77,10 @@ class OrganizationContractApiTest(BaseAPITestCase):
             role=enums.MEMBER,
         )
 
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         factories.ContractFactory.create_batch(
             5,
             order__product=relation.product,
@@ -122,7 +128,8 @@ class OrganizationContractApiTest(BaseAPITestCase):
             )
 
             relation = factories.CourseProductRelationFactory(
-                organizations=[organization]
+                organizations=[organization],
+                product__contract_definition=factories.ContractDefinitionFactory(),
             )
             factories.ContractFactory.create_batch(
                 5,
@@ -205,7 +212,10 @@ class OrganizationContractApiTest(BaseAPITestCase):
             role=random.choice([enums.ADMIN, enums.OWNER]),
         )
 
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         unsigned_contracts = factories.ContractFactory.create_batch(
             5,
             order__product=relation.product,
@@ -289,7 +299,10 @@ class OrganizationContractApiTest(BaseAPITestCase):
         organization = factories.OrganizationFactory()
         user = factories.UserFactory()
         token = self.generate_token_from_user(user)
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         contract = factories.ContractFactory(
             order__product=relation.product,
             order__course=relation.course,
@@ -318,7 +331,10 @@ class OrganizationContractApiTest(BaseAPITestCase):
             role=enums.MEMBER,
         )
 
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         contract = factories.ContractFactory(
             order__product=relation.product,
             order__course=relation.course,
@@ -356,7 +372,8 @@ class OrganizationContractApiTest(BaseAPITestCase):
             )
 
             relation = factories.CourseProductRelationFactory(
-                organizations=[organization]
+                organizations=[organization],
+                product__contract_definition=factories.ContractDefinitionFactory(),
             )
             factories.ContractFactory.create_batch(
                 5,
@@ -432,7 +449,10 @@ class OrganizationContractApiTest(BaseAPITestCase):
             role=random.choice([enums.ADMIN, enums.OWNER]),
         )
 
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         contract = factories.ContractFactory(
             order__product=relation.product,
             order__course=relation.course,

--- a/src/backend/joanie/tests/core/test_models_contract.py
+++ b/src/backend/joanie/tests/core/test_models_contract.py
@@ -68,9 +68,9 @@ class ContractModelTestCase(TestCase):
         factories.AddressFactory.create(owner=user)
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
-        contract = factories.ContractFactory(
+        factories.ContractFactory(
             order=order, signed_on=None, submitted_for_signature_on=None
         )
         contract = models.Contract.objects.get()
@@ -87,7 +87,7 @@ class ContractModelTestCase(TestCase):
         factories.AddressFactory.create(owner=user)
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         factories.ContractFactory(
             order=order,
@@ -112,7 +112,7 @@ class ContractModelTestCase(TestCase):
         factories.AddressFactory.create(owner=user)
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
 
         factories.ContractFactory(
@@ -167,7 +167,7 @@ class ContractModelTestCase(TestCase):
         factories.AddressFactory.create(owner=user)
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
 
         factories.ContractFactory(
@@ -194,7 +194,7 @@ class ContractModelTestCase(TestCase):
         factories.AddressFactory.create(owner=user)
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
 
         factories.ContractFactory(
@@ -270,7 +270,7 @@ class ContractModelTestCase(TestCase):
         factories.AddressFactory.create(owner=user)
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         factories.ContractFactory(order=order, context=None, definition_checksum=None)
         contract = models.Contract.objects.get()
@@ -407,7 +407,7 @@ class ContractModelTestCase(TestCase):
         )
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order, recipient_address=address)
         contract = factories.ContractFactory(order=order)
@@ -429,7 +429,7 @@ class ContractModelTestCase(TestCase):
         'submitted_for_signature_on'.
         """
         order = factories.OrderFactory(
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory()
         )
         contract = factories.ContractFactory(order=order)
 
@@ -453,7 +453,7 @@ class ContractModelTestCase(TestCase):
         and 'submitted_for_signature_on'.
         """
         order = factories.OrderFactory(
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory()
         )
         contract = factories.ContractFactory(
             order=order,
@@ -482,7 +482,7 @@ class ContractModelTestCase(TestCase):
         the validity period to be signed, it should return True to get signed.
         """
         order = factories.OrderFactory(
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory()
         )
         contract = factories.ContractFactory(
             order=order,
@@ -503,10 +503,12 @@ class ContractModelTestCase(TestCase):
     )
     def test_model_contract_is_eligible_for_signature_must_be_false(self):
         """
-        When the contract field 'submitted_for_signature_on' is not within the validity period
-        to be signed, it should return False to get signed.
+        When the contract field 'submitted_for_signature_on' is not within the validity
+        period to be signed, it should return False to get signed.
         """
-        order = factories.OrderFactory(product=factories.ProductFactory())
+        order = factories.OrderFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
         contract = factories.ContractFactory(
             order=order,
             definition=order.product.contract_definition,
@@ -527,7 +529,9 @@ class ContractModelTestCase(TestCase):
         If the contract does not have a value for 'submitted_for_signature_on', it should
         return False to get signed.
         """
-        order = factories.OrderFactory(product=factories.ProductFactory())
+        order = factories.OrderFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
         contract = factories.ContractFactory(
             order=order,
             submitted_for_signature_on=None,

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -955,7 +955,7 @@ class OrderModelsTestCase(TestCase):
                     enums.ORDER_STATE_PENDING,
                 ]
             ),
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
 
         with self.assertRaises(ValidationError) as context:
@@ -983,7 +983,7 @@ class OrderModelsTestCase(TestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order)
 
@@ -1018,7 +1018,7 @@ class OrderModelsTestCase(TestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order)
         context = contract_definition.generate_document_context(
@@ -1063,7 +1063,7 @@ class OrderModelsTestCase(TestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order)
         contract = factories.ContractFactory(
@@ -1102,7 +1102,7 @@ class OrderModelsTestCase(TestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         InvoiceFactory(order=order)
         context = contract_definition.generate_document_context(
@@ -1141,7 +1141,7 @@ class OrderModelsTestCase(TestCase):
         order = factories.OrderFactory(
             owner=user,
             state=enums.ORDER_STATE_VALIDATED,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         now = django_timezone.now()
         factories.ContractFactory(

--- a/src/backend/joanie/tests/core/test_utils_contract.py
+++ b/src/backend/joanie/tests/core/test_utils_contract.py
@@ -32,7 +32,9 @@ class UtilsContractTestCase(TestCase):
         return an empty generator.
         """
         users = factories.UserFactory.create_batch(3)
-        relation = factories.CourseProductRelationFactory()
+        relation = factories.CourseProductRelationFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
         signature_reference_choices = [
             "wfl_fake_dummy_1",
             "wfl_fake_dummy_2",
@@ -72,12 +74,15 @@ class UtilsContractTestCase(TestCase):
         self,
     ):
         """
-        From a Course Product Relation product object, we should be able to find the contract's
-        signature backend references that are attached to the validated orders only for a specific
-        course and product. It should return an iterator with signature backend references.
+        From a Course Product Relation product object, we should be able to find the
+        contract's signature backend references that are attached to the validated
+        orders only for a specific course and product. It should return an iterator with
+        signature backend references.
         """
         users = factories.UserFactory.create_batch(3)
-        relation = factories.CourseProductRelationFactory()
+        relation = factories.CourseProductRelationFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
         signature_reference_choices = [
             "wfl_fake_dummy_1",
             "wfl_fake_dummy_2",
@@ -112,11 +117,13 @@ class UtilsContractTestCase(TestCase):
         self,
     ):
         """
-        From an Organization object, if there are no signed contracts attached to the organization,
-        it should return an empty iterator.
+        From an Organization object, if there are no signed contracts attached to the
+        organization, it should return an empty iterator.
         """
         users = factories.UserFactory.create_batch(3)
-        relation = factories.CourseProductRelationFactory()
+        relation = factories.CourseProductRelationFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
         organization = relation.organizations.first()
         signature_reference_choices = [
             "wfl_fake_dummy_1",
@@ -157,12 +164,14 @@ class UtilsContractTestCase(TestCase):
         self,
     ):
         """
-        From an Organization object, we should be able to find the contract's signature backend
-        references from signed contracts. It should return an iterator with signature backend
-        references.
+        From an Organization object, we should be able to find the contract's signature
+        backend references from signed contracts. It should return an iterator with
+        signature backend references.
         """
         users = factories.UserFactory.create_batch(3)
-        relation = factories.CourseProductRelationFactory()
+        relation = factories.CourseProductRelationFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
         organization = relation.organizations.first()
         signature_reference_choices = [
             "wfl_fake_dummy_1",
@@ -203,9 +212,9 @@ class UtilsContractTestCase(TestCase):
         reference and get an empty iterator in return.
         """
         users = factories.UserFactory.create_batch(3)
-        product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CERTIFICATE)
         relation = factories.CourseProductRelationFactory(
-            product=product,
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         signature_reference_choices = [
             "wfl_fake_dummy_1",
@@ -253,14 +262,14 @@ class UtilsContractTestCase(TestCase):
         self,
     ):
         """
-        From a Course Product Relation product object, we should be able to find the signed
-        contract signature backend references that are attached to the 'validated' Orders of a
-        specific Enrollment.
+        From a Course Product Relation product object, we should be able to find the
+        signed contract signature backend references that are attached to the
+        'validated' Orders of a specific Enrollment.
         """
         users = factories.UserFactory.create_batch(3)
-        product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CERTIFICATE)
         relation = factories.CourseProductRelationFactory(
-            product=product,
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         signature_reference_choices = [
             "wfl_fake_dummy_1",
@@ -313,9 +322,10 @@ class UtilsContractTestCase(TestCase):
         factories.UserOrganizationAccessFactory(
             organization=organization, user=requesting_user
         )
-        product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CERTIFICATE)
         relation = factories.CourseProductRelationFactory(
-            product=product, organizations=[organization]
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+            organizations=[organization],
         )
         signature_reference_choices = [
             "wfl_fake_dummy_1",
@@ -371,9 +381,10 @@ class UtilsContractTestCase(TestCase):
             organization=factories.OrganizationFactory(), user=requesting_user
         )
         organization_course_supplier = factories.OrganizationFactory()
-        product = factories.ProductFactory(type=enums.PRODUCT_TYPE_CERTIFICATE)
         relation = factories.CourseProductRelationFactory(
-            product=product, organizations=[organization_course_supplier]
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+            organizations=[organization_course_supplier],
         )
         signature_reference_choices = [
             "wfl_fake_dummy_1",
@@ -517,7 +528,9 @@ class UtilsContractTestCase(TestCase):
         storage = storages["contracts"]
         users = factories.UserFactory.create_batch(3)
         requesting_user = factories.UserFactory()
-        relation = factories.CourseProductRelationFactory()
+        relation = factories.CourseProductRelationFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
         signature_reference_choices = [
             "wfl_fake_dummy_4",
             "wfl_fake_dummy_5",

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
@@ -292,7 +292,7 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
         user = factories.UserFactory(email="johnnydo@example.fr")
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(
             order=order,
@@ -360,7 +360,7 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
         user = factories.UserFactory(email="johnnydo@example.fr")
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(
             order=order,
@@ -430,7 +430,7 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
         user = factories.UserFactory(email="johnnydo@example.fr")
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(
             order=order,

--- a/src/backend/joanie/tests/signature/test_backend_signature_base.py
+++ b/src/backend/joanie/tests/signature/test_backend_signature_base.py
@@ -87,7 +87,7 @@ class BaseSignatureBackendTestCase(TestCase):
         user = factories.UserFactory()
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(
             order=order,
@@ -125,7 +125,7 @@ class BaseSignatureBackendTestCase(TestCase):
         user = factories.UserFactory()
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         factories.ContractFactory(
             order=order,
@@ -162,7 +162,7 @@ class BaseSignatureBackendTestCase(TestCase):
         user = factories.UserFactory()
         order = factories.OrderFactory(
             owner=user,
-            product=factories.ProductFactory(),
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         contract = factories.ContractFactory(
             order=order,

--- a/src/backend/joanie/tests/signature/test_commands_generate_zip_archive_of_contracts.py
+++ b/src/backend/joanie/tests/signature/test_commands_generate_zip_archive_of_contracts.py
@@ -153,7 +153,8 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         factories.UserOrganizationAccessFactory(user=requesting_user)
         organization_course_provider = factories.OrganizationFactory()
         relation = factories.CourseProductRelationFactory(
-            organizations=[organization_course_provider]
+            organizations=[organization_course_provider],
+            product__contract_definition=factories.ContractDefinitionFactory(),
         )
         options = random.choice(
             [
@@ -214,7 +215,10 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         factories.UserOrganizationAccessFactory(
             organization=organization, user=requesting_user
         )
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         options = random.choice(
             [
                 {
@@ -280,7 +284,10 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         factories.UserOrganizationAccessFactory(
             organization=organization, user=requesting_user
         )
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         zip_uuid = uuid4()
         options = {
             "user": requesting_user.pk,
@@ -369,7 +376,10 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         factories.UserOrganizationAccessFactory(
             organization=organization, user=requesting_user
         )
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         zip_uuid = uuid4()
         options = {
             "user": requesting_user.pk,
@@ -455,7 +465,10 @@ class GenerateZipArchiveOfContractsCommandTestCase(TestCase):
         factories.UserOrganizationAccessFactory(
             organization=organization, user=requesting_user
         )
-        relation = factories.CourseProductRelationFactory(organizations=[organization])
+        relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
         zip_uuid = random.choice(
             [
                 "aH3kRj2ZvXo5Nt1wPq9SbYp4Q8sU6W2G3eL7ia",  # 38 characters long


### PR DESCRIPTION
## Purpose

Currently, the ProductFactory always create a ContractDefinition. This is relation is not mandatory, so we should not create one on each Product but only when it is expected.


## Proposal

- [x] Generate Contract Definition only when needed
- [x] Fix all related tests
