### PR TITLE
👨‍💻(backend) improve dx of generate_jwt_tokens command

### DIFF
--- a/src/backend/joanie/demo/management/commands/generate_jwt_tokens.py
+++ b/src/backend/joanie/demo/management/commands/generate_jwt_tokens.py
@@ -1,4 +1,5 @@
 """Management command to generate user JWT tokens"""
+import json
 from datetime import datetime, timedelta
 
 from django.core.management.base import BaseCommand
@@ -16,9 +17,14 @@ class Command(BaseCommand):
         """Generate user tokens"""
         self.stdout.write("\nTokens:")
         expires_at = datetime.utcnow() + timedelta(days=365)
+        tokens = {}
         for user in User.objects.all():
             token = generate_jwt_token_from_user(user, expires_at=expires_at)
+            tokens[user.username] = str(token)
             self.stdout.write(f"jwt: {token}")
             for key, value in token.payload.items():
                 self.stdout.write(f"  {key}: {value}")
             self.stdout.write("")
+
+        self.stdout.write("Copy the following into your dummy.ts file in Richie:")
+        self.stdout.write(json.dumps(tokens, indent=2))


### PR DESCRIPTION
## Purpose

The command "generate_jwt_tokens" is really useful but, it could be improved to ease the work of frontend developers on Richie. Indeed, for developer, richie allows to use a fake authentication interface which just get value from an object containing a keypair username/jwt_tokens. So we update the command to log
 in output this object, in this way, developer has just to copy/paste it to have
  fresh users.

```
Copy the following into your dummy.ts file in Richie:
{
  "user3": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "user4": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "student_user": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "test": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "admin": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "user0": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "user1": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "user2": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**",
  "organization_owner": "eyJhb**.eyJ0b2tlbl90**.Dpy4bjPpf**"
}

```