### PR TITLE
🐛(backend) exclude not validated order contract from bulk signature

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -1032,7 +1032,9 @@ class GenericContractViewSet(
     serializer_class = serializers.ContractSerializer
     filterset_class = filters.ContractViewSetFilter
     ordering = ["-student_signed_on", "-created_on"]
-    queryset = models.Contract.objects.all().select_related(
+    queryset = models.Contract.objects.filter(
+        order__state=enums.ORDER_STATE_VALIDATED
+    ).select_related(
         "definition",
         "order__organization",
         "order__course",

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -234,6 +234,7 @@ class Organization(parler_models.TranslatableModel, BaseModel):
                 submitted_for_signature_on__isnull=False,
                 student_signed_on__isnull=False,
                 order__organization=self,
+                order__state=enums.ORDER_STATE_VALIDATED,
             ).values_list("id", "signature_backend_reference")
         )
         if contracts_ids and len(contracts_to_sign) != len(contracts_ids):


### PR DESCRIPTION
## Purpose

Currently, the bulk data signature endpoint embeds also contract relying on canceled orders that is weird. We fix that and to keep api consistent we also filter out contracts which are no relying on validated orders on contract endpoints.


## Proposal

- [x] Fix organization bulk sign logic to ignore contracts relying on not validated order
- [x] Update queryset of GenericContractViewSet to filter contracts by `order__state`
