### PR TITLE
♻️(backend) add uri property to CourseRun et CPR models

### DIFF
--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -644,7 +644,8 @@ class CourseProductRelation(BaseModel):
             raise ValidationError(_("You cannot delete this course product relation."))
         return super().delete(using=using, keep_parents=keep_parents)
 
-    def get_read_detail_api_url(self):
+    @property
+    def uri(self):
         """
         Build the api url to get the detail of the provided course product relation.
         """
@@ -657,7 +658,7 @@ class CourseProductRelation(BaseModel):
             },
         )
 
-        return f"https://{site.domain:s}{resource_path:s}"
+        return f"https://{site.domain}{resource_path}"
 
     @property
     def can_edit(self):
@@ -723,13 +724,20 @@ class CourseRun(parler_models.TranslatableModel, BaseModel):
             f"[{self.state.get('text')}]"
         )
 
+    @property
+    def uri(self):
+        """Return the uri of Course Run."""
+        site = Site.objects.get_current()
+        resource_path = reverse("course-runs-detail", kwargs={"id": self.id})
+
+        return f"https://{site.domain:s}{resource_path:s}"
+
     def get_serialized(self, visibility=None):
         """
         Return data for the course run that will be sent to the remote web hooks.
         Course run visibility can be forced via the eponym argument.
         """
-        site = Site.objects.get_current()
-        resource_path = reverse("course-runs-detail", kwargs={"id": self.id})
+
         if (
             visibility is not None
             and visibility not in enums.CATALOG_VISIBILITY_CHOICES
@@ -751,7 +759,7 @@ class CourseRun(parler_models.TranslatableModel, BaseModel):
             if self.enrollment_end
             else None,
             "languages": self.languages,
-            "resource_link": f"https://{site.domain:s}{resource_path:s}",
+            "resource_link": self.uri,
             "start": self.start.isoformat() if self.start else None,
         }
 

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -224,7 +224,7 @@ class Product(parler_models.TranslatableModel, BaseModel):
                 equivalent_course_runs.append(
                     {
                         **course_run_data,
-                        "resource_link": relation.get_read_detail_api_url(),
+                        "resource_link": relation.uri,
                         "course": relation.course.code,
                     }
                 )

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -62,8 +62,9 @@ class AdminCourseRunLightSerializer(serializers.ModelSerializer):
             "end",
             "enrollment_start",
             "enrollment_end",
+            "uri",
         ]
-        read_only_fields = ["id"]
+        read_only_fields = ["id", "uri"]
 
 
 class AdminUserSerializer(serializers.ModelSerializer):
@@ -342,8 +343,9 @@ class AdminCourseProductRelationsSerializer(serializers.ModelSerializer):
             "organizations",
             "order_groups",
             "product",
+            "uri",
         ]
-        read_only_fields = ["id", "can_edit", "order_groups"]
+        read_only_fields = ["id", "can_edit", "order_groups", "uri"]
 
     def create(self, validated_data):
         """
@@ -599,8 +601,9 @@ class AdminCourseRunSerializer(serializers.ModelSerializer):
             "end",
             "enrollment_start",
             "enrollment_end",
+            "uri",
         ]
-        read_only_fields = ["id"]
+        read_only_fields = ["id", "uri"]
 
     def validate(self, attrs):
         """

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
@@ -98,6 +98,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             response.json(),
             {
                 "id": str(relation.id),
+                "uri": relation.uri,
                 "can_edit": relation.can_edit,
                 "course": {
                     "code": course.code,
@@ -204,6 +205,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                                 "title": course.title,
                             },
                             "id": str(relation.id),
+                            "uri": relation.uri,
                             "order_groups": [],
                             "organizations": [
                                 {
@@ -308,6 +310,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             response.json(),
             {
                 "id": str(relation.id),
+                "uri": relation.uri,
                 "can_edit": relation.can_edit,
                 "course": {
                     "code": course.code,
@@ -414,6 +417,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                                 "title": course.title,
                             },
                             "id": str(relation.id),
+                            "uri": relation.uri,
                             "order_groups": [],
                             "organizations": [],
                         }

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
@@ -79,6 +79,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
                 "results": [
                     {
                         "id": str(relation.id),
+                        "uri": relation.uri,
                         "can_edit": relation.can_edit,
                         "course": {
                             "code": relation.course.code,
@@ -197,6 +198,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
                                         "title": relation.course.title,
                                     },
                                     "id": str(relation.id),
+                                    "uri": relation.uri,
                                     "order_groups": [],
                                     "organizations": [
                                         {

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
@@ -73,6 +73,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
             response.json(),
             {
                 "id": str(relation.id),
+                "uri": relation.uri,
                 "can_edit": relation.can_edit,
                 "course": {
                     "code": relation.course.code,
@@ -183,6 +184,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
                                 "title": relation.course.title,
                             },
                             "id": str(relation.id),
+                            "uri": relation.uri,
                             "order_groups": [],
                             "organizations": [
                                 {

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
@@ -96,11 +96,13 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
+        relation.refresh_from_db()
 
         self.assertEqual(
             response.json(),
             {
                 "id": str(relation.id),
+                "uri": relation.uri,
                 "can_edit": relation.can_edit,
                 "course": {
                     "code": course.code,
@@ -209,6 +211,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                                 "title": course.title,
                             },
                             "id": str(relation.id),
+                            "uri": relation.uri,
                             "order_groups": [],
                             "organizations": [
                                 {
@@ -301,11 +304,12 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-
+        relation.refresh_from_db()
         self.assertEqual(
             response.json(),
             {
                 "id": str(relation.id),
+                "uri": relation.uri,
                 "can_edit": relation.can_edit,
                 "course": {
                     "code": course.code,
@@ -414,6 +418,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                                 "title": course.title,
                             },
                             "id": str(relation.id),
+                            "uri": relation.uri,
                             "order_groups": [],
                             "organizations": [
                                 {
@@ -472,6 +477,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
 
         assert response.json() == {
             "id": str(relation.id),
+            "uri": relation.uri,
             "can_edit": relation.can_edit,
             "course": {
                 "code": relation.course.code,
@@ -582,6 +588,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                             "title": relation.course.title,
                         },
                         "id": str(relation.id),
+                        "uri": relation.uri,
                         "order_groups": [],
                         "organizations": [
                             {

--- a/src/backend/joanie/tests/core/test_api_admin_course_runs.py
+++ b/src/backend/joanie/tests/core/test_api_admin_course_runs.py
@@ -3,16 +3,20 @@ Test suite for Course run Admin API.
 """
 import random
 from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
 
 from django.test import TestCase
 
 from joanie.core import factories, models
+from joanie.tests import format_date
 
 
 class CourseRunAdminApiTest(TestCase):
     """
     Test suite for Course run Admin API.
     """
+
+    maxDiff = None
 
     def test_admin_api_course_runs_request_without_authentication(self):
         """
@@ -120,22 +124,34 @@ class CourseRunAdminApiTest(TestCase):
 
         response = self.client.get(f"/api/v1.0/admin/course-runs/{course_run.id}/")
 
-        self.assertEqual(response.status_code, 200)
-        content = response.json()
-        self.assertEqual(content["id"], str(course_run.id))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
         self.assertEqual(
-            content["start"], course_run.start.isoformat().replace("+00:00", "Z")
-        )
-        self.assertEqual(
-            content["end"], course_run.end.isoformat().replace("+00:00", "Z")
-        )
-        self.assertEqual(
-            content["enrollment_start"],
-            course_run.enrollment_start.isoformat().replace("+00:00", "Z"),
-        )
-        self.assertEqual(
-            content["enrollment_end"],
-            course_run.enrollment_end.isoformat().replace("+00:00", "Z"),
+            response.json(),
+            {
+                "id": str(course_run.id),
+                "start": format_date(course_run.start),
+                "end": format_date(course_run.end),
+                "enrollment_start": format_date(course_run.enrollment_start),
+                "enrollment_end": format_date(course_run.enrollment_end),
+                "course": {
+                    "code": course_run.course.code,
+                    "title": course_run.course.title,
+                    "id": str(course_run.course.id),
+                    "state": {
+                        "priority": course_run.course.state["priority"],
+                        "datetime": format_date(course_run.course.state["datetime"]),
+                        "call_to_action": course_run.course.state["call_to_action"],
+                        "text": course_run.course.state["text"],
+                    },
+                },
+                "resource_link": course_run.resource_link,
+                "title": course_run.title,
+                "is_gradable": course_run.is_gradable,
+                "is_listed": course_run.is_listed,
+                "languages": course_run.languages,
+                "uri": course_run.uri,
+            },
         )
 
     def test_admin_api_course_runs_create(self):

--- a/src/backend/joanie/tests/core/test_api_admin_courses.py
+++ b/src/backend/joanie/tests/core/test_api_admin_courses.py
@@ -165,6 +165,7 @@ class CourseAdminApiTest(TestCase):
                         "is_gradable": course_run.is_gradable,
                         "is_listed": course_run.is_listed,
                         "resource_link": course_run.resource_link,
+                        "uri": course_run.uri,
                     }
                     for course_run in reversed(course_runs)
                 ],
@@ -218,7 +219,7 @@ class CourseAdminApiTest(TestCase):
         organization = factories.OrganizationFactory()
         product = factories.ProductFactory()
         data = {
-            "code": "COURSE-001",
+            "code": "00001",
             "title": "Course 001",
             "organization_ids": [str(organization.id)],
             "product_relations": [
@@ -237,7 +238,7 @@ class CourseAdminApiTest(TestCase):
         content = response.json()
 
         self.assertIsNotNone(content["code"])
-        self.assertEqual(content["code"], "COURSE-001")
+        self.assertEqual(content["code"], "00001")
         self.assertListEqual(
             content["organizations"],
             [
@@ -292,7 +293,7 @@ class CourseAdminApiTest(TestCase):
         """
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=admin.username, password="password")
-        course = factories.CourseFactory(code="COURSE-001", title="Course 001")
+        course = factories.CourseFactory(code="00001", title="Course 00001")
         organization = factories.OrganizationFactory(code="ORG-002")
         product = factories.ProductFactory()
 
@@ -300,7 +301,7 @@ class CourseAdminApiTest(TestCase):
             f"/api/v1.0/admin/courses/{course.id}/",
             content_type="application/json",
             data={
-                "title": "Updated Course 001",
+                "title": "Updated Course 00001",
                 "organization_ids": [str(organization.id)],
                 "product_relations": [
                     {
@@ -314,7 +315,7 @@ class CourseAdminApiTest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertEqual(content["id"], str(course.id))
-        self.assertEqual(content["title"], "Updated Course 001")
+        self.assertEqual(content["title"], "Updated Course 00001")
         self.assertEqual(content["organizations"][0]["code"], "ORG-002")
         self.assertEqual(len(content["product_relations"]), 1)
 

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -161,6 +161,7 @@ class ProductAdminApiTest(TestCase):
             "course_relations": [
                 {
                     "id": str(relation.id),
+                    "uri": relation.uri,
                     "can_edit": relation.can_edit,
                     "course": {
                         "id": str(relation.course.id),

--- a/src/backend/joanie/tests/core/test_models_course_product_relation.py
+++ b/src/backend/joanie/tests/core/test_models_course_product_relation.py
@@ -9,15 +9,15 @@ from joanie.core import factories
 class CourseProductRelationModelTestCase(TestCase):
     """Test suite for the CourseProductRelation model."""
 
-    def test_model_course_product_relation_get_read_detail_api_url(self):
+    def test_model_course_product_relation_uri(self):
         """
-        CourseProductRelation instance should have a method `get_read_detail_api_url`
+        CourseProductRelation instance should have a property `uri`
         that returns the API url to get instance detail.
         """
         relation = factories.CourseProductRelationFactory()
 
         self.assertEqual(
-            relation.get_read_detail_api_url(),
+            relation.uri,
             (
                 "https://example.com/api/v1.0/"
                 f"courses/{relation.course.code}/products/{relation.product.id}/"

--- a/src/backend/joanie/tests/core/test_models_course_run.py
+++ b/src/backend/joanie/tests/core/test_models_course_run.py
@@ -44,6 +44,18 @@ class CourseRunModelsTestCase(TestCase):
             course_run.resource_link, "https://www.example.com/Capitalized-Path"
         )
 
+    def test_models_course_run_uri(self):
+        """
+        CourseRun instance should have a property `uri`
+        that returns the API url to get instance detail.
+        """
+        course_run = factories.CourseRunFactory()
+
+        self.assertEqual(
+            course_run.uri,
+            f"https://example.com/api/v1.0/course-runs/{course_run.id}/",
+        )
+
     def test_models_course_run_dates_not_required(self):
         """
         Course run dates are not required.

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -3737,6 +3737,10 @@
                             }
                         ],
                         "readOnly": true
+                    },
+                    "uri": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -3745,7 +3749,8 @@
                     "id",
                     "order_groups",
                     "organizations",
-                    "product"
+                    "product",
+                    "uri"
                 ]
             },
             "AdminCourseRequest": {
@@ -3831,6 +3836,10 @@
                         "type": "string",
                         "format": "date-time",
                         "nullable": true
+                    },
+                    "uri": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -3838,7 +3847,8 @@
                     "id",
                     "languages",
                     "resource_link",
-                    "title"
+                    "title",
+                    "uri"
                 ]
             },
             "AdminCourseRunLight": {
@@ -3893,13 +3903,18 @@
                         "type": "string",
                         "format": "date-time",
                         "nullable": true
+                    },
+                    "uri": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
                     "id",
                     "languages",
                     "resource_link",
-                    "title"
+                    "title",
+                    "uri"
                 ]
             },
             "AdminCourseRunLightRequest": {
@@ -4697,6 +4712,10 @@
                             }
                         ],
                         "readOnly": true
+                    },
+                    "uri": {
+                        "type": "string",
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -4704,7 +4723,8 @@
                     "id",
                     "order_groups",
                     "organizations",
-                    "product"
+                    "product",
+                    "uri"
                 ]
             },
             "AdminProductRequest": {


### PR DESCRIPTION
## Purpose

Back office needs to retrieve uri of CourseRun and CourseProductRelations in order to improve UX about those models.

## Proposal

- [x] Refactor `CourseRun` and `CourseProductRelation` to add a `uri` property
- [x] Bind `uri` property into `CourseRun` and `CourseProductRelation`
