### PR TITLE
✨(backend) improve contract filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow to filter contracts by signature state
 - Add bulk download of signed contracts to generate ZIP archive with command
 - Add read-only api admin endpoint to list/retrieve orders
 - Add a management command to synchronize course run or product 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to
 
 ## Added
 
-- Allow to filter contracts by signature state
+- Allow to filter contracts by signature state, 
+  product, course and organization and id
 - Add bulk download of signed contracts to generate ZIP archive with command
 - Add read-only api admin endpoint to list/retrieve orders
 - Add a management command to synchronize course run or product 

--- a/src/backend/joanie/core/enums.py
+++ b/src/backend/joanie/core/enums.py
@@ -98,6 +98,20 @@ CONTRACT_DEFINITION = "contract_definition"
 
 CONTRACT_NAME_CHOICES = ((CONTRACT_DEFINITION, _("Contract Definition")),)  # default
 
+# For contract signature state choices
+CONTRACT_SIGNATURE_STATE_UNSIGNED = "unsigned"
+CONTRACT_SIGNATURE_STATE_HALF_SIGNED = "half_signed"
+CONTRACT_SIGNATURE_STATE_SIGNED = "signed"
+
+CONTRACT_SIGNATURE_STATE_FILTER_CHOICES = (
+    (CONTRACT_SIGNATURE_STATE_UNSIGNED, _("Unsigned")),
+    (
+        CONTRACT_SIGNATURE_STATE_HALF_SIGNED,
+        _("Partially signed"),
+    ),  # Only the student has signed, organization is pending
+    (CONTRACT_SIGNATURE_STATE_SIGNED, _("Signed")),
+)
+
 # For certification names choices
 CERTIFICATE = "certificate"
 DEGREE = "degree"

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -732,6 +732,7 @@ class ContractFactory(factory.django.DjangoModelFactory):
         product__contract_definition=factory.SubFactory(ContractDefinitionFactory),
     )
     student_signed_on = None
+    organization_signed_on = None
 
     @factory.lazy_attribute
     def definition(self):

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -105,10 +105,14 @@ class ContractViewSetFilter(filters.FilterSet):
         method="filter_signature_state",
         choices=enums.CONTRACT_SIGNATURE_STATE_FILTER_CHOICES,
     )
+    id = filters.AllValuesMultipleFilter()
+    course_id = filters.UUIDFilter(field_name="order__course__id")
+    product_id = filters.UUIDFilter(field_name="order__product__id")
+    organization_id = filters.UUIDFilter(field_name="order__organization__id")
 
     class Meta:
         model = models.Contract
-        fields: List[str] = ["signature_state"]
+        fields: List[str] = ["id", "signature_state"]
 
     def filter_signature_state(self, queryset, _name, value):
         """

--- a/src/backend/joanie/tests/core/test_api_courses_contract.py
+++ b/src/backend/joanie/tests/core/test_api_courses_contract.py
@@ -46,7 +46,7 @@ class CourseContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -91,7 +91,7 @@ class CourseContractApiTest(BaseAPITestCase):
         # Having course access does not imply to be able to access to course's contract
         factories.UserCourseAccessFactory(course=relation.course, user=user)
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -148,7 +148,7 @@ class CourseContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
         factories.ContractFactory(order__owner=user)
 
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(courses[0].id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -261,7 +261,7 @@ class CourseContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 9 contracts
-        with self.assertNumQueries(56):
+        with self.assertNumQueries(57):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -272,7 +272,7 @@ class CourseContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 9)
 
         # - Filter by state=unsigned should return 5 contracts
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/?signature_state=unsigned",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -288,7 +288,7 @@ class CourseContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=half_signed should return 3 contracts
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(
                 (
                     f"/api/v1.0/courses/{str(relation.course.id)}"
@@ -307,7 +307,7 @@ class CourseContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=signed should return 1 contract
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/?signature_state=signed",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -355,7 +355,7 @@ class CourseContractApiTest(BaseAPITestCase):
         # Having course access does not imply to be able to access to course's contract
         factories.UserCourseAccessFactory(course=relation.course, user=user)
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(organization.id)}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -387,7 +387,7 @@ class CourseContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -437,7 +437,7 @@ class CourseContractApiTest(BaseAPITestCase):
 
         contract = models.Contract.objects.filter(order__course=courses[0]).first()
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(courses[0].id)}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -513,7 +513,7 @@ class CourseContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(47):
+        with self.assertNumQueries(48):
             response = self.client.get(
                 f"/api/v1.0/courses/{relation.course.code}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -49,7 +49,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -91,7 +91,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -145,7 +145,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
         factories.ContractFactory(order__owner=user)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organizations[0].id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -258,7 +258,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 6 contracts
-        with self.assertNumQueries(56):
+        with self.assertNumQueries(57):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -269,7 +269,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 9)
 
         # - Filter by state=unsigned should return 5 contracts
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{str(organization.id)}"
@@ -288,7 +288,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=half_signed should return 3 contracts
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{str(organization.id)}"
@@ -307,7 +307,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=signed should return 1 contract
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/?signature_state=signed",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -352,7 +352,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -384,7 +384,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(2):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -429,7 +429,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organizations[0]
         ).first()
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{str(organizations[0].id)}"
@@ -510,7 +510,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(47):
+        with self.assertNumQueries(48):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organization.code}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -207,7 +207,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             ],
         }
 
-    def test_api_organizations_contracts_list_filter_is_signed(self):
+    def test_api_organizations_contracts_list_filter_signature_state(self):
         """
         Authenticated user with admin or owner access to the organization
         can query organization's contracts and filter them by signature state.
@@ -232,6 +232,17 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
+        half_signed_contract = factories.ContractFactory.create_batch(
+            3,
+            order__product=relation.product,
+            order__course=relation.course,
+            order__organization=organization,
+            student_signed_on=timezone.now(),
+            submitted_for_signature_on=timezone.now(),
+            definition_checksum="test",
+            context={"title": "test"},
+        )
+
         signed_contract = factories.ContractFactory.create(
             order__product=relation.product,
             order__course=relation.course,
@@ -247,7 +258,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 6 contracts
-        with self.assertNumQueries(53):
+        with self.assertNumQueries(56):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -255,12 +266,15 @@ class OrganizationContractApiTest(BaseAPITestCase):
 
         self.assertEqual(response.status_code, 200)
         content = response.json()
-        self.assertEqual(content["count"], 6)
+        self.assertEqual(content["count"], 9)
 
-        # - Filter by is_signed=false should return 5 contracts
+        # - Filter by state=unsigned should return 5 contracts
         with self.assertNumQueries(8):
             response = self.client.get(
-                f"/api/v1.0/organizations/{str(organization.id)}/contracts/?is_signed=false",
+                (
+                    f"/api/v1.0/organizations/{str(organization.id)}"
+                    "/contracts/?signature_state=unsigned"
+                ),
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
@@ -273,10 +287,29 @@ class OrganizationContractApiTest(BaseAPITestCase):
             result_ids, [str(contract.id) for contract in unsigned_contracts]
         )
 
-        # - Filter by is_signed=true should return 1 contract
+        # - Filter by state=half_signed should return 3 contracts
+        with self.assertNumQueries(6):
+            response = self.client.get(
+                (
+                    f"/api/v1.0/organizations/{str(organization.id)}"
+                    "/contracts/?signature_state=half_signed"
+                ),
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        count = content["count"]
+        result_ids = [result["id"] for result in content["results"]]
+        self.assertEqual(count, 3)
+        self.assertCountEqual(
+            result_ids, [str(contract.id) for contract in half_signed_contract]
+        )
+
+        # - Filter by state=signed should return 1 contract
         with self.assertNumQueries(4):
             response = self.client.get(
-                f"/api/v1.0/organizations/{str(organization.id)}/contracts/?is_signed=true",
+                f"/api/v1.0/organizations/{str(organization.id)}/contracts/?signature_state=signed",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -458,13 +458,6 @@
                 "description": "Contract Viewset to list & retrieve contracts owned by the authenticated user.\n\nGET /api/contracts/\n    Return list of all contracts owned by the logged-in user.\n\nGET /api/contracts/<contract_id>/\n    Return a contract if one matches the provided id,\n    and it is owned by the logged-in user.\n\nGET /api/contracts/<contract_id>/download/\n    Return a contract in PDF format when it is signed on.",
                 "parameters": [
                     {
-                        "in": "query",
-                        "name": "is_signed",
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    },
-                    {
                         "name": "page",
                         "required": false,
                         "in": "query",
@@ -481,6 +474,19 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "signature_state",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "half_signed",
+                                "signed",
+                                "unsigned"
+                            ]
+                        },
+                        "description": "* `unsigned` - Unsigned\n* `half_signed` - Partially signed\n* `signed` - Signed"
                     }
                 ],
                 "tags": [
@@ -1236,13 +1242,6 @@
                         "required": true
                     },
                     {
-                        "in": "query",
-                        "name": "is_signed",
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    },
-                    {
                         "name": "page",
                         "required": false,
                         "in": "query",
@@ -1259,6 +1258,19 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "signature_state",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "half_signed",
+                                "signed",
+                                "unsigned"
+                            ]
+                        },
+                        "description": "* `unsigned` - Unsigned\n* `half_signed` - Partially signed\n* `signed` - Signed"
                     }
                 ],
                 "tags": [
@@ -2992,13 +3004,6 @@
                 "description": "Nested Contract Viewset inside organization route.\nIt allows to list & retrieve organization's contracts if the user is\nan administrator or an owner of the organization.\n\nGET /api/courses/<organization_id|organization_code>/contracts/\n    Return list of all organization's contracts\n\nGET /api/courses/<organization_id|organization_code>/contracts/<contract_id>/\n    Return an organization's contract if one matches the provided id",
                 "parameters": [
                     {
-                        "in": "query",
-                        "name": "is_signed",
-                        "schema": {
-                            "type": "boolean"
-                        }
-                    },
-                    {
                         "in": "path",
                         "name": "organization_id",
                         "schema": {
@@ -3024,6 +3029,19 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "signature_state",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "half_signed",
+                                "signed",
+                                "unsigned"
+                            ]
+                        },
+                        "description": "* `unsigned` - Unsigned\n* `half_signed` - Partially signed\n* `signed` - Signed"
                     }
                 ],
                 "tags": [

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -458,6 +458,36 @@
                 "description": "Contract Viewset to list & retrieve contracts owned by the authenticated user.\n\nGET /api/contracts/\n    Return list of all contracts owned by the logged-in user.\n\nGET /api/contracts/<contract_id>/\n    Return a contract if one matches the provided id,\n    and it is owned by the logged-in user.\n\nGET /api/contracts/<contract_id>/download/\n    Return a contract in PDF format when it is signed on.",
                 "parameters": [
                     {
+                        "in": "query",
+                        "name": "course_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
                         "name": "page",
                         "required": false,
                         "in": "query",
@@ -473,6 +503,14 @@
                         "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     {
@@ -1242,6 +1280,36 @@
                         "required": true
                     },
                     {
+                        "in": "query",
+                        "name": "course_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
                         "name": "page",
                         "required": false,
                         "in": "query",
@@ -1257,6 +1325,14 @@
                         "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     {
@@ -3004,6 +3080,28 @@
                 "description": "Nested Contract Viewset inside organization route.\nIt allows to list & retrieve organization's contracts if the user is\nan administrator or an owner of the organization.\n\nGET /api/courses/<organization_id|organization_code>/contracts/\n    Return list of all organization's contracts\n\nGET /api/courses/<organization_id|organization_code>/contracts/<contract_id>/\n    Return an organization's contract if one matches the provided id",
                 "parameters": [
                     {
+                        "in": "query",
+                        "name": "course_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "id",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
                         "in": "path",
                         "name": "organization_id",
                         "schema": {
@@ -3011,6 +3109,14 @@
                             "pattern": "^[0-9a-z-]*$"
                         },
                         "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
                     },
                     {
                         "name": "page",
@@ -3028,6 +3134,14 @@
                         "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
                         }
                     },
                     {


### PR DESCRIPTION
## Purpose

Previously, we allow to filter contract by signed state. Since we introduce the
double signature logic (student and organization), this filter is no more
relevant and confusing. Indeed, it returns contract at least signed by student
but it could let understand that it should return contracts signed by both
student and organization. We have to replace this filter by something more relevant.

Furthermore we need to be able to retrieve Contract to a specific organization or course
product relation. That's why we added three new filters on Contract API Viewset:
organization_id, course_id and product_id.

## Proposal

- [x] Replace `is_signed` filter by a new `signature-state` filter
- [x] Add `id`, `product_id`, `course_id` and `organization_id` filters
