### PR TITLE
✨(backend) prevent to enroll on course runs if signature is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to
 
 ### Changed
 
+- If a product has a contract, delay auto enroll logic on leaner signature
 - Prevent to enroll to not listed course runs related to an order awaiting
   signature of a contract by the learner
 - Use Invoice.recipient_address to populate Contract address context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to
 
 ### Changed
 
+- Prevent to enroll to not listed course runs related to an order awaiting
+  signature of a contract by the learner
 - Use Invoice.recipient_address to populate Contract address context
 - Link Invoice to Address object
 - Update psycopg to version 3

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -974,6 +974,15 @@ class Enrollment(BaseModel):
                         )
                         | models.Q(course_relations__course_runs=self.course_run)
                     ),
+                    (
+                        models.Q(
+                            product__contract_definition__isnull=False,
+                            contract__signed_on__isnull=False,
+                        )
+                        | models.Q(
+                            product__contract_definition__isnull=True,
+                        )
+                    ),
                     state=enums.ORDER_STATE_VALIDATED,
                 )
                 if validated_user_orders.count() == 0:

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -984,7 +984,12 @@ def order_post_transition_callback(sender, instance, **kwargs):  # pylint: disab
     unenrolls user.
     """
     instance.save()
-    if instance.state == enums.ORDER_STATE_VALIDATED:
+    # Only enroll user if the product has no contract to sign, otherwise we should wait
+    # for the contract to be signed before enrolling the user.
+    if (
+        instance.state == enums.ORDER_STATE_VALIDATED
+        and instance.product.contract_definition is None
+    ):
         instance.enroll_user_to_course_run()
 
     if instance.state == enums.ORDER_STATE_CANCELED:

--- a/src/backend/joanie/signature/backends/base.py
+++ b/src/backend/joanie/signature/backends/base.py
@@ -62,6 +62,11 @@ class BaseSignatureBackend:
         contract.submitted_for_signature_on = None
         contract.signed_on = django_timezone.now()
         contract.save()
+
+        # The student has signed the contract, we can now try to automatically enroll
+        # it to single course runs opened for enrollment.
+        contract.order.enroll_user_to_course_run()
+
         logger.info("Document signature completed for the contract '%s'", contract.id)
 
     def reset_contract(self, reference):

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -896,7 +896,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         self.assertNotIn("2000", content["created_on"])
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment", return_value=True)
-    def test_models_enrollment_duplicate_course_run_with_order(self, _mock_set):
+    def test_api_enrollment_duplicate_course_run_with_order(self, _mock_set):
         """
         It should not be possible to enroll to course runs of the same course for a
         given order.

--- a/src/backend/joanie/tests/signature/test_backend_signature_base.py
+++ b/src/backend/joanie/tests/signature/test_backend_signature_base.py
@@ -1,13 +1,14 @@
 """Test suite of common methods for Base, to Dummy and Client Signature Backend."""
 import random
 from datetime import timedelta
+from unittest import mock
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone as django_timezone
 
-from joanie.core import factories
+from joanie.core import enums, factories
 from joanie.signature.backends import get_signature_backend
 
 
@@ -78,16 +79,22 @@ class BaseSignatureBackendTestCase(TestCase):
             ]
         )
     )
-    def test_backend_signature_base_backend_confirm_signature(self):
+    @mock.patch("joanie.core.models.Order.enroll_user_to_course_run")
+    def test_backend_signature_base_backend_confirm_signature(self, _mock_enroll_user):
         """
         This test verifies that the `confirm_signature` method updates the contract with a
         timestamps for the field 'signed_on', and it should set 'None' to the field
         'submitted_for_signature_on'.
+
+        Furthermore, it should call the method
+        `enroll_user_to_course_run` on the contract's order. In this way, when user has signed
+        its contract, it should be enrolled to courses with only one course run.
         """
         user = factories.UserFactory()
         order = factories.OrderFactory(
             owner=user,
             product__contract_definition=factories.ContractDefinitionFactory(),
+            state=enums.ORDER_STATE_VALIDATED,
         )
         contract = factories.ContractFactory(
             order=order,
@@ -104,6 +111,9 @@ class BaseSignatureBackendTestCase(TestCase):
         contract.refresh_from_db()
         self.assertIsNone(contract.submitted_for_signature_on)
         self.assertIsNotNone(contract.signed_on)
+
+        # contract.order.enroll_user_to_course should have been called once
+        _mock_enroll_user.assert_called_once()
 
     @override_settings(
         JOANIE_SIGNATURE_BACKEND=random.choice(


### PR DESCRIPTION
## Purpose

We want to forbid enrollment to not listed course run until a user has a validated order and has signed the contract link to the order if there is one. Currently, we do not check the contract signature state. 

Furthermore, currently, if a target course has only one course run and this one is opened for enrollment we automatically enroll the user on order validation. We have to update this logic according to if there is a contract to sign or not : 
1. If there is no contract, we should keep the current behaviour
2. If there is contract to sign, we should enroll the user only after it signs it.


## Proposal

- [x] Forbid to enroll to not listed course runs if the user does not have a validated order with a signed contract (if product has a contract definition)
- [x] Update auto enrollment logic. 
