### PR TITLE
✨ (backend) - remote endpoint API Joanie for other services (token security and endpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to
 
 ## Added
 
-- Allow to filter contracts by signature state, 
+- Add API endpoints for other services to fetch  data on course run
+- Allow to filter contracts by signature state,
   product, course and organization and id
 - Add bulk download of signed contracts to generate ZIP archive with command
 - Add read-only api admin endpoint to list/retrieve orders
-- Add a management command to synchronize course run or product 
+- Add a management command to synchronize course run or product
   on a remote catalog
 - Install and configure celery with redis
 - Add CachedModelSerializer

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -53,3 +53,6 @@ JOANIE_BACKOFFICE_BASE_URL="http://localhost:8072"
 
 # must be reachable for signature email notifications
 DEVELOPER_EMAIL="developer@example.com"
+
+# Security for remote endpoints API
+JOANIE_AUTHORIZED_API_TOKENS = "secretTokenForRemoteAPIConsumer"

--- a/src/backend/joanie/core/api/remote_endpoints.py
+++ b/src/backend/joanie/core/api/remote_endpoints.py
@@ -1,0 +1,38 @@
+"""
+Remote endpoints API for other servers.
+"""
+from django.http import JsonResponse
+
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from joanie.core.permissions import HasAPIKey
+from joanie.core.utils.course_run import get_course_run_metrics
+
+
+@api_view(["GET"])
+@permission_classes([HasAPIKey])
+@authentication_classes([])
+def enrollments_and_orders_on_course_run(request: Request):
+    """
+    If the related course run is archived, return the amount of active enrollments and the amount
+    of validated certificate orders.
+    It requires an existing `resource_link` from an ended course run as input.
+
+    Remote service must have its token set in Joanie's settings `JOANIE_AUTHORIZED_API_TOKENS`
+    """
+    resource_link = request.query_params.get("resource_link")
+    if resource_link is None:
+        return Response(
+            {"detail": "Query parameter `resource_link` is required."},
+            status=400,
+        )
+
+    response = get_course_run_metrics(resource_link=resource_link)
+
+    return JsonResponse(response, status=200)

--- a/src/backend/joanie/core/utils/course_run.py
+++ b/src/backend/joanie/core/utils/course_run.py
@@ -1,0 +1,42 @@
+"""
+Utility methods for Course Run on enrollments metrics and orders made.
+"""
+import logging
+
+from django.core.exceptions import ValidationError
+from django.utils import timezone as django_timezone
+
+from joanie.core import enums
+from joanie.core.models import CourseRun, Enrollment, Order
+
+logger = logging.getLogger(__name__)
+
+
+def get_course_run_metrics(resource_link: str):
+    """
+    From an existing `resource_link` from an ended Course Run, it returns a dictionary containing :
+        - amount of active enrollments,
+        - amount of validated certificate orders.
+    """
+    try:
+        course_run = CourseRun.objects.get(
+            resource_link=resource_link, end__lte=django_timezone.now()
+        )
+    except CourseRun.DoesNotExist as exception:
+        error_message = (
+            "Make sure to give an existing resource link from an ended course run."
+        )
+        logger.error("Error: %s", error_message)
+        raise ValidationError(error_message) from exception
+
+    return {
+        "nb_active_enrollments": Enrollment.objects.filter(
+            course_run=course_run,
+            is_active=True,
+        ).count(),
+        "nb_validated_certificate_orders": Order.objects.filter(
+            enrollment__course_run=course_run,
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            state=enums.ORDER_STATE_VALIDATED,
+        ).count(),
+    }

--- a/src/backend/joanie/remote_endpoints_urls.py
+++ b/src/backend/joanie/remote_endpoints_urls.py
@@ -1,0 +1,15 @@
+"""
+API routes exposed for server to server. Requires a specific token to request.
+"""
+from django.conf import settings
+from django.urls import path
+
+from joanie.core.api.remote_endpoints import enrollments_and_orders_on_course_run
+
+urlpatterns = [
+    path(
+        f"api/{settings.API_VERSION}/course-run-metrics/",
+        enrollments_and_orders_on_course_run,
+        name="enrollments_and_orders_on_course_run",
+    ),
+]

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -72,6 +72,8 @@ class Base(Configuration):
     # Security
     ALLOWED_HOSTS = values.ListValue([])
     SECRET_KEY = values.Value(None)
+    # Security - Server to server authorized API keys
+    JOANIE_AUTHORIZED_API_TOKENS = values.ListValue([], environ_prefix=None)
 
     # Application definition
     ROOT_URLCONF = "joanie.urls"

--- a/src/backend/joanie/tests/core/api/remote_endpoints/course_run/test_course_run.py
+++ b/src/backend/joanie/tests/core/api/remote_endpoints/course_run/test_course_run.py
@@ -1,0 +1,646 @@
+"""Test suite for remote API endpoints on course run."""
+from datetime import timedelta
+
+from django.test.utils import override_settings
+from django.utils import timezone as django_timezone
+
+from joanie.core import enums, factories, models
+from joanie.tests.base import BaseAPITestCase
+
+
+class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
+    """Test suite for remote API endpoints on course run."""
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=[])
+    def test_remote_endpoints_course_run_anonymous_without_token(self):
+        """
+        Anonymous users cannot query our remote endpoint without a token.
+        """
+        response = self.client.get("/api/v1.0/course-run-metrics/?resource_link=")
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_anonymous_with_invalid_token(self):
+        """
+        Anonymous users cannot query our remote endpoint with an invalid token.
+        """
+        response = self.client.get(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION="Bearer invalid_token",
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_valid_token_and_wrong_scheme_prefix_should_fail(
+        self,
+    ):
+        """
+        Test the scenario where another server uses the wrong scheme prefix 'Token' instead of
+        'Bearer'. It should fail if the token does not precede by the scheme 'Bearer'.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ARCHIVED_CLOSED,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Token valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_valid_token_and_missing_scheme_prefix_should_fail(
+        self,
+    ):
+        """
+        Test the scenario where another server sends its requests without the prefix scheme for
+        the token. It should fail if the token does not precede by the scheme 'Bearer'.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ARCHIVED_CLOSED,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_anonymous_valid_token_but_with_post_method_should_fail(
+        self,
+    ):
+        """
+        Anonymous users cannot query our remote endpoint with a valid token and the post method.
+        It should fail and return a 405 status code Method Not Allowed.
+        """
+        response = self.client.post(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_anonymous_valid_token_but_with_patch_method_should_fail(
+        self,
+    ):
+        """
+        Anonymous users cannot query our remote endpoint with a valid token and the patch method.
+        It should fail and return a 405 status code Method Not Allowed.
+        """
+        response = self.client.patch(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_anonymous_valid_token_but_with_put_method_should_fail(
+        self,
+    ):
+        """
+        Anonymous users cannot query our remote endpoint with a valid token and the put method.
+        It should fail and return a 405 status code Method Not Allowed.
+        """
+        response = self.client.put(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_anonymous_valid_token_but_with_delete_method_should_fail(
+        self,
+    ):
+        """
+        Anonymous users cannot query our remote endpoint with a valid token and the delete method.
+        It should fail and return a 405 status code Method Not Allowed.
+        """
+        response = self.client.delete(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_anonymous_valid_token_without_required_query_params(
+        self,
+    ):
+        """
+        Anonymous users cannot query our remote endpoint with get method and without the required
+        query parameter `resource_link`. It raises a 400 status code.
+        """
+        response = self.client.get(
+            "/api/v1.0/course-run-metrics/",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response, "Query parameter `resource_link` is required.", status_code=400
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_authenticated_get_method_should_fail(
+        self,
+    ):
+        """
+        Authenticated user cannot query our remote endpoint with the get method and a token that
+        is not stored in the settings variable `JOANIE_AUTHORIZED_API_TOKENS`.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_authenticated_post_method_should_fail(
+        self,
+    ):
+        """
+        Authenticated user cannot query our remote endpoint with the post method and a token that
+        is not stored in the settings variable `JOANIE_AUTHORIZED_API_TOKENS`.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.post(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_authenticated_patch_method_should_fail(
+        self,
+    ):
+        """
+        Authenticated user cannot query our remote endpoint with the patch method and a token that
+        is not stored in the settings variable `JOANIE_AUTHORIZED_API_TOKENS`.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.patch(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_authenticated_delete_method_should_fail(
+        self,
+    ):
+        """
+        Authenticated user cannot query our remote endpoint with the delete method and a token that
+        is not stored in the settings variable `JOANIE_AUTHORIZED_API_TOKENS`.
+        """
+        user = factories.UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.delete(
+            "/api/v1.0/course-run-metrics/?resource_link=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=403,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_not_existent_resource_link_as_input_parameter_fails(
+        self,
+    ):
+        """
+        When we parse a non existent `resource_link` as input of a course run, it should return an
+        error asking to provide an existing `resource_link` as input parameter.
+        """
+        course = factories.CourseFactory()
+        factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ARCHIVED_OPEN,
+            languages="fr",
+        )
+        resource_link = "http://openedx.test/courses/course-v1:a_fake_one/course"
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "Make sure to give an existing resource link from an ended course run.",
+            status_code=400,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_ongoing_open_course_run_state_should_fail(
+        self,
+    ):
+        """
+        When the course run's end date is not yet reached, for example the state 'ongoing open',
+        it should raise the error asking to provide a `resource_link` where the course run
+        has reached its end date.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ONGOING_OPEN,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "Make sure to give an existing resource link from an ended course run.",
+            status_code=400,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_future_open_course_run_state_should_fail(
+        self,
+    ):
+        """
+        When the course run's end date is not yet reached, for example the state 'future open',
+        it should raise the error asking to provide a `resource_link` where the course run
+        has reached its end date.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.FUTURE_OPEN,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "Make sure to give an existing resource link from an ended course run.",
+            status_code=400,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_future_not_yet_open_course_run_state_should_fail(
+        self,
+    ):
+        """
+        When the course run's end date is not yet reached, for example the state 'future not yet
+        open', it should raise the error asking to provide a `resource_link` where the course run
+        has reached its end date.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.FUTURE_NOT_YET_OPEN,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "Make sure to give an existing resource link from an ended course run.",
+            status_code=400,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_future_closed_course_run_state_should_fail(
+        self,
+    ):
+        """
+        When the course run's end date is not yet reached, for example the state 'future closed',
+        it should raise the error asking to provide a `resource_link` where the course run
+        has reached its end date.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.FUTURE_CLOSED,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "Make sure to give an existing resource link from an ended course run.",
+            status_code=400,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_ongoing_closed_course_run_state_should_fail(
+        self,
+    ):
+        """
+        When the course run's end date is not yet reached, for example the state 'ongoing closed',
+        it should raise the error asking to provide a `resource_link` where the course run
+        has reached its end date.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ONGOING_CLOSED,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "Make sure to give an existing resource link from an ended course run.",
+            status_code=400,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_with_to_be_scheduled_course_run_state_should_fail(
+        self,
+    ):
+        """
+        When the course run's end date is not yet reached, for example the state 'to be scheduled',
+        it should raise the error asking to provide a `resource_link` where the course run
+        has reached its end date.
+        """
+        course = factories.CourseFactory()
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.TO_BE_SCHEDULED,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertContains(
+            response,
+            "Make sure to give an existing resource link from an ended course run.",
+            status_code=400,
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_authenticated_with_valid_token_and_the_required_parameter(
+        self,
+    ):
+        """
+        Authenticated user can query our remote endpoint if parsing valid token to the headers
+        with an existing `resource_link`. The token must be set into the settings variable
+        `JOANIE_AUTHORIZED_API_TOKENS`.
+        """
+        user = factories.UserFactory()
+        organization = factories.OrganizationFactory()
+        course = factories.CourseFactory(
+            organizations=[organization], users=[[user, enums.OWNER]]
+        )
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ARCHIVED_CLOSED,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+
+        response = self.client.get(
+            f"/api/v1.0/course-run-metrics/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "nb_active_enrollments": 0,
+                "nb_validated_certificate_orders": 0,
+            },
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_another_server_with_known_token_and_required_query_params(
+        self,
+    ):
+        """
+        Test the scenario where another server can query our remote endpoint with the required
+        query parameter `resource_link` when it has in its possession a valid token to request.
+        No enrollments were made on this course run, so no one bought the access to unlock the
+        certifate. We should find in output 0 enrollment and 0 order to access the certificate.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        course = factories.CourseFactory(
+            organizations=[organization], users=[[user, enums.OWNER]]
+        )
+        course_run = factories.CourseRunFactory(
+            course=course,
+            is_listed=True,
+            state=models.CourseState.ARCHIVED_CLOSED,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+        url = f"/api/v1.0/course-run-metrics/?resource_link={resource_link}"
+
+        response = self.client.get(
+            url, HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "nb_active_enrollments": 0,
+                "nb_validated_certificate_orders": 0,
+            },
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_server_student_not_buy_certificate_at_the_end_of_course(
+        self,
+    ):
+        """
+        Test the scenario where a student enrolls to a course run and he does not purchase the
+        access to get the certificate. Once the course run's end date is reached,
+        the output must indicate 1 enrollment at the end of the course and find 0 certificate that
+        was bought.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        course = factories.CourseFactory(
+            organizations=[organization], users=[[user, enums.OWNER]]
+        )
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ONGOING_OPEN,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+        url = f"/api/v1.0/course-run-metrics/?resource_link={resource_link}"
+        # Set an enrollment for the course run
+        enrollment = factories.EnrollmentFactory(course_run=course_run, is_active=True)
+        # Make an order to unlock the access to the certificate
+        factories.OrderFactory(
+            owner=enrollment.user,
+            enrollment=enrollment,
+            course=None,
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            product__courses=[enrollment.course_run.course],
+        )
+        # Close the course run enrollments and set the end date to have "archived" state
+        closing_date = django_timezone.now() - timedelta(days=1)
+        course_run.enrollment_end = closing_date
+        course_run.end = closing_date
+        course_run.save()
+
+        response = self.client.get(
+            url, HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "nb_active_enrollments": 1,
+                "nb_validated_certificate_orders": 0,
+            },
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_remote_endpoints_course_run_another_server_valid_token_enrollments_by_resource_link(
+        self,
+    ):
+        """
+        Test the scenario where a student enrolls to a course run and purchases the certificate
+        before the end of the course run end date.
+        Once the course run's end date has been reached, the ouput must indicate 1 enrollment at
+        the end of the course run and 1 certificate that was bought.
+        """
+        organization = factories.OrganizationFactory()
+        user = factories.UserFactory()
+        course = factories.CourseFactory(
+            organizations=[organization], users=[[user, enums.OWNER]]
+        )
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=course,
+            state=models.CourseState.ONGOING_OPEN,
+            languages="fr",
+        )
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+        url = f"/api/v1.0/course-run-metrics/?resource_link={resource_link}"
+        # Set an enrollment for the course run
+        enrollment = factories.EnrollmentFactory(course_run=course_run, is_active=True)
+        # Make an order to unlock the access to the certificate
+        factories.OrderFactory(
+            owner=enrollment.user,
+            enrollment=enrollment,
+            course=None,
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            product__courses=[enrollment.course_run.course],
+            state=enums.ORDER_STATE_VALIDATED,
+        )
+        # Close the course run enrollments and set the end date to have "archived" state
+        closing_date = django_timezone.now() - timedelta(days=1)
+        course_run.enrollment_end = closing_date
+        course_run.end = closing_date
+        course_run.save()
+
+        response = self.client.get(
+            url, HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {
+                "nb_active_enrollments": 1,
+                "nb_validated_certificate_orders": 1,
+            },
+        )

--- a/src/backend/joanie/tests/core/test_utils_course_run.py
+++ b/src/backend/joanie/tests/core/test_utils_course_run.py
@@ -1,0 +1,100 @@
+"""Test suite for course run utility methods."""
+from datetime import timedelta
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.utils import timezone as django_timezone
+
+from joanie.core import enums, factories, models
+from joanie.core.utils.course_run import get_course_run_metrics
+
+
+class UtilsCourseRunTestCase(TestCase):
+    """Test suite for course run utility methods."""
+
+    def test_utils_course_run_with_non_existing_resource_link_parameter(self):
+        """
+        Test the scenario when a non existent `resource_link` is parsed as input.
+        It should raise a 'ValidationError' mentionning to provide an existing `resource_link`
+        of a course run that has ended.
+        """
+        with self.assertRaises(ValidationError) as context:
+            get_course_run_metrics(resource_link="http://opendex.test/fake_course_run")
+
+        self.assertEqual(
+            str(context.exception),
+            "['Make sure to give an existing resource link from an ended course run.']",
+        )
+
+    def test_utils_course_run_where_student_enrolls_and_does_not_make_an_order_to_get_certificate(
+        self,
+    ):
+        """
+        Test the scenario where a student enrolls to a course run that is open for enrollment,
+        and he does not buy the access to get the certificate at the end of the course.
+        The ouput must indicate that there was 1 enrollment made and 0 order to have access
+        to the certificate.
+        """
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=factories.CourseFactory(),
+            state=models.CourseState.ONGOING_OPEN,
+            languages="fr",
+            resource_link="http://openedx.test/courses/course-v1:edx+00000+0/course/",
+        )
+        # Set an enrollment for the course run
+        factories.EnrollmentFactory(course_run=course_run, is_active=True)
+        # Close the course run enrollments and set the end date to have "archived" state
+        closing_date = django_timezone.now() - timedelta(days=1)
+        course_run.enrollment_end = closing_date
+        course_run.end = closing_date
+        course_run.save()
+
+        self.assertEqual(
+            get_course_run_metrics(resource_link=course_run.resource_link),
+            {
+                "nb_active_enrollments": 1,
+                "nb_validated_certificate_orders": 0,
+            },
+        )
+
+    def test_utils_course_run_where_student_enrolls_and_makes_an_order_to_access_to_certificate(
+        self,
+    ):
+        """
+        Test the scenario where a student enrolls to a course run that is open for enrollment,
+        then he decides to unlock the access to get the certificate before the course run
+        has ended. The ouput must indicate that there was 1 enrollment made and 1 order to
+        have access to the certificate.
+        """
+        course_run = factories.CourseRunFactory(
+            is_listed=True,
+            course=factories.CourseFactory(),
+            state=models.CourseState.ONGOING_OPEN,
+            languages="fr",
+            resource_link="http://openedx.test/courses/course-v1:edx+00000+0/course/",
+        )
+        # Set an enrollment
+        enrollment = factories.EnrollmentFactory(course_run=course_run, is_active=True)
+        # Prepare the order and set it to 'validated' state
+        factories.OrderFactory(
+            owner=enrollment.user,
+            enrollment=enrollment,
+            course=None,
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            product__courses=[enrollment.course_run.course],
+            state=enums.ORDER_STATE_VALIDATED,
+        )
+        # Close the course run enrollments and set the end date to have "archived" state
+        closing_date = django_timezone.now() - timedelta(days=1)
+        course_run.enrollment_end = closing_date
+        course_run.end = closing_date
+        course_run.save()
+
+        self.assertEqual(
+            get_course_run_metrics(resource_link=course_run.resource_link),
+            {
+                "nb_active_enrollments": 1,
+                "nb_validated_certificate_orders": 1,
+            },
+        )

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -26,7 +26,7 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
-from joanie import admin_urls, client_urls
+from joanie import admin_urls, client_urls, remote_endpoints_urls
 from joanie.core.views import (
     BackOfficeRedirectView,
     DebugCertificateTemplateView,
@@ -48,6 +48,7 @@ urlpatterns = (
     ]
     + admin_urls.urlpatterns
     + client_urls.urlpatterns
+    + remote_endpoints_urls.urlpatterns
 )
 
 if settings.DEBUG:


### PR DESCRIPTION
## Purpose

Implement a secure way to communicate between Joanie and other services (other apps) if they want to retrieve
some data through an endpoint.

Add new endpoint that returns the awaited data needed by JENNY FunERP about course run metrics on : enrollments and unclocking access to obtain a certificate.

## Proposal

First, we will implement a new setting that will store every valid Token (`AUTHORIZED_API_TOKENS`). 
The token must be declared into the settings of the other service in order to use it in the headers of their request. Without a valid token that is set into `AUTHORIZED_API_TOKENS`, we reject them immediately. If that first step is validated, they should also provide an existing `resource_link` of a `course_run` in order to get their values in return.

The new endpoint for remote services will return the values : 
- number of enrollments when a course run has reached its end date.
- number of orders made by leaners who have decided to unlock the accessibility to pass the final exam in order to get the certificate.

- [x] Add new variable in settings that stores the list of authorized tokens to communicate with Joanie's API remote endpoints : `AUTHORIZED_API_KEYS`
- [x] Create a new route to return the awaited values as a dictionary (key:value)
- [x] Create utility methods to count the number of enrollments and orders (WIP)
- [x] Add tests
