### PR TITLE
🧑‍💻(backend) add a date format helper

### DIFF
--- a/src/backend/joanie/tests/__init__.py
+++ b/src/backend/joanie/tests/__init__.py
@@ -1,0 +1,11 @@
+"""Test helpers"""
+
+from datetime import datetime
+
+
+def format_date(value: datetime) -> str | None:
+    """Format a datetime to be used in a json response"""
+    try:
+        return value.isoformat().replace("+00:00", "Z")
+    except AttributeError:
+        return None

--- a/src/backend/joanie/tests/core/test_api_admin_courses.py
+++ b/src/backend/joanie/tests/core/test_api_admin_courses.py
@@ -6,6 +6,7 @@ import random
 from django.test import TestCase
 
 from joanie.core import factories
+from joanie.tests import format_date
 
 
 class CourseAdminApiTest(TestCase):
@@ -155,14 +156,10 @@ class CourseAdminApiTest(TestCase):
                 "course_runs": [
                     {
                         "id": str(course_run.id),
-                        "start": course_run.start.isoformat().replace("+00:00", "Z"),
-                        "end": course_run.end.isoformat().replace("+00:00", "Z"),
-                        "enrollment_start": course_run.enrollment_start.isoformat().replace(
-                            "+00:00", "Z"
-                        ),
-                        "enrollment_end": course_run.enrollment_end.isoformat().replace(
-                            "+00:00", "Z"
-                        ),
+                        "start": format_date(course_run.start),
+                        "end": format_date(course_run.end),
+                        "enrollment_start": format_date(course_run.enrollment_start),
+                        "enrollment_end": format_date(course_run.enrollment_end),
                         "languages": course_run.languages,
                         "title": course_run.title,
                         "is_gradable": course_run.is_gradable,
@@ -193,11 +190,7 @@ class CourseAdminApiTest(TestCase):
                 "product_relations": [],
                 "state": {
                     "priority": course.state["priority"],
-                    "datetime": course.state["datetime"]
-                    .isoformat()
-                    .replace("+00:00", "Z")
-                    if course.state["datetime"]
-                    else None,
+                    "datetime": format_date(course.state["datetime"]),
                     "call_to_action": course.state["call_to_action"],
                     "text": course.state["text"],
                 },

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -8,6 +8,7 @@ from rest_framework.pagination import PageNumberPagination
 
 from joanie.core import enums, factories
 from joanie.core.serializers import fields
+from joanie.tests import format_date
 from joanie.tests.base import BaseAPITestCase
 
 
@@ -78,9 +79,7 @@ class CertificateApiTest(BaseAPITestCase):
                             "name": other_certificate.certificate_definition.name,
                             "title": other_certificate.certificate_definition.title,
                         },
-                        "issued_on": other_certificate.issued_on.isoformat().replace(
-                            "+00:00", "Z"
-                        ),
+                        "issued_on": format_date(other_certificate.issued_on),
                         "order": {
                             "id": str(other_order.id),
                             "course": None,
@@ -92,44 +91,24 @@ class CertificateApiTest(BaseAPITestCase):
                                         "id": str(enrollment.course_run.course.id),
                                         "title": enrollment.course_run.course.title,
                                     },
-                                    "end": enrollment.course_run.end.isoformat().replace(
-                                        "+00:00", "Z"
-                                    )
-                                    if enrollment.course_run.end
-                                    else None,
-                                    "enrollment_end": (
-                                        enrollment.course_run.enrollment_end.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                        if enrollment.course_run.enrollment_end
-                                        else None
+                                    "end": format_date(enrollment.course_run.end),
+                                    "enrollment_end": format_date(
+                                        enrollment.course_run.enrollment_end
                                     ),
-                                    "enrollment_start": (
-                                        enrollment.course_run.enrollment_start.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                        if enrollment.course_run.enrollment_start
-                                        else None
+                                    "enrollment_start": format_date(
+                                        enrollment.course_run.enrollment_start
                                     ),
                                     "id": str(enrollment.course_run.id),
                                     "languages": enrollment.course_run.languages,
                                     "resource_link": enrollment.course_run.resource_link,
-                                    "start": enrollment.course_run.start.isoformat().replace(
-                                        "+00:00", "Z"
-                                    )
-                                    if enrollment.course_run.start
-                                    else None,
+                                    "start": format_date(enrollment.course_run.start),
                                     "state": {
                                         "call_to_action": enrollment.course_run.state.get(
                                             "call_to_action"
                                         ),
-                                        "datetime": enrollment.course_run.state.get(
-                                            "datetime"
-                                        )
-                                        .isoformat()
-                                        .replace("+00:00", "Z")
-                                        if enrollment.course_run.state.get("datetime")
-                                        else None,
+                                        "datetime": format_date(
+                                            enrollment.course_run.state.get("datetime")
+                                        ),
                                         "priority": enrollment.course_run.state.get(
                                             "priority"
                                         ),
@@ -137,9 +116,7 @@ class CertificateApiTest(BaseAPITestCase):
                                     },
                                     "title": enrollment.course_run.title,
                                 },
-                                "created_on": enrollment.created_on.isoformat().replace(
-                                    "+00:00", "Z"
-                                ),
+                                "created_on": format_date(enrollment.created_on),
                                 "id": str(enrollment.id),
                                 "is_active": enrollment.is_active,
                                 "state": enrollment.state,
@@ -162,9 +139,7 @@ class CertificateApiTest(BaseAPITestCase):
                             "name": certificate.certificate_definition.name,
                             "title": certificate.certificate_definition.title,
                         },
-                        "issued_on": certificate.issued_on.isoformat().replace(
-                            "+00:00", "Z"
-                        ),
+                        "issued_on": format_date(certificate.issued_on),
                         "order": {
                             "id": str(order.id),
                             "course": {
@@ -294,7 +269,7 @@ class CertificateApiTest(BaseAPITestCase):
                     "name": certificate.certificate_definition.name,
                     "title": certificate.certificate_definition.title,
                 },
-                "issued_on": certificate.issued_on.isoformat().replace("+00:00", "Z"),
+                "issued_on": format_date(certificate.issued_on),
                 "order": {
                     "id": str(certificate.order.id),
                     "course": {


### PR DESCRIPTION


## Purpose

We are repeating date formating in many tests.
As it is too much to manage them all in only one PR, a helper has been used in two of them.
Other tests may be cleaned as we work on them.
