### PR TITLE
💚(tray) fix command starting celery app

### DIFF
--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -49,7 +49,7 @@ joanie_celery_command:
   - joanie.celery_app
   - worker
   - -l
-  - INFO"
+  - INFO
 
 # -- resources
 {% set app_resources = {


### PR DESCRIPTION
## Purpose

The command starting the celery app contains a leading double quote and the container was failing to start because of that.

## Proposal

- [x] fix command starting celery app