### PR TITLE
✨(backend) return contract_ids into contracts_signature_link response

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -709,18 +709,22 @@ class OrganizationViewSet(
         """
         organization = self.get_object()
         contracts_ids = request.query_params.getlist("contracts_ids[]")
+
         try:
-            return JsonResponse(
-                {
-                    "invitation_link": organization.contracts_signature_link(
-                        request.user,
-                        contracts_ids,
-                    )
-                },
-                status=200,
+            (signature_link, ids) = organization.contracts_signature_link(
+                request.user,
+                contracts_ids,
             )
         except NoContractToSignError as error:
             return Response({"detail": f"{error}"}, status=400)
+
+        return JsonResponse(
+            {
+                "invitation_link": signature_link,
+                "contract_ids": ids,
+            },
+            status=200,
+        )
 
 
 class OrganizationAccessViewSet(


### PR DESCRIPTION
## Purpose

`contracts_signature_link` is in charge to generate an invitation link to sign all contracts which are pending for the related organization signature. For API consumers, it is interesting to retrieve the list of all contract ids implies in the signature process. In this way, API Consumer could be able to retrieve related contracts to ensure that they have been updated properly once the signature has been done. (That's why we added a filter by `id` into Contract ViewSets in PR #525)


## Proposal

- [x] Return implied contract ids into the `contracts_signature_link` response
