### PR TITLE
Feat/Invoice template and remove Howard/Marion dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to
 
 ### Changed
 
+- Internalize invoice template
 - Use HTTPStatus instead of raw HTTP code value
 - If a product has a contract, delay auto enroll logic on leaner signature
 - Prevent to enroll to not listed course runs related to an order awaiting

--- a/docs/media.md
+++ b/docs/media.md
@@ -1,8 +1,7 @@
 # Media files in Joanie
 
 Media files are kept private in Joanie and are not served on the web. They
-are only used to render pdf documents with code using WeasyPrint via
-[Marion](https://github.com/openfun/marion).
+are only used to render pdf documents with code using WeasyPrint.
 
 At [France Université Numérique](https://www.france-universite-numerique.fr),
 we host our media files in [Swift](https://docs.openstack.org/swift) at

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -29,6 +29,7 @@ from joanie.core.exceptions import NoContractToSignError
 from joanie.core.tasks import generate_zip_archive_task
 from joanie.core.utils import contract as contract_utility
 from joanie.core.utils import contract_definition, issuers
+from joanie.payment import enums as payment_enums
 from joanie.payment.models import Invoice
 
 # pylint: disable=too-many-ancestors, too-many-lines
@@ -474,8 +475,13 @@ class OrderViewSet(
                 status=HTTPStatus.NOT_FOUND,
             )
 
+        context = invoice.get_document_context()
+        invoice_pdf_bytes = issuers.generate_document(
+            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+        )
+
         response = HttpResponse(
-            invoice.document, content_type="application/pdf", status=HTTPStatus.OK
+            invoice_pdf_bytes, content_type="application/pdf", status=HTTPStatus.OK
         )
         response[
             "Content-Disposition"

--- a/src/backend/joanie/core/models/certifications.py
+++ b/src/backend/joanie/core/models/certifications.py
@@ -31,7 +31,6 @@ class CertificateDefinition(parler_models.TranslatableModel, BaseModel):
         title=models.CharField(_("title"), max_length=255),
         description=models.TextField(_("description"), max_length=500, blank=True),
     )
-    # howard template used to generate pdf certificate
     template = models.CharField(
         _("template to generate pdf"),
         choices=enums.CERTIFICATE_NAME_CHOICES,

--- a/src/backend/joanie/core/templates/issuers/contract_definition.html
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load static %}
-{% load howard_tags %}
 
 <html>
   {% if debug %}

--- a/src/backend/joanie/core/templates/issuers/invoice.css
+++ b/src/backend/joanie/core/templates/issuers/invoice.css
@@ -1,0 +1,241 @@
+/* load extra fonts */
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700");
+
+:root {
+  font-size: 12pt; /* 16px */
+}
+
+body {
+  background: #fff;
+  font-family: Roboto, -apple-system, BlinkMacSystemFont, "Segoe UI", Oxygen,
+    Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 18px;
+  line-height: 1.5em; /* 24px */
+  color: #333;
+  padding: 0;
+  margin: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ul,
+ol,
+dl,
+dd,
+dt,
+blockquote,
+pre,
+figure,
+figcaption,
+table,
+td,
+th,
+tr {
+  line-height: 1.5rem;
+  list-style: none;
+  margin: 0 0 1.5rem 0;
+  padding: 0;
+}
+
+h1 {
+  font-size: 2.25rem;
+  line-height: 3rem;
+}
+h2 {
+  font-size: 2rem;
+  line-height: 3rem;
+}
+h3 {
+  font-size: 1.75rem;
+}
+h4 {
+  font-size: 1.5rem;
+}
+h5 {
+  font-size: 1.15rem;
+}
+h6 {
+  font-size: 1rem;
+}
+
+.light {
+  color: rgba(33, 33, 33, 0.35);
+}
+
+/* ----------------------------------------------------------------- == debug
+   Create a debug grid to ensure that vertical rhythm is maintained.
+*/
+body.debug {
+  --grid-x-color: rgba(255, 33, 33, 0.1);
+  --grid-y-color: rgba(33, 33, 255, 0.1);
+  background-image: linear-gradient(
+      to left,
+      var(--grid-x-color) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, var(--grid-y-color) 1px, transparent 1px);
+  background-repeat: repeat;
+  background-size: 1rem 1.5rem;
+}
+
+/* ----------------------------------------------------------------- == print */
+@media print {
+  @page {
+    size: A4 portrait;
+    height: 297mm;
+    margin: 0;
+    padding: 0;
+    width: 210mm;
+  }
+}
+
+/* --------------------------------------------------------------- == invoice */
+.invoice {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 3rem;
+}
+
+.invoice-list .invoice-list__item strong {
+  font-weight: normal;
+}
+
+/* -------------------------------------------------------- == invoice-header */
+.invoice-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-bottom: 3rem;
+}
+
+.header-logo > img {
+  height: 6rem;
+}
+
+.header-title {
+  font-size: 3rem;
+  font-weight: 900;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+/* --------------------------------------------------------- == .invoice-body */
+.invoice-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding-bottom: 3rem;
+}
+
+.invoice-stakeholders {
+  border-bottom: thin solid rgba(33, 33, 33, 0.25);
+  border-top: thin solid rgba(33, 33, 33, 0.25);
+  box-sizing: border-box;
+  display: flex;
+  margin: 0;
+  padding: 1.5rem 0;
+}
+
+.invoice-stakeholders .invoice-stakeholders__item:not(:last-child) {
+  margin-right: 9rem;
+}
+
+.invoice-stakeholders .invoice-stakeholders__item-label {
+  margin: 0;
+  font-weight: 700;
+}
+
+.invoice-stakeholders .invoice-stakeholders__item-address {
+  margin: 0;
+  font-style: normal;
+}
+
+.invoice-metadata {
+  margin-top: 3rem;
+}
+
+.invoice-metadata__title {
+  margin-bottom: 0;
+}
+
+.invoice-metadata .invoice-list__item strong {
+  display: inline-block;
+  font-weight: normal;
+  width: 125px;
+}
+
+.product-table {
+  border-spacing: 0;
+  text-align: left;
+  width: 100%;
+}
+
+.product-table__cell {
+  padding: 0 0.5rem;
+  vertical-align: top;
+}
+
+.product-table__cell:first-child {
+  padding-left: 0;
+}
+
+.product-table__cell:last-child {
+  padding-right: 0;
+}
+
+.product-table__cell.product-table__cell--head {
+  border-bottom: thin solid rgba(33, 33, 33, 0.25);
+  box-sizing: border-box;
+  font-weight: bold;
+}
+
+.product-table__cell.product-table__cell--center {
+  text-align: center;
+}
+
+.product-table__cell.product-table__cell--right {
+  text-align: right;
+}
+
+/* -------------------------------------------------------- == invoice-details */
+
+.invoice_detail_container {
+  display: flex;
+  align-items: flex-end;
+  flex-direction: row-reverse;
+  justify-content:space-evenly;
+  padding-top: 3mm;
+}
+
+.invoice_detail_table {
+  /* Push the table to the right */
+  margin-left: auto;
+}
+
+.invoice_category_item {
+  border-bottom: 1px solid #dfdfdf;
+}
+
+.invoice_item_value {
+  border-bottom: 1px solid #dfdfdf;
+  text-align: right;
+  padding: 3mm;
+}
+
+/* -------------------------------------------------------- == invoice-footer */
+.invoice-footer {
+  font-size: 1rem;
+  text-align: center;
+}
+
+.company-info {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}

--- a/src/backend/joanie/core/templates/issuers/invoice.html
+++ b/src/backend/joanie/core/templates/issuers/invoice.html
@@ -1,0 +1,149 @@
+{% load i18n %}
+{% load static %}
+{% load extra_tags %}
+
+<html>
+  {% if debug %}
+  <head>
+    <style>
+      {{ css }}
+    </style>
+  </head>
+  {% endif %}
+  <body class="{%if debug %}debug {% endif %}invoice">
+    <header class="invoice-header">
+      <div class="header-logo">
+        <img src="{% base64_static "joanie/images/logo_fun.png" %}" />
+        <img src="{{ organization.logo }}" />
+      </div>
+      <h1 class="header-title light">
+        {% if metadata.type == "invoice" %}
+          {% trans "Invoice" %}
+        {% else %}
+          {% trans "Credit note" %}
+        {% endif %}
+      </h1>
+    </header>
+    <article class="invoice-body">
+      <ul class="invoice-stakeholders">
+        <li class="invoice-stakeholders__item">
+          <h5 class="invoice-stakeholders__item-label">
+            {% if metadata.type == "invoice" %}
+              {% trans "Sold by" %}
+            {% else %}
+              {% trans "Refunded by" %}
+            {% endif %}
+          </h5>
+          <address class="invoice-stakeholders__item-address">
+            {{ order.seller.address|linebreaksbr }}
+          </address>
+        </li>
+        <li class="invoice-stakeholders__item">
+          <h5 class="invoice-stakeholders__item-label">
+            {% if metadata.type == "invoice" %}
+              {% trans "Billed to" %}
+            {% else %}
+              {% trans "Refunded to" %}
+            {% endif %}
+          </h5>
+          <address class="invoice-stakeholders__item-address">
+            {{ order.customer.name }}
+            <br />
+            {{ order.customer.address|linebreaksbr }}
+          </address>
+        </li>
+      </ul>
+      <section class="invoice-metadata">
+        <h5 class="invoice-metadata__title">
+          {% if metadata.type == "invoice" %}
+            {% trans "Invoice information" %}
+          {% else %}
+            {% trans "Credit note information" %}
+          {% endif %}
+        </h5>
+        <ul class="invoice-list">
+          <li class="invoice-list__item">
+            <strong>{% trans "Reference" %}</strong>&nbsp;{{ metadata.reference }}
+          </li>
+          <li class="invoice-list__item">
+            <strong>{% trans "Issue date" %}</strong>&nbsp;{{ metadata.issued_on|date:"d/m/Y"}}
+          </li>
+        </ul>
+      </section>
+      {% with currency=order.amount.currency %}
+      <table class="product-table">
+        <thead class="product-table__head">
+          <tr class="product-table__row">
+            <th class="product-table__cell product-table__cell--head">
+              {% trans "Product" %}
+            </th>
+            <th
+              class="
+                product-table__cell
+                product-table__cell--head
+                product-table__cell--right
+              "
+            >
+              {% trans "Price" %}
+            </th>
+            <th
+              class="
+                product-table__cell
+                product-table__cell--head
+                product-table__cell--right
+              "
+            >
+              {% trans "VAT" %}&nbsp;({{ order.amount.vat }}%)
+            </th>
+            <th
+              class="
+                product-table__cell
+                product-table__cell--head
+                product-table__cell--right
+              "
+            >
+              {% trans "Total" %}
+            </th>
+          </tr>
+        </thead>
+        <tbody class="product-table__body">
+          <tr class="product-table__row">
+            <td class="product-table__cell">
+              {{ order.product.name }}<br />
+              <span class="light">{{ order.product.description }}</span>
+            </td>
+            <td class="product-table__cell product-table__cell--right">
+              {{ order.amount.subtotal|floatformat:2 }}&nbsp;{{ currency }}
+            </td>
+            <td class="product-table__cell product-table__cell--right">
+              {{ order.amount.vat_amount|floatformat:2 }}&nbsp;{{ currency }}
+            </td>
+            <td class="product-table__cell product-table__cell--right">
+              {{ order.amount.total|floatformat:2 }}&nbsp;{{ currency }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="invoice_detail_container">
+        <table class="invoice_detail_table">
+          <tr>
+            <td class="invoice_category_item"><strong>{% trans "Subtotal" %}</strong></td>
+            <td class="invoice_item_value">{{ order.amount.subtotal|floatformat:2 }}&nbsp;{{ currency }}</td>
+          </tr>
+          <tr>
+            <td class="invoice_category_item"><strong>{% trans "Sales Tax VAT" %} {{ order.amount.vat }}%</strong></td>
+            <td class="invoice_item_value">{{ order.amount.vat_amount|floatformat:2 }}&nbsp;{{ currency }}</td>
+          </tr>
+          <tr>
+            <td class="invoice_category_item"><strong>{% trans "Total" %}</strong></td>
+            <td class="invoice_item_value">{{ order.amount.total|floatformat:2 }}&nbsp;{{ currency }}</td>
+          </tr>
+        </table>
+      </div>
+      {% endwith %}
+    </article>
+    <footer class="invoice-footer">
+      <p class="company-info">{{ order.company|linebreaksbr }}</p>
+    </footer>
+  </body>
+</html>

--- a/src/backend/joanie/payment/models.py
+++ b/src/backend/joanie/payment/models.py
@@ -1,6 +1,7 @@
 """
 Declare and configure models for the payment part
 """
+import logging
 from decimal import Decimal as D
 
 from django.conf import settings
@@ -15,7 +16,6 @@ from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 
 from babel.numbers import get_currency_symbol
-from howard.issuers import InvoiceDocument
 from parler.utils import get_language_settings
 from parler.utils.context import switch_language
 
@@ -25,6 +25,7 @@ from joanie.payment import enums as payment_enums
 from joanie.payment import get_payment_backend
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 
 class Invoice(BaseModel):
@@ -110,14 +111,6 @@ class Invoice(BaseModel):
             return payment_enums.INVOICE_STATE_PAID
 
         return payment_enums.INVOICE_STATE_UNPAID
-
-    @property
-    def document(self):
-        """
-        Get the document related to the invoice instance;
-        """
-        document = InvoiceDocument(context_query=self.get_document_context())
-        return document.create(persist=False)
 
     @property
     def type(self):
@@ -213,7 +206,7 @@ class Invoice(BaseModel):
 
         base_context = {
             "metadata": {
-                "issued_on": str(self.updated_on),
+                "issued_on": self.updated_on,
                 "reference": self.reference,
                 "type": self.type,
             },

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -213,8 +213,6 @@ class Base(Configuration):
         "django_filters",
         "rest_framework",
         "parler",
-        "marion",
-        "howard",
         "easy_thumbnails",
         # Joanie
         "joanie.core",
@@ -339,9 +337,6 @@ class Base(Configuration):
     EMAIL_PORT = values.PositiveIntegerValue(None)
     EMAIL_USE_TLS = values.BooleanValue(False)
     EMAIL_FROM = values.Value("from@fun-mooc.fr")
-
-    # Marion
-    MARION_DOCUMENT_ISSUER_CHOICES_CLASS = "howard.defaults.DocumentIssuerChoices"
 
     # Django Money
     DEFAULT_CURRENCY = "EUR"

--- a/src/backend/joanie/tests/core/test_utils_issuers_invoice_generate_document.py
+++ b/src/backend/joanie/tests/core/test_utils_issuers_invoice_generate_document.py
@@ -1,0 +1,151 @@
+"""Test suite for utility method to generate an invoice in PDF bytes format."""
+from io import BytesIO
+
+from django.test import TestCase
+from django.utils.translation import override
+
+from pdfminer.high_level import extract_text as pdf_extract_text
+
+from joanie.core.factories import ProductFactory
+from joanie.core.utils import issuers
+from joanie.payment import enums as payment_enums
+from joanie.payment.factories import InvoiceFactory
+
+
+class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
+    """Test suite for utility method to generate invoice document in PDF bytes format."""
+
+    def test_utils_issuers_generate_document(self):
+        """
+        Using the issuer to generate an invoice document in PDF bytes format.
+        The context should be set in the active language.
+        """
+        product = ProductFactory(title="Product 1", description="Product 1 description")
+        product.translations.create(
+            language_code="fr-fr",
+            title="Produit 1",
+            description="Description du produit 1",
+        )
+        invoice = InvoiceFactory(order__product=product, total=product.price)
+
+        context = invoice.get_document_context()
+        file_bytes = issuers.generate_document(
+            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+        )
+
+        # - The default language is used first
+        document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+        self.assertRegex(document_text, r"Product 1.*Product 1 description")
+
+        # - Then if we switch to an existing language, it should generate
+        #   a document with the context in the active language
+        with override("fr-fr", deactivate=True):
+            context = invoice.get_document_context()
+            file_bytes = issuers.generate_document(
+                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            )
+            document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+            self.assertRegex(document_text, r"Produit 1.*Description du produit 1")
+
+        # # - Finally, unknown language should use the default language as fallback
+        with override("de-de", deactivate=True):
+            context = invoice.get_document_context()
+            file_bytes = issuers.generate_document(
+                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            )
+            document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+            self.assertRegex(document_text, r"Product 1.*Product 1 description")
+
+    def test_utils_issuers_generate_document_type_invoice(self):
+        """
+        If invoice type is "invoice", a document of type invoice should be generated.
+        """
+        invoice = InvoiceFactory()
+
+        context = invoice.get_document_context()
+        file_bytes = issuers.generate_document(
+            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+        )
+
+        # - The default language is used first
+        document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+        self.assertRegex(document_text, r"INVOICE")
+
+        # - Then if we switch to an existing language, it should generate
+        #   a document with the context in the active language
+        with override("fr-fr", deactivate=True):
+            context = invoice.get_document_context()
+            file_bytes = issuers.generate_document(
+                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            )
+            document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+            self.assertRegex(document_text, r"FACTURE")
+
+    def test_utils_issuers_generate_document_type_credit_note(self):
+        """
+        If invoice type is "credit_note", a document of type credit_note should be generated.
+        """
+        invoice = InvoiceFactory()
+        credit_note = InvoiceFactory(
+            order=invoice.order,
+            parent=invoice,
+            total=-invoice.total,
+        )
+
+        # - The default language is used first
+        context = credit_note.get_document_context()
+        file_bytes = issuers.generate_document(
+            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+        )
+
+        document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+        self.assertRegex(document_text, r"CREDIT NOTE")
+
+        # - Then if we switch to an existing language, it should generate
+        #   a document with the context in the active language
+        with override("fr-fr", deactivate=True):
+            context = credit_note.get_document_context()
+            file_bytes = issuers.generate_document(
+                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            )
+            document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+            self.assertRegex(document_text, r"AVOIR")
+
+    def test_utils_issuers_generate_document_into_active_language(self):
+        """
+        Invoice generate document method should generate a document into the active language.
+        """
+        product = ProductFactory(title="Product 1", description="Product 1 description")
+        product.translations.create(
+            language_code="fr-fr",
+            title="Produit 1",
+            description="Description du produit 1",
+        )
+        invoice = InvoiceFactory(order__product=product, total=product.price)
+
+        # - The default language is used first
+        context = invoice.get_document_context()
+        file_bytes = issuers.generate_document(
+            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+        )
+
+        document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+        self.assertRegex(document_text, r"Product 1.*Product 1 description")
+        # - Then if we switch to an existing language, it should generate
+        #   a document with the context in the active language
+        with override("fr-fr", deactivate=True):
+            context = invoice.get_document_context()
+            file_bytes = issuers.generate_document(
+                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            )
+            document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+            self.assertRegex(document_text, r"Produit 1.*Description du produit 1")
+
+        # - Finally, unknown language should use the default language as fallback
+        with override("de-de", deactivate=True):
+            context = invoice.get_document_context()
+            file_bytes = issuers.generate_document(
+                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            )
+            document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+            self.assertRegex(document_text, r"Product 1.*Product 1 description")

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -18,7 +18,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.urls import include, path, re_path
+from django.urls import path, re_path
 
 from drf_spectacular.views import (
     SpectacularJSONAPIView,
@@ -55,7 +55,6 @@ if settings.DEBUG:
     urlpatterns = (
         urlpatterns
         + [
-            path("__debug__/", include("marion.urls.debug")),
             path(
                 "__debug__/mail/order_validated_html",
                 DebugMailSuccessPaymentViewHtml.as_view(),

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -36,8 +36,6 @@ dependencies = [
     "django-countries==7.5.1",
     "django-filter==23.5",
     "django-fsm==2.8.1",
-    "django-marion-howard==0.6.0",
-    "django-marion==0.6.0",
     "django-money==3.4.1",
     "django-object-actions==4.2.0",
     "django-parler==2.3",


### PR DESCRIPTION
## Purpose

Since we added contract models, we have all the stuff to generate PDF document without Marion and Howard. So in order to ease maintainability and remove dependencies, we internalize **invoice template**. 
This is the last migration step, once this will be done we will be able to remove marion/howard dependencies.

## Proposal

- [x] Prepare `def generate_document` for the `Invoice` Model.
- [x] Add .HTLM and .CSS files for Invoice template.
- [x] Adjust endpoint `def invoice()` into `jenny/core/api`.
- [x] Update test suite with new method instead of `document` property of the Invoice Model.
- [x] Remove dependencies : Howard and Marion from `settings.py`, and `pyproject.toml`
