### PR TITLE
✨(frontend) add course product relations 

### DIFF
--- a/src/frontend/admin/src/components/presentational/dnd/DndDefaultRow.tsx
+++ b/src/frontend/admin/src/components/presentational/dnd/DndDefaultRow.tsx
@@ -8,7 +8,7 @@ import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
 import ModeEditOutlineTwoToneIcon from "@mui/icons-material/ModeEditOutlineTwoTone";
 
 export interface DndDefaultRowProps {
-  mainTitle: string;
+  mainTitle: string | ReactNode;
   subTitle?: string | ReactNode;
   rightActions?: React.ReactNode;
   permanentRightActions?: React.ReactNode;

--- a/src/frontend/admin/src/components/presentational/list/DefaultRow.tsx
+++ b/src/frontend/admin/src/components/presentational/list/DefaultRow.tsx
@@ -12,7 +12,7 @@ import { SxProps } from "@mui/material/styles";
 import Tooltip from "@mui/material/Tooltip";
 
 export interface DefaultRowProps {
-  mainTitle: string;
+  mainTitle: string | ReactNode;
   subTitle?: string | ReactNode;
   rightActions?: React.ReactNode;
   permanentRightActions?: React.ReactNode;

--- a/src/frontend/admin/src/components/templates/courses/form/product-relation/CourseProductRelationForm.tsx
+++ b/src/frontend/admin/src/components/templates/courses/form/product-relation/CourseProductRelationForm.tsx
@@ -5,6 +5,7 @@ import Grid from "@mui/material/Unstable_Grid2";
 import { yupResolver } from "@hookform/resolvers/yup";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
 import {
   CourseRelationToProduct,
@@ -15,6 +16,24 @@ import { DndDefaultRow } from "@/components/presentational/dnd/DndDefaultRow";
 import { ProductSearch } from "@/components/templates/products/inputs/search/ProductSearch";
 import { OrganizationControlledSearch } from "@/components/templates/organizations/inputs/search/OrganizationControlledSearch";
 import { Product } from "@/services/api/models/Product";
+
+const messages = defineMessages({
+  productLabel: {
+    id: "components.templates.course.form.translations.productRelation.productLabel",
+    defaultMessage: "Product",
+    description: "Product label for the CourseProductRelation form",
+  },
+  chooseProduct: {
+    id: "components.templates.course.form.translations.productRelation.chooseProduct",
+    defaultMessage: "Choose your product",
+    description: "Label form the product search input",
+  },
+  organizationsTitle: {
+    id: "components.templates.course.form.translations.productRelation.organizationsTitle",
+    defaultMessage: "Managed by this organizations",
+    description: "Title for the organizations section",
+  },
+});
 
 export interface CourseProductRelationFormValues {
   product: Product | null;
@@ -40,6 +59,8 @@ export function CourseProductRelationForm({
   onSubmit,
   courseId,
 }: Props) {
+  const intl = useIntl();
+
   const methods = useForm<CourseProductRelationFormValues>({
     resolver: yupResolver(CourseProductRelationFormSchema),
     defaultValues: {
@@ -68,14 +89,19 @@ export function CourseProductRelationForm({
     >
       <Grid container spacing={2}>
         <Grid xs={12}>
-          <Typography variant="subtitle2">Product</Typography>
+          <Typography variant="subtitle2">
+            <FormattedMessage {...messages.productLabel} />
+          </Typography>
         </Grid>
         <Grid xs={12}>
-          <ProductSearch name="product" label="Choose your product" />
+          <ProductSearch
+            name="product"
+            label={intl.formatMessage(messages.chooseProduct)}
+          />
         </Grid>
         <Grid xs={12}>
           <Typography variant="subtitle2">
-            Managed by this organizations
+            <FormattedMessage {...messages.organizationsTitle} />
           </Typography>
         </Grid>
         <Grid xs={12}>

--- a/src/frontend/admin/src/components/templates/courses/form/sections/product-relation/CourseProductRelationRow.tsx
+++ b/src/frontend/admin/src/components/templates/courses/form/sections/product-relation/CourseProductRelationRow.tsx
@@ -20,6 +20,8 @@ import { useCourseProductRelations } from "@/hooks/useCourseProductRelation/useC
 import { AlertModal } from "@/components/presentational/modal/AlertModal";
 import { useList } from "@/hooks/useList/useList";
 import { OrderGroupRow } from "@/components/templates/courses/form/sections/product-relation/OrderGroupRow";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { PATH_ADMIN } from "@/utils/routes/path";
 
 const messages = defineMessages({
   mainTitleOrderGroup: {
@@ -201,7 +203,11 @@ export function CourseProductRelationRow({
       <DefaultRow
         loading={courseProductRelationQuery.states.updating}
         key={relation.product.title}
-        mainTitle={relation.product.title}
+        mainTitle={
+          <CustomLink href={PATH_ADMIN.products.edit(relation.product.id)}>
+            {relation.product.title}
+          </CustomLink>
+        }
         enableEdit={canEdit}
         enableDelete={canEdit}
         disableDeleteMessage={disabledActionsMessage}

--- a/src/frontend/admin/src/components/templates/products/form/ProductForm.tsx
+++ b/src/frontend/admin/src/components/templates/products/form/ProductForm.tsx
@@ -10,6 +10,7 @@ import { ProductFormTypeSection } from "@/components/templates/products/form/sec
 import { ProductFormTargetCoursesSection } from "@/components/templates/products/form/sections/target-courses/ProductFormTargetCoursesSection";
 import { productFormMessages } from "@/components/templates/products/form/translations";
 import { Wizard, WizardStep } from "@/components/presentational/wizard/Wizard";
+import { ProductFormCourseProductRelations } from "@/components/templates/products/form/sections/course-product-relations/ProductFormCourseProductRelations";
 
 type Props = {
   product?: Product;
@@ -70,10 +71,19 @@ export function ProductForm({ product, fromProduct, afterSubmit }: Props) {
   }
 
   return (
-    <SimpleCard>
-      <Box padding={4}>
-        <Wizard steps={formSteps} />
-      </Box>
-    </SimpleCard>
+    <>
+      <SimpleCard>
+        <Box padding={4}>
+          <Wizard steps={formSteps} />
+        </Box>
+      </SimpleCard>
+      {product && (
+        <Box mt={6}>
+          <ProductFormCourseProductRelations
+            relations={product.course_relations}
+          />
+        </Box>
+      )}
+    </>
   );
 }

--- a/src/frontend/admin/src/components/templates/products/form/sections/course-product-relations/ProductFormCourseProductRelations.tsx
+++ b/src/frontend/admin/src/components/templates/products/form/sections/course-product-relations/ProductFormCourseProductRelations.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { defineMessages, FormattedMessage } from "react-intl";
+import Alert from "@mui/material/Alert";
+import Box from "@mui/material/Box";
+import { ProductRelationToCourse } from "@/services/api/models/Relations";
+import { SimpleCard } from "@/components/presentational/card/SimpleCard";
+import { CustomLink } from "@/components/presentational/link/CustomLink";
+import { PATH_ADMIN } from "@/utils/routes/path";
+import { DefaultRow } from "@/components/presentational/list/DefaultRow";
+
+const messages = defineMessages({
+  sectionTitle: {
+    id: "components.templates.products.form.translations.courseProductRelations.sectionTitle",
+    defaultMessage: "List of courses to which this product is linked",
+    description: "Product course relation section title",
+  },
+  sectionAlertMessage: {
+    id: "components.templates.products.form.translations.courseProductRelations.sectionAlertMessage",
+    defaultMessage:
+      "In this section, you have access to all courses to which this product is attached. Click on the course title to navigate to its detail.",
+    description: "Product course relation section alert message",
+  },
+});
+
+type Props = {
+  relations?: ProductRelationToCourse[];
+};
+export function ProductFormCourseProductRelations({ relations = [] }: Props) {
+  return (
+    <SimpleCard>
+      <Box padding={4}>
+        <Stack spacing={2}>
+          <Typography variant="subtitle2">
+            <FormattedMessage {...messages.sectionTitle} />
+          </Typography>
+          <Alert data-testid="product-course-relation-alert" severity="info">
+            <FormattedMessage {...messages.sectionAlertMessage} />
+          </Alert>
+        </Stack>
+        <Stack spacing={1} mt={3}>
+          {relations.map((relation) => (
+            <DefaultRow
+              enableDelete={false}
+              subTitle={relation.organizations
+                .map((org) => org.title)
+                .join(",")}
+              mainTitle={
+                <CustomLink href={PATH_ADMIN.courses.edit(relation.course.id)}>
+                  {relation.course.title}
+                </CustomLink>
+              }
+              key={relation.course.title}
+            />
+          ))}
+        </Stack>
+      </Box>
+    </SimpleCard>
+  );
+}

--- a/src/frontend/admin/src/pages/admin/products/[id]/edit.tsx
+++ b/src/frontend/admin/src/pages/admin/products/[id]/edit.tsx
@@ -2,7 +2,6 @@ import { useRouter } from "next/router";
 import { defineMessages, useIntl } from "react-intl";
 import { DashboardLayoutPage } from "@/layouts/dashboard/page/DashboardLayoutPage";
 import { PATH_ADMIN } from "@/utils/routes/path";
-import { SimpleCard } from "@/components/presentational/card/SimpleCard";
 import { useProduct } from "@/hooks/useProducts/useProducts";
 import { ProductForm } from "@/components/templates/products/form/ProductForm";
 import { productsPagesTranslation } from "@/translations/pages/products/breadcrumbsTranslations";
@@ -48,9 +47,7 @@ export default function EditProductPage() {
         },
       ]}
     >
-      <SimpleCard>
-        {product.item && <ProductForm product={product.item} />}
-      </SimpleCard>
+      {product.item && <ProductForm product={product.item} />}
     </DashboardLayoutPage>
   );
 }

--- a/src/frontend/admin/src/services/api/models/Product.ts
+++ b/src/frontend/admin/src/services/api/models/Product.ts
@@ -18,7 +18,7 @@ export type Product = {
   price_currency?: string;
   instructions?: string;
   certificate_definition?: CertificateDefinition;
-  courses?: ProductRelationToCourse[];
+  course_relations?: ProductRelationToCourse[];
 };
 
 export enum ProductType {

--- a/src/frontend/admin/src/services/factories/product/index.ts
+++ b/src/frontend/admin/src/services/factories/product/index.ts
@@ -3,6 +3,7 @@ import { Product, ProductType } from "@/services/api/models/Product";
 import { CertificateDefinitionFactory } from "@/services/factories/certificate-definition";
 import { randomNumber } from "@/utils/numbers";
 import { ProductTargetCourseRelationFactory } from "@/services/api/models/ProductTargetCourseRelation";
+import { ProductRelationToCourseFactory } from "@/services/api/models/Relations";
 
 const build = (): Product => {
   return {
@@ -15,6 +16,7 @@ const build = (): Product => {
     price_currency: "EUR",
     certificate_definition: CertificateDefinitionFactory(),
     target_courses: ProductTargetCourseRelationFactory(randomNumber(2)),
+    course_relations: ProductRelationToCourseFactory(2),
   };
 };
 

--- a/src/frontend/admin/src/services/http/HttpService.ts
+++ b/src/frontend/admin/src/services/http/HttpService.ts
@@ -55,7 +55,8 @@ export async function checkStatus(
   response: Response,
   options: CheckStatusOptions = { fallbackValue: null, ignoredErrorStatus: [] },
 ): Promise<any> {
-  if (response.status === HttpStatus.UNAUTHORIZED) {
+  const isTestSource = process.env.NEXT_PUBLIC_API_SOURCE === "test";
+  if (response.status === HttpStatus.UNAUTHORIZED && !isTestSource) {
     window.location.replace(PATH_ADMIN.auth.login());
   }
 


### PR DESCRIPTION
## Purpose

Currently, we cannot see the courses to which the products are attached. So we
add a list below the form

<img width="2560" alt="Capture d’écran 2023-12-22 à 14 32 05" src="https://github.com/openfun/joanie/assets/19410531/4e6e2cb8-bbbe-4c73-8358-f4ec379d9b91">
