### PR TITLE
🩹(backend) fix crop setting of easy thumbnail aliases

### DIFF
--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -401,16 +401,16 @@ class Base(Configuration):
     THUMBNAIL_TRANSPARENCY_EXTENSION = "webp"
     THUMBNAIL_ALIASES = {
         "core.Course.cover": {
-            "1920w": {"size": (1920, 1080), "crop": "smart", "upscale": True},
-            "1280w": {"size": (1280, 720), "crop": "smart", "upscale": True},
-            "768w": {"size": (768, 432), "crop": "smart", "upscale": True},
-            "384w": {"size": (384, 216), "crop": "smart", "upscale": True},
+            "1920w": {"size": (1920, 1080), "crop": "scale", "upscale": True},
+            "1280w": {"size": (1280, 720), "crop": "scale", "upscale": True},
+            "768w": {"size": (768, 432), "crop": "scale", "upscale": True},
+            "384w": {"size": (384, 216), "crop": "scale", "upscale": True},
         },
         "core.Organization.logo": {
-            "1024w": {"size": (1024, 1024), "crop": "smart", "upscale": True},
-            "512w": {"size": (512, 512), "crop": "smart", "upscale": True},
-            "256w": {"size": (256, 256), "crop": "smart", "upscale": True},
-            "128w": {"size": (128, 128), "crop": "smart", "upscale": True},
+            "1024w": {"size": (1024, 1024), "crop": "scale", "upscale": True},
+            "512w": {"size": (512, 512), "crop": "scale", "upscale": True},
+            "256w": {"size": (256, 256), "crop": "scale", "upscale": True},
+            "128w": {"size": (128, 128), "crop": "scale", "upscale": True},
         },
     }
 

--- a/src/backend/joanie/tests/core/test_api_admin_courses.py
+++ b/src/backend/joanie/tests/core/test_api_admin_courses.py
@@ -172,13 +172,13 @@ class CourseAdminApiTest(TestCase):
                     "size": course.cover.size,
                     "src": f"http://testserver{course.cover.url}.1x1_q85.webp",
                     "srcset": (
-                        f"http://testserver{course.cover.url}.1920x1080_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.1920x1080_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "1920w, "
-                        f"http://testserver{course.cover.url}.1280x720_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.1280x720_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "1280w, "
-                        f"http://testserver{course.cover.url}.768x432_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.768x432_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "768w, "
-                        f"http://testserver{course.cover.url}.384x216_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{course.cover.url}.384x216_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "384w"
                     ),
                     "height": course.cover.height,

--- a/src/backend/joanie/tests/core/test_api_admin_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_admin_organizations.py
@@ -227,13 +227,13 @@ class OrganizationAdminApiTest(TestCase):
                     "width": 1,
                     "size": organization.logo.size,
                     "srcset": (
-                        f"http://testserver{organization.logo.url}.1024x1024_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.1024x1024_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "1024w, "
-                        f"http://testserver{organization.logo.url}.512x512_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.512x512_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "512w, "
-                        f"http://testserver{organization.logo.url}.256x256_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.256x256_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "256w, "
-                        f"http://testserver{organization.logo.url}.128x128_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                        f"http://testserver{organization.logo.url}.128x128_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                         "128w"
                     ),
                     "filename": organization.logo.name,

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -172,10 +172,10 @@ class ProductAdminApiTest(TestCase):
                             "src": f"{relation.course.cover.url}.1x1_q85.webp",
                             "size": relation.course.cover.size,
                             "srcset": (
-                                f"{relation.course.cover.url}.1920x1080_q85_crop-smart_upscale.webp 1920w, "  # pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.1280x720_q85_crop-smart_upscale.webp 1280w, "  # pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.768x432_q85_crop-smart_upscale.webp 768w, "  # pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.384x216_q85_crop-smart_upscale.webp 384w"  # pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.1920x1080_q85_crop-scale_upscale.webp 1920w, "  # pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.1280x720_q85_crop-scale_upscale.webp 1280w, "  # pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.768x432_q85_crop-scale_upscale.webp 768w, "  # pylint: disable=line-too-long
+                                f"{relation.course.cover.url}.384x216_q85_crop-scale_upscale.webp 384w"  # pylint: disable=line-too-long
                             ),
                         },
                         "title": relation.course.title,

--- a/src/backend/joanie/tests/core/test_api_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations.py
@@ -92,13 +92,13 @@ class OrganizationApiTest(BaseAPITestCase):
                             "filename": organization.logo.name,
                             "src": f"http://testserver{organization.logo.url}.1x1_q85.webp",
                             "srcset": (
-                                f"http://testserver{organization.logo.url}.1024x1024_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.1024x1024_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                                 "1024w, "
-                                f"http://testserver{organization.logo.url}.512x512_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.512x512_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                                 "512w, "
-                                f"http://testserver{organization.logo.url}.256x256_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.256x256_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                                 "256w, "
-                                f"http://testserver{organization.logo.url}.128x128_q85_crop-smart_upscale.webp "  # pylint: disable=line-too-long
+                                f"http://testserver{organization.logo.url}.128x128_q85_crop-scale_upscale.webp "  # pylint: disable=line-too-long
                                 "128w"
                             ),
                             "width": 1,


### PR DESCRIPTION
## Purpose

We previously declare easy thumbnail aliases and for all of them, we set crop property to "smart". It appears this configuration is weird as the asset can be truncated to fit the size defined. To prevent that, a good workaround seems to set "crop" argument to "scale"

## Proposal

- [x] Change easy thumbnail aliases argument 
