### PR TITLE
🔧(Makefile) fix command name to create frontend admin .env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ bootstrap: \
 	env.d/development/common \
 	env.d/development/crowdin \
 	env.d/development/localtunnel \
-	frontend/admin/env \
+	src/frontend/admin/.env \
 	build \
 	admin-install \
 	admin-build \
@@ -228,7 +228,7 @@ resetdb: ## flush database and create a superuser "admin"
 .PHONY: resetdb
 
 # -- Frontend admin
-frontend/admin/env:
+src/frontend/admin/.env:
 	cp -n src/frontend/admin/.env.example src/frontend/admin/.env
 
 admin-install: ## Install node_modules


### PR DESCRIPTION
## Purpose

In order to work properly, make command to create an env variable from a template file should be named with the exact path of the related file otherwise an Error 1 is returned.


## Proposal

- [x] Fix Makefile command
