### PR TITLE
🎨(backend) use HTTPStatus instead of raw HTTP code value 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to
 
 ### Changed
 
+- Use HTTPStatus instead of raw HTTP code value
 - If a product has a contract, delay auto enroll logic on leaner signature
 - Prevent to enroll to not listed course runs related to an order awaiting
   signature of a contract by the learner

--- a/src/backend/joanie/core/api/__init__.py
+++ b/src/backend/joanie/core/api/__init__.py
@@ -1,4 +1,6 @@
 """API for the joanie project."""
+from http import HTTPStatus
+
 from django.core.exceptions import ValidationError as DjangoValidationError
 
 from django_fsm import TransitionNotAllowed
@@ -25,6 +27,6 @@ def exception_handler(exc, context):
         exc = DRFValidationError(detail=detail)
     elif isinstance(exc, TransitionNotAllowed):
         detail = str(exc)
-        exc = DRFValidationError(detail=detail, code=422)
+        exc = DRFValidationError(detail=detail, code=HTTPStatus.UNPROCESSABLE_ENTITY)
 
     return drf_exception_handler(exc, context)

--- a/src/backend/joanie/core/api/remote_endpoints.py
+++ b/src/backend/joanie/core/api/remote_endpoints.py
@@ -1,6 +1,8 @@
 """
 Remote endpoints API for other servers.
 """
+from http import HTTPStatus
+
 from django.http import JsonResponse
 
 from rest_framework.decorators import (
@@ -30,9 +32,9 @@ def enrollments_and_orders_on_course_run(request: Request):
     if resource_link is None:
         return Response(
             {"detail": "Query parameter `resource_link` is required."},
-            status=400,
+            status=HTTPStatus.BAD_REQUEST,
         )
 
     response = get_course_run_metrics(resource_link=resource_link)
 
-    return JsonResponse(response, status=200)
+    return JsonResponse(response, status=HTTPStatus.OK)

--- a/src/backend/joanie/core/fields/multiselect.py
+++ b/src/backend/joanie/core/fields/multiselect.py
@@ -22,7 +22,7 @@ def to_sentence(elements):
         ["French", "English", "german"] > "French, english and german"
 
     """
-    if len(elements) > 2:
+    if len(elements) > 2:  # noqa: PLR2004
         return (
             _("{:s} and {:s}").format(
                 ", ".join(map(str, elements[:-1])), str(elements[-1])

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -480,7 +480,7 @@ class Order(BaseModel):
         An order can be validated if the product is free or if it
         has invoices.
         """
-        return self.total == 0.0 or self.invoices.count() > 0
+        return self.total == 0.0 or self.invoices.count() > 0  # noqa: PLR2004
 
     def can_be_state_submitted(self):
         """
@@ -529,7 +529,7 @@ class Order(BaseModel):
         """
         Transition order to submitted state and to validate if order is free
         """
-        if self.total != 0.0 and billing_address is None:
+        if self.total != 0.0 and billing_address is None:  # noqa: PLR2004
             raise ValidationError({"billing_address": ["This field is required."]})
 
         if self.state == enums.ORDER_STATE_DRAFT:
@@ -544,7 +544,7 @@ class Order(BaseModel):
                 )
                 order_relation.course_runs.set(relation.course_runs.all())
 
-        if self.total == 0.0:
+        if self.total == 0.0:  # noqa: PLR2004
             self.validate()
             return None
 

--- a/src/backend/joanie/payment/api.py
+++ b/src/backend/joanie/payment/api.py
@@ -2,6 +2,7 @@
 API endpoints
 """
 import logging
+from http import HTTPStatus
 
 from django.db import transaction
 
@@ -28,7 +29,7 @@ def webhook(request):
     except exceptions.ParseNotificationFailed as error:
         return Response(str(error), status=error.status_code)
 
-    return Response(status=200)
+    return Response(status=HTTPStatus.OK)
 
 
 # pylint: disable=too-many-ancestors

--- a/src/backend/joanie/payment/exceptions.py
+++ b/src/backend/joanie/payment/exceptions.py
@@ -1,4 +1,6 @@
 """Payment exceptions"""
+from http import HTTPStatus
+
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import APIException
@@ -7,7 +9,7 @@ from rest_framework.exceptions import APIException
 class AbortPaymentFailed(APIException):
     """Exception triggered when aborting a payment failed."""
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Cannot abort this payment.")
     default_code = "abort_payment_failed"
 
@@ -15,7 +17,7 @@ class AbortPaymentFailed(APIException):
 class CreatePaymentFailed(APIException):
     """Exception triggered when creating payment failed."""
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Cannot create a payment.")
     default_code = "create_payment_failed"
 
@@ -23,7 +25,7 @@ class CreatePaymentFailed(APIException):
 class RegisterPaymentFailed(APIException):
     """Exception triggered when registering payment failed."""
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Cannot register this payment.")
     default_code = "register_payment_failed"
 
@@ -31,7 +33,7 @@ class RegisterPaymentFailed(APIException):
 class RefundPaymentFailed(APIException):
     """Exception triggered when refunding payment failed."""
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Cannot refund this payment.")
     default_code = "refund_payment_failed"
 
@@ -39,6 +41,6 @@ class RefundPaymentFailed(APIException):
 class ParseNotificationFailed(APIException):
     """Exception triggered when parsing notification failed."""
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Cannot parse notification.")
     default_code = "parse_notification_failed"

--- a/src/backend/joanie/signature/api.py
+++ b/src/backend/joanie/signature/api.py
@@ -2,6 +2,7 @@
 API endpoint for Signature
 """
 import logging
+from http import HTTPStatus
 
 from django.db import transaction
 
@@ -23,4 +24,4 @@ def webhook_signature(request: Request):
     signature_backend = get_signature_backend()
     signature_backend.handle_notification(request)
 
-    return Response(status=200)
+    return Response(status=HTTPStatus.OK)

--- a/src/backend/joanie/signature/exceptions.py
+++ b/src/backend/joanie/signature/exceptions.py
@@ -1,4 +1,6 @@
 """Signature exceptions"""
+from http import HTTPStatus
+
 from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import APIException
@@ -11,7 +13,7 @@ class CreateSignatureProcedureFailed(APIException):
     required data in the payload's creation
     """
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Cannot create a signature procedure.")
     default_code = "create_signature_procedure_failed"
 
@@ -19,7 +21,7 @@ class CreateSignatureProcedureFailed(APIException):
 class UploadFileFailed(APIException):
     """Exception triggered when uploading a file at the signature provider failed."""
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _(
         "Cannot upload the file to the signature provider with the signature reference."
     )
@@ -33,7 +35,7 @@ class StartSignatureProcedureFailed(APIException):
     that is already finished.
     """
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _(
         "Cannot start the signature procedure with the signature reference."
     )
@@ -47,7 +49,7 @@ class InvitationSignatureFailed(APIException):
     the signature backend reference does not exist.
     """
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _(
         "Cannot get invitation link to sign the file from the signature provider."
     )
@@ -61,6 +63,6 @@ class DeleteSignatureProcedureFailed(APIException):
     does not exists at the signature provider.
     """
 
-    status_code = 400
+    status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Cannot delete the signature procedure.")
     default_code = "delete_signature_procedure_failed"

--- a/src/backend/joanie/tests/badges/test_models.py
+++ b/src/backend/joanie/tests/badges/test_models.py
@@ -14,7 +14,7 @@ class BadgeModelTestCase(TestCase):
         factories.BadgeFactory(name="foo")
         factories.BadgeFactory(name="bar")
 
-        assert models.Badge.objects.count() == 2
+        assert models.Badge.objects.count() == 2  # noqa: PLR2004
         assert models.Badge.objects.first().name == "foo"
 
         badge = factories.BadgeFactory(provider="OBF", name="lol")
@@ -32,8 +32,8 @@ class IssuedBadgeModelTestCase(TestCase):
         factories.IssuedBadgeFactory(user=user)
         factories.IssuedBadgeFactory(user=user)
 
-        assert models.IssuedBadge.objects.count() == 2
-        assert user.issued_badges.count() == 2
+        assert models.IssuedBadge.objects.count() == 2  # noqa: PLR2004
+        assert user.issued_badges.count() == 2  # noqa: PLR2004
         assert models.Badge.objects.first().issued.count() == 1
 
         user = UserFactory(first_name="John", last_name="Doe")

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
@@ -2,6 +2,7 @@
 Test suite for CourseProductRelation create Admin API.
 """
 import uuid
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -35,7 +36,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -59,7 +60,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertDictEqual(
             response.json(),
             {"detail": "You do not have permission to perform this action."},
@@ -90,7 +91,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             },
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         relation = models.CourseProductRelation.objects.get(id=response.json()["id"])
 
@@ -248,7 +249,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {"course_id": "This field is required."},
@@ -272,7 +273,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {"product_id": "This field is required."},
@@ -302,7 +303,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             },
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         relation = models.CourseProductRelation.objects.get(id=response.json()["id"])
 
@@ -439,7 +440,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             "/api/v1.0/admin/course-product-relations/",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {
@@ -470,7 +471,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             },
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         assert response.json() == {
             "organization_ids": [

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_delete.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_delete.py
@@ -1,6 +1,7 @@
 """
 Test suite for CourseProductRelation delete Admin API.
 """
+from http import HTTPStatus
 from unittest import mock
 
 from django.test import TestCase
@@ -25,7 +26,7 @@ class CourseProductRelationDeleteAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -43,7 +44,7 @@ class CourseProductRelationDeleteAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertDictEqual(
             response.json(),
             {"detail": "You do not have permission to perform this action."},
@@ -67,7 +68,7 @@ class CourseProductRelationDeleteAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         with self.assertRaises(models.CourseProductRelation.DoesNotExist):
             relation.refresh_from_db()
 
@@ -95,7 +96,7 @@ class CourseProductRelationDeleteAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertDictEqual(
             response.json(),
             {"detail": "['You cannot delete this course product relation.']"},
@@ -123,7 +124,7 @@ class CourseProductRelationDeleteAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         with self.assertRaises(models.CourseProductRelation.DoesNotExist):
             relation.refresh_from_db()
         with self.assertRaises(models.OrderGroup.DoesNotExist):

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
@@ -1,6 +1,7 @@
 """
 Test suite for CourseProductRelation list Admin API.
 """
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -26,7 +27,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
             "/api/v1.0/admin/course-product-relations/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -42,7 +43,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
             "/api/v1.0/admin/course-product-relations/",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertDictEqual(
             response.json(),
             {"detail": "You do not have permission to perform this action."},
@@ -68,7 +69,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
             "/api/v1.0/admin/course-product-relations/",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertEqual(
             response.json(),

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
@@ -1,6 +1,7 @@
 """
 Test suite for CourseProductRelation retrieve Admin API.
 """
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -26,7 +27,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -42,7 +43,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertDictEqual(
             response.json(),
             {"detail": "You do not have permission to perform this action."},
@@ -67,7 +68,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
             f"/api/v1.0/admin/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertEqual(
             response.json(),

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
@@ -2,6 +2,7 @@
 Test suite for CourseProductRelation update Admin API.
 """
 import uuid
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -36,7 +37,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -61,7 +62,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertDictEqual(
             response.json(),
             {"detail": "You do not have permission to perform this action."},
@@ -95,7 +96,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         relation.refresh_from_db()
 
         self.assertEqual(
@@ -252,7 +253,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -273,7 +274,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertDictEqual(
             response.json(),
             {"detail": "You do not have permission to perform this action."},
@@ -303,7 +304,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         relation.refresh_from_db()
         self.assertEqual(
             response.json(),
@@ -473,7 +474,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         assert response.json() == {
             "id": str(relation.id),
@@ -635,7 +636,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         assert response.json() == {
             "organization_ids": [

--- a/src/backend/joanie/tests/core/api/order/test_cancel.py
+++ b/src/backend/joanie/tests/core/api/order/test_cancel.py
@@ -1,4 +1,6 @@
 """Tests for the Order cancel API."""
+from http import HTTPStatus
+
 from django.core.cache import cache
 from django.test.client import RequestFactory
 
@@ -26,7 +28,7 @@ class OrderCancelApiTest(BaseAPITestCase):
             f"/api/v1.0/orders/{order.id}/cancel/",
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         order.refresh_from_db()
         self.assertNotEqual(order.state, enums.ORDER_STATE_CANCELED)
 
@@ -42,7 +44,7 @@ class OrderCancelApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_order_cancel_authenticated_not_owned(self):
         """
@@ -60,7 +62,7 @@ class OrderCancelApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         order.refresh_from_db()
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(order.state, enums.ORDER_STATE_SUBMITTED)
 
     def test_api_order_cancel_authenticated_owned(self):
@@ -84,7 +86,7 @@ class OrderCancelApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         order_draft.refresh_from_db()
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(order_draft.state, enums.ORDER_STATE_CANCELED)
 
         # Canceling pending order
@@ -93,7 +95,7 @@ class OrderCancelApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         order_pending.refresh_from_db()
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(order_pending.state, enums.ORDER_STATE_CANCELED)
 
         # Canceling submitted order
@@ -102,7 +104,7 @@ class OrderCancelApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         order_submitted.refresh_from_db()
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(order_submitted.state, enums.ORDER_STATE_CANCELED)
 
     def test_api_order_cancel_authenticated_validated(self):
@@ -119,5 +121,5 @@ class OrderCancelApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         order_validated.refresh_from_db()
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
         self.assertEqual(order_validated.state, enums.ORDER_STATE_VALIDATED)

--- a/src/backend/joanie/tests/core/api/order/test_create.py
+++ b/src/backend/joanie/tests/core/api/order/test_create.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-lines
 import random
 import uuid
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -34,7 +35,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         response = self.client.post(
             "/api/v1.0/orders/", data=data, content_type="application/json"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
@@ -68,7 +69,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         # order has been created
         self.assertEqual(models.Order.objects.count(), 1)
         order = models.Order.objects.get()
@@ -151,7 +152,7 @@ class OrderCreateApiTest(BaseAPITestCase):
                 f"/api/v1.0/orders/{order.id}/submit/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         # user has been created
         self.assertEqual(models.User.objects.count(), 1)
@@ -194,7 +195,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         # order has been created
         self.assertEqual(models.Order.objects.count(), 1)
         order = models.Order.objects.get(
@@ -295,7 +296,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {"enrollment_id": f"Enrollment with id {data['enrollment_id']} not found."},
@@ -337,7 +338,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertFalse(models.Order.objects.exists())
         self.assertDictEqual(
             response.json(),
@@ -375,14 +376,14 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         order_id = response.json()["id"]
         self.assertTrue(models.Order.objects.filter(id=order_id).exists())
         response = self.client.patch(
             f"/api/v1.0/orders/{order_id}/submit/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             models.Order.objects.get(id=order_id).state, enums.ORDER_STATE_DRAFT
         )
@@ -416,7 +417,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         # order has been created
 
         self.assertEqual(
@@ -491,7 +492,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(models.Order.objects.count(), 10)  # 9 + 1
         # The chosen organization should be one of the organizations with the lowest order count
         organization_id = models.Order.objects.get(id=order_id).organization.id
@@ -535,7 +536,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         order.submit(request=RequestFactory().request())
         # - Order has been successfully created and read_only_fields
         #   has been ignored.
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(models.Order.objects.count(), 1)
 
         self.assertCountEqual(
@@ -645,7 +646,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertFalse(models.Order.objects.exists())
         self.assertDictEqual(
             response.json(),
@@ -667,7 +668,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertTrue(models.Order.objects.filter(course=course).exists())
 
     def test_api_order_create_authenticated_invalid_organization(self):
@@ -693,7 +694,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertFalse(models.Order.objects.exists())
         self.assertDictEqual(
             response.json(),
@@ -713,7 +714,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertTrue(models.Order.objects.filter(organization=organization).exists())
 
     def test_api_order_create_authenticated_missing_product_then_course(self):
@@ -727,7 +728,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertFalse(models.Order.objects.exists())
         self.assertDictEqual(
@@ -745,7 +746,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             data={"product_id": str(product.id)},
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertFalse(models.Order.objects.exists())
         self.assertDictEqual(
@@ -780,7 +781,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {"__all__": ["An order for this product and course already exists."]},
@@ -796,7 +797,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
     def test_api_order_create_authenticated_billing_address_not_required(self):
         """
@@ -823,7 +824,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(models.Order.objects.count(), 1)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(response.json()["state"], enums.ORDER_STATE_DRAFT)
         order = models.Order.objects.get()
         self.assertEqual(order.state, enums.ORDER_STATE_DRAFT)
@@ -870,7 +871,7 @@ class OrderCreateApiTest(BaseAPITestCase):
 
         self.assertEqual(models.Order.objects.count(), 1)
         order = models.Order.objects.get(product=product, course=course, owner=user)
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         self.assertDictEqual(
             response.json(),
@@ -1009,7 +1010,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(models.Order.objects.count(), 1)
         order = models.Order.objects.get(product=product, course=course, owner=user)
         expected_json = {
@@ -1092,7 +1093,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         )
 
         self.assertEqual(models.Order.objects.exclude(state="draft").count(), 0)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(response.json(), {"detail": "Unreachable endpoint"})
 
@@ -1135,7 +1136,7 @@ class OrderCreateApiTest(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {
@@ -1187,7 +1188,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         self.assertEqual(
             models.Order.objects.filter(product=product, course=course).count(), 101
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
     def test_api_order_create_authenticated_free_product_no_billing_address(self):
         """
@@ -1211,14 +1212,14 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(response.json()["state"], enums.ORDER_STATE_DRAFT)
         order = models.Order.objects.get(id=response.json()["id"])
         response = self.client.patch(
             f"/api/v1.0/orders/{order.id}/submit/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         order.refresh_from_db()
         self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
 
@@ -1248,7 +1249,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(response.json()["state"], enums.ORDER_STATE_DRAFT)
         order_id = response.json()["id"]
         billing_address = BillingAddressDictFactory()
@@ -1259,7 +1260,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         order = models.Order.objects.get(id=order_id)
         self.assertEqual(order.state, enums.ORDER_STATE_SUBMITTED)
 
@@ -1298,7 +1299,7 @@ class OrderCreateApiTest(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {
@@ -1339,7 +1340,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {
@@ -1389,7 +1390,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {
@@ -1409,7 +1410,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(
             models.Order.objects.filter(course=course, product=product).count(), 2
         )
@@ -1442,7 +1443,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(
             models.Order.objects.filter(course=course, product=product).count(), 1
         )

--- a/src/backend/joanie/tests/core/api/order/test_delete.py
+++ b/src/backend/joanie/tests/core/api/order/test_delete.py
@@ -1,5 +1,6 @@
 """Tests for the Order delete API."""
 import random
+from http import HTTPStatus
 
 from django.core.cache import cache
 
@@ -23,7 +24,7 @@ class OrderDeleteApiTest(BaseAPITestCase):
 
         response = self.client.delete(f"/api/v1.0/orders/{order.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(),
@@ -49,7 +50,7 @@ class OrderDeleteApiTest(BaseAPITestCase):
             f"/api/v1.0/orders/{order.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Order.objects.count(), 1)
 
     def test_api_order_delete_owner(self):
@@ -62,5 +63,5 @@ class OrderDeleteApiTest(BaseAPITestCase):
             f"/api/v1.0/orders/{order.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Order.objects.count(), 1)

--- a/src/backend/joanie/tests/core/api/order/test_invoice.py
+++ b/src/backend/joanie/tests/core/api/order/test_invoice.py
@@ -1,4 +1,5 @@
 """Tests for the Order invoice API."""
+from http import HTTPStatus
 from io import BytesIO
 
 from django.core.cache import cache
@@ -30,7 +31,7 @@ class OrderInvoiceApiTest(BaseAPITestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
@@ -49,7 +50,7 @@ class OrderInvoiceApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(), {"reference": "This parameter is required."}
@@ -70,7 +71,7 @@ class OrderInvoiceApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         self.assertEqual(
             response.json(),
@@ -97,7 +98,7 @@ class OrderInvoiceApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         self.assertEqual(
             response.json(),
@@ -123,7 +124,7 @@ class OrderInvoiceApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.headers["Content-Type"], "application/pdf")
         self.assertEqual(
             response.headers["Content-Disposition"],

--- a/src/backend/joanie/tests/core/api/order/test_read_detail.py
+++ b/src/backend/joanie/tests/core/api/order/test_read_detail.py
@@ -1,4 +1,5 @@
 """Tests for the Order read detail API."""
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -24,7 +25,7 @@ class OrderReadApiTest(BaseAPITestCase):
         order = factories.OrderFactory(product=product)
 
         response = self.client.get(f"/api/v1.0/orders/{order.id}/")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(),
@@ -52,7 +53,7 @@ class OrderReadApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -136,6 +137,6 @@ class OrderReadApiTest(BaseAPITestCase):
             f"/api/v1.0/orders/{order.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         self.assertDictEqual(response.json(), {"detail": "Not found."})

--- a/src/backend/joanie/tests/core/api/order/test_read_list.py
+++ b/src/backend/joanie/tests/core/api/order/test_read_list.py
@@ -1,5 +1,6 @@
 """Tests for the Order read list API."""
 # pylint: disable=too-many-lines
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -29,7 +30,7 @@ class OrderListApiTest(BaseAPITestCase):
         response = self.client.get(
             "/api/v1.0/orders/",
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
@@ -55,7 +56,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -100,7 +101,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -151,7 +152,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
         self.assertEqual(
@@ -168,7 +169,7 @@ class OrderListApiTest(BaseAPITestCase):
             "/api/v1.0/orders/?page_size=2&page=2", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -205,7 +206,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -258,7 +259,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(response.json(), {"product_id": ["Enter a valid UUID."]})
 
     @mock.patch.object(
@@ -299,7 +300,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -407,7 +408,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(), {"enrollment_id": ["Enter a valid UUID."]}
         )
@@ -437,7 +438,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -510,7 +511,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -638,7 +639,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
 
@@ -652,7 +653,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
         self.assertCountEqual(
@@ -666,7 +667,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
         self.assertCountEqual(
@@ -705,7 +706,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {
@@ -743,7 +744,7 @@ class OrderListApiTest(BaseAPITestCase):
             "/api/v1.0/orders/?state=draft", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -805,7 +806,7 @@ class OrderListApiTest(BaseAPITestCase):
             "/api/v1.0/orders/?state=canceled", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -871,7 +872,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -933,7 +934,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         response = response.json()
 
         self.assertEqual(len(response["results"]), 4)
@@ -944,7 +945,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         response = response.json()
 
         self.assertEqual(len(response["results"]), 3)
@@ -965,7 +966,7 @@ class OrderListApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         response = response.json()
 
         self.assertEqual(len(response["results"]), 2)
@@ -995,7 +996,7 @@ class OrderListApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(),
             {

--- a/src/backend/joanie/tests/core/api/order/test_submit.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit.py
@@ -56,7 +56,7 @@ class OrderSubmitApiTest(BaseAPITestCase):
             f"/api/v1.0/orders/{order.id}/submit/",
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         order.refresh_from_db()
         self.assertEqual(order.state, enums.ORDER_STATE_DRAFT)
 
@@ -72,7 +72,7 @@ class OrderSubmitApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_order_submit_authenticated_not_owned(self):
         """
@@ -90,7 +90,7 @@ class OrderSubmitApiTest(BaseAPITestCase):
         )
 
         order.refresh_from_db()
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(order.state, enums.ORDER_STATE_DRAFT)
 
     def test_api_order_submit_authenticated_no_billing_address(self):
@@ -108,7 +108,7 @@ class OrderSubmitApiTest(BaseAPITestCase):
         )
 
         order.refresh_from_db()
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(), {"billing_address": ["This field is required."]}
         )

--- a/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
@@ -2,6 +2,7 @@
 import json
 import random
 from datetime import timedelta
+from http import HTTPStatus
 
 from django.core.cache import cache
 from django.test.utils import override_settings
@@ -35,7 +36,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION="Bearer fake",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         content = response.json()
         self.assertEqual(content["detail"], "Given token not valid for any token type")
@@ -65,7 +66,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         content = response.json()
         self.assertEqual(content["detail"], "Not found.")
@@ -100,7 +101,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         content = response.json()
         self.assertEqual(
@@ -130,7 +131,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         content = response.json()
         self.assertEqual(content[0], "No contract definition attached to the product.")
@@ -157,7 +158,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsNotNone(order.contract)
         self.assertIsNotNone(order.contract.context)
         self.assertIsNotNone(order.contract.definition_checksum)
@@ -211,7 +212,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         )
 
         contract.refresh_from_db()
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertNotEqual(contract.context, "content")
         self.assertIn("fake_dummy_file_hash", contract.definition_checksum)
         self.assertNotEqual(contract.signature_backend_reference, "wfl_fake_dummy_id")
@@ -262,7 +263,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         )
 
         contract.refresh_from_db()
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertNotEqual(contract.signature_backend_reference, "wfl_dummy_test_id_1")
         self.assertNotEqual(contract.definition_checksum, "fake_test_file_hash")
         self.assertNotEqual(contract.context, "a new content")

--- a/src/backend/joanie/tests/core/api/order/test_update.py
+++ b/src/backend/joanie/tests/core/api/order/test_update.py
@@ -2,6 +2,7 @@
 import json
 import random
 import uuid
+from http import HTTPStatus
 
 from django.core.cache import cache
 
@@ -111,7 +112,7 @@ class OrderUpdateApiTest(BaseAPITestCase):
         *target_courses, _other_course = factories.CourseFactory.create_batch(3)
         product = factories.ProductFactory(target_courses=target_courses)
         order = factories.OrderFactory(product=product)
-        self._check_api_order_update_detail(order, None, 401)
+        self._check_api_order_update_detail(order, None, HTTPStatus.UNAUTHORIZED)
 
     def test_api_order_update_detail_authenticated_superuser(self):
         """An authenticated superuser should not be allowed to update any order."""
@@ -119,7 +120,7 @@ class OrderUpdateApiTest(BaseAPITestCase):
         *target_courses, _other_course = factories.CourseFactory.create_batch(3)
         product = factories.ProductFactory(target_courses=target_courses)
         order = factories.OrderFactory(product=product)
-        self._check_api_order_update_detail(order, user, 405)
+        self._check_api_order_update_detail(order, user, HTTPStatus.METHOD_NOT_ALLOWED)
 
     def test_api_order_update_detail_authenticated_unowned(self):
         """
@@ -130,7 +131,7 @@ class OrderUpdateApiTest(BaseAPITestCase):
         *target_courses, _other_course = factories.CourseFactory.create_batch(3)
         product = factories.ProductFactory(target_courses=target_courses)
         order = factories.OrderFactory(product=product)
-        self._check_api_order_update_detail(order, user, 405)
+        self._check_api_order_update_detail(order, user, HTTPStatus.METHOD_NOT_ALLOWED)
 
     def test_api_order_update_detail_authenticated_owned(self):
         """
@@ -143,26 +144,26 @@ class OrderUpdateApiTest(BaseAPITestCase):
         order = factories.OrderFactory(
             owner=owner, product=product, state=enums.ORDER_STATE_SUBMITTED
         )
-        self._check_api_order_update_detail(order, owner, 405)
+        self._check_api_order_update_detail(order, owner, HTTPStatus.METHOD_NOT_ALLOWED)
         models.Order.objects.all().delete()
         order = factories.OrderFactory(
             owner=owner, product=product, state=enums.ORDER_STATE_VALIDATED
         )
-        self._check_api_order_update_detail(order, owner, 405)
+        self._check_api_order_update_detail(order, owner, HTTPStatus.METHOD_NOT_ALLOWED)
         Transaction.objects.all().delete()
         Invoice.objects.all().delete()
         models.Order.objects.all().delete()
         order = factories.OrderFactory(
             owner=owner, product=product, state=enums.ORDER_STATE_PENDING
         )
-        self._check_api_order_update_detail(order, owner, 405)
+        self._check_api_order_update_detail(order, owner, HTTPStatus.METHOD_NOT_ALLOWED)
         models.Order.objects.all().delete()
         order = factories.OrderFactory(
             owner=owner, product=product, state=enums.ORDER_STATE_CANCELED
         )
-        self._check_api_order_update_detail(order, owner, 405)
+        self._check_api_order_update_detail(order, owner, HTTPStatus.METHOD_NOT_ALLOWED)
         models.Order.objects.all().delete()
         order = factories.OrderFactory(
             owner=owner, product=product, state=enums.ORDER_STATE_DRAFT
         )
-        self._check_api_order_update_detail(order, owner, 405)
+        self._check_api_order_update_detail(order, owner, HTTPStatus.METHOD_NOT_ALLOWED)

--- a/src/backend/joanie/tests/core/api/order/test_validate.py
+++ b/src/backend/joanie/tests/core/api/order/test_validate.py
@@ -1,4 +1,6 @@
 """Tests for the Order validate API."""
+from http import HTTPStatus
+
 from django.core.cache import cache
 from django.test.client import RequestFactory
 
@@ -28,7 +30,7 @@ class OrderValidateApiTest(BaseAPITestCase):
         response = self.client.put(
             f"/api/v1.0/orders/{order.id}/validate/",
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         order.refresh_from_db()
         self.assertEqual(order.state, enums.ORDER_STATE_SUBMITTED)
 
@@ -44,7 +46,7 @@ class OrderValidateApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_order_validate_authenticated_not_owned(self):
         """
@@ -62,7 +64,7 @@ class OrderValidateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         order.refresh_from_db()
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(order.state, enums.ORDER_STATE_SUBMITTED)
 
     def test_api_order_validate_owned(self):
@@ -79,5 +81,5 @@ class OrderValidateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         order.refresh_from_db()
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)

--- a/src/backend/joanie/tests/core/api/remote_endpoints/course_run/test_course_run.py
+++ b/src/backend/joanie/tests/core/api/remote_endpoints/course_run/test_course_run.py
@@ -1,5 +1,6 @@
 """Test suite for remote API endpoints on course run."""
 from datetime import timedelta
+from http import HTTPStatus
 
 from django.test.utils import override_settings
 from django.utils import timezone as django_timezone
@@ -21,7 +22,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -37,7 +38,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -65,7 +66,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -93,7 +94,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -109,7 +110,11 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
         )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
     def test_remote_endpoints_course_run_anonymous_valid_token_but_with_patch_method_should_fail(
@@ -125,7 +130,9 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -141,7 +148,11 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
         )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
     def test_remote_endpoints_course_run_anonymous_valid_token_but_with_delete_method_should_fail(
@@ -157,7 +168,9 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -174,7 +187,9 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, "Query parameter `resource_link` is required.", status_code=400
+            response,
+            "Query parameter `resource_link` is required.",
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -196,7 +211,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -218,7 +233,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -240,7 +255,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -262,7 +277,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -290,7 +305,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Make sure to give an existing resource link from an ended course run.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -319,7 +334,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Make sure to give an existing resource link from an ended course run.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -348,7 +363,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Make sure to give an existing resource link from an ended course run.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -377,7 +392,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Make sure to give an existing resource link from an ended course run.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -406,7 +421,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Make sure to give an existing resource link from an ended course run.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -435,7 +450,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Make sure to give an existing resource link from an ended course run.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -464,7 +479,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Make sure to give an existing resource link from an ended course run.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
@@ -494,7 +509,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -531,7 +546,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
             url, HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -583,7 +598,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
             url, HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -636,7 +651,7 @@ class RemoteEndpointsCourseRunApiTest(BaseAPITestCase):
             url, HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {

--- a/src/backend/joanie/tests/core/test_admin_course.py
+++ b/src/backend/joanie/tests/core/test_admin_course.py
@@ -1,6 +1,7 @@
 """
 Test suite for courses admin pages
 """
+from http import HTTPStatus
 
 from django.conf import settings
 from django.urls import reverse
@@ -35,7 +36,7 @@ class CourseAdminTestCase(BaseAPITestCase):
                 reverse("admin:core_course_change", args=(course.pk,)),
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, course.title)
 
         html = lxml.html.fromstring(response.content)

--- a/src/backend/joanie/tests/core/test_admin_order.py
+++ b/src/backend/joanie/tests/core/test_admin_order.py
@@ -1,7 +1,7 @@
 """
 Test suite for orders admin pages
 """
-
+from http import HTTPStatus
 from unittest import mock
 
 from django.urls import reverse
@@ -24,12 +24,12 @@ class OrderAdminTestCase(BaseAPITestCase):
         self.client.login(username=user.username, password="password")
         order_changelist_page = reverse("admin:core_order_changelist")
         response = self.client.get(order_changelist_page)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, "Cancel selected orders")
 
         # - Trigger "cancel" action
         self.client.post(
             order_changelist_page, {"action": "cancel", "_selected_action": order.pk}
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         mock_cancel.assert_called_once_with()

--- a/src/backend/joanie/tests/core/test_admin_product.py
+++ b/src/backend/joanie/tests/core/test_admin_product.py
@@ -3,6 +3,7 @@ Test suite for products admin pages
 """
 import random
 import uuid
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -35,7 +36,7 @@ class ProductAdminTestCase(BaseAPITestCase):
             },
         )
         self.assertEqual(models.Product.objects.count(), 0)
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
     def test_admin_product_create_success_enrollment(self):
         """A user with permissions should be able to create a product of type enrollment."""
@@ -88,7 +89,7 @@ class ProductAdminTestCase(BaseAPITestCase):
             },
         )
         self.assertEqual(models.Product.objects.count(), 0)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, "errorlist")
         self.assertContains(
             response,
@@ -191,7 +192,7 @@ class ProductAdminTestCase(BaseAPITestCase):
             reverse("admin:core_product_change", args=(product.pk,)),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, product.title)
 
         # - Check that there is a sortable product target course relation section
@@ -288,7 +289,7 @@ class ProductAdminTestCase(BaseAPITestCase):
             reverse("admin:core_product_change", args=(product.pk,)),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, product.title)
 
         # - Check there are links to go to related courses admin change view
@@ -338,7 +339,7 @@ class ProductAdminTestCase(BaseAPITestCase):
             reverse("admin:core_product_change", args=(product.pk,)),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, product.title)
 
         # - Check there are links to go to related courses admin change view

--- a/src/backend/joanie/tests/core/test_api_admin_certificate_definitions.py
+++ b/src/backend/joanie/tests/core/test_api_admin_certificate_definitions.py
@@ -2,6 +2,7 @@
 Test suite for Certificate definition Admin API.
 """
 import random
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -19,7 +20,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
         """
         response = self.client.get("/api/v1.0/admin/certificate-definitions/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -34,7 +35,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/certificate-definitions/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -53,7 +54,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/certificate-definitions/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], certification_definitions_count)
 
@@ -70,21 +71,21 @@ class CertificateDefinitionAdminApiTest(TestCase):
         )
 
         response = self.client.get("/api/v1.0/admin/certificate-definitions/?query=")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], certification_definitions_count)
 
         response = self.client.get(
             f"/api/v1.0/admin/certificate-definitions/?query={items[0].title}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
 
         response = self.client.get(
             f"/api/v1.0/admin/certificate-definitions/?query={items[0].name}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
 
@@ -120,7 +121,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
         response = self.client.get(
             "/api/v1.0/admin/certificate-definitions/?query=Certificate 1"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Certificate 1")
@@ -129,7 +130,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
             "/api/v1.0/admin/certificate-definitions/?query=Certificat 1",
             HTTP_ACCEPT_LANGUAGE="fr-fr",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Certificat 1")
@@ -138,7 +139,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
             "/api/v1.0/admin/certificate-definitions/?query=Certificate 1",
             HTTP_ACCEPT_LANGUAGE="fr-fr",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Certificat 1")
@@ -155,7 +156,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
             f"/api/v1.0/admin/certificate-definitions/{certification_definition.id}/"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(certification_definition.id))
 
@@ -177,7 +178,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
             data=data,
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertIsNotNone(content["id"])
         self.assertEqual(content["name"], "Certificate Definition 001")
@@ -205,7 +206,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
             data=payload,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(certification_definition.id))
         self.assertEqual(content["name"], "Updated Certificate Definition 001")
@@ -228,7 +229,7 @@ class CertificateDefinitionAdminApiTest(TestCase):
             data={"template": enums.DEGREE},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(certification_definition.id))
         self.assertEqual(content["template"], "degree")
@@ -245,4 +246,4 @@ class CertificateDefinitionAdminApiTest(TestCase):
             f"/api/v1.0/admin/certificate-definitions/{certificate_definition.id}/"
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)

--- a/src/backend/joanie/tests/core/test_api_admin_contract_definitions.py
+++ b/src/backend/joanie/tests/core/test_api_admin_contract_definitions.py
@@ -2,6 +2,7 @@
 Test suite for Contract definition Admin API.
 """
 import random
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -21,7 +22,7 @@ class ContractDefinitionAdminApiTest(TestCase):
         """
         response = self.client.get("/api/v1.0/admin/contract-definitions/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -36,7 +37,7 @@ class ContractDefinitionAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/contract-definitions/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -53,7 +54,7 @@ class ContractDefinitionAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/contract-definitions/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], contract_definitions_count)
 
@@ -73,7 +74,7 @@ class ContractDefinitionAdminApiTest(TestCase):
             f"/api/v1.0/admin/contract-definitions/?query={contract_definition_1.title}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -105,7 +106,7 @@ class ContractDefinitionAdminApiTest(TestCase):
             f"/api/v1.0/admin/contract-definitions/{contract_definition.id}/"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(
             content,
@@ -137,7 +138,7 @@ class ContractDefinitionAdminApiTest(TestCase):
             data=data,
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertIsNotNone(content["id"])
         self.assertEqual(content["title"], "Contract 001")
@@ -163,7 +164,7 @@ class ContractDefinitionAdminApiTest(TestCase):
             data=payload,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(contract_definition.id))
         self.assertEqual(content["title"], "Updated Contract grade 1")
@@ -185,7 +186,7 @@ class ContractDefinitionAdminApiTest(TestCase):
             data={"title": "new title"},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(contract_definition.id))
         self.assertEqual(content["title"], "new title")
@@ -202,5 +203,5 @@ class ContractDefinitionAdminApiTest(TestCase):
             f"/api/v1.0/admin/contract-definitions/{contract_definition.id}/"
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertFalse(models.ContractDefinition.objects.exists())

--- a/src/backend/joanie/tests/core/test_api_admin_course_access.py
+++ b/src/backend/joanie/tests/core/test_api_admin_course_access.py
@@ -2,6 +2,7 @@
 Test suite for CourseAccess Admin API.
 """
 import uuid
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -20,7 +21,7 @@ class CourseAccessAdminApiTest(TestCase):
         course = factories.CourseFactory()
         response = self.client.get(f"/api/v1.0/admin/courses/{course.id}/accesses/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -38,7 +39,7 @@ class CourseAccessAdminApiTest(TestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     def test_admin_api_course_accesses_request_list(self):
@@ -53,7 +54,7 @@ class CourseAccessAdminApiTest(TestCase):
         self.assertContains(
             response,
             'Method \\"GET\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_admin_api_course_accesses_request_get(self):
@@ -71,7 +72,7 @@ class CourseAccessAdminApiTest(TestCase):
         self.assertContains(
             response,
             'Method \\"GET\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_admin_api_course_accesses_request_create(self):
@@ -92,7 +93,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(course.accesses.count(), 1)
         course_access = course.accesses.first()
         content = response.json()
@@ -127,7 +128,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.json(), {"user_id": ["Resource does not exist."]})
 
     def test_admin_api_course_accesses_request_create_with_unknown_course_id(self):
@@ -148,7 +149,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertContains(response, "Not found.", status_code=404)
+        self.assertContains(response, "Not found.", status_code=HTTPStatus.NOT_FOUND)
 
     def test_admin_api_course_accesses_request_create_with_invalid_role(self):
         """
@@ -168,7 +169,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             response.json(), {"role": ['"invalid_role" is not a valid choice.']}
         )
@@ -194,7 +195,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(
             content,
@@ -227,7 +228,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertContains(response, "Not found.", status_code=404)
+        self.assertContains(response, "Not found.", status_code=HTTPStatus.NOT_FOUND)
 
     def test_admin_api_course_accesses_request_update_with_partial_payload(self):
         """
@@ -249,7 +250,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         content = response.json()
         self.assertEqual(content, {"user_id": ["This field is required."]})
 
@@ -271,7 +272,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.json(), {"user_id": ["Resource does not exist."]})
 
     def test_admin_api_course_accesses_request_partial_update(self):
@@ -294,7 +295,7 @@ class CourseAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(
             content,
@@ -325,5 +326,5 @@ class CourseAccessAdminApiTest(TestCase):
             f"/api/v1.0/admin/courses/{course.id}/accesses/{course_access.id}/"
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(course.accesses.count(), 0)

--- a/src/backend/joanie/tests/core/test_api_admin_course_runs.py
+++ b/src/backend/joanie/tests/core/test_api_admin_course_runs.py
@@ -24,7 +24,7 @@ class CourseRunAdminApiTest(TestCase):
         """
         response = self.client.get("/api/v1.0/admin/course-runs/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -39,7 +39,7 @@ class CourseRunAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/course-runs/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -56,7 +56,7 @@ class CourseRunAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/course-runs/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], course_runs_count)
 
@@ -71,14 +71,14 @@ class CourseRunAdminApiTest(TestCase):
         items = factories.CourseRunFactory.create_batch(course_runs_count)
 
         response = self.client.get("/api/v1.0/admin/course-runs/?query=")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], course_runs_count)
 
         response = self.client.get(
             f"/api/v1.0/admin/course-runs/?query={items[0].title}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
 
@@ -93,7 +93,7 @@ class CourseRunAdminApiTest(TestCase):
         item.translations.create(language_code="fr-fr", title="Session 1")
 
         response = self.client.get("/api/v1.0/admin/course-runs/?query=Course")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Course run 1")
@@ -101,7 +101,7 @@ class CourseRunAdminApiTest(TestCase):
         response = self.client.get(
             "/api/v1.0/admin/course-runs/?query=Session", HTTP_ACCEPT_LANGUAGE="fr-fr"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Session 1")
@@ -109,7 +109,7 @@ class CourseRunAdminApiTest(TestCase):
         response = self.client.get(
             "/api/v1.0/admin/course-runs/?query=Course", HTTP_ACCEPT_LANGUAGE="fr-fr"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Session 1")
@@ -176,7 +176,7 @@ class CourseRunAdminApiTest(TestCase):
             "/api/v1.0/admin/course-runs/", content_type="application/json", data=data
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertIsNotNone(content["id"])
         self.assertEqual(
@@ -211,7 +211,7 @@ class CourseRunAdminApiTest(TestCase):
             data=payload,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(course_run.id))
         self.assertEqual(content["title"], "Updated Run 001")
@@ -234,7 +234,7 @@ class CourseRunAdminApiTest(TestCase):
             data={"title": "Updated Run 001"},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(course_run.id))
         self.assertEqual(content["title"], "Updated Run 001")
@@ -249,7 +249,7 @@ class CourseRunAdminApiTest(TestCase):
 
         response = self.client.delete(f"/api/v1.0/admin/course-runs/{course_run.id}/")
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
 
     def test_admin_api_course_run_read_list_authenticated_with_nested_course_filter_name(
         self,
@@ -271,7 +271,7 @@ class CourseRunAdminApiTest(TestCase):
             f"/api/v1.0/admin/courses/{course.id}/course-runs/?query=is%20a",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["id"], str(course_run.id))
@@ -279,7 +279,7 @@ class CourseRunAdminApiTest(TestCase):
             f"/api/v1.0/admin/courses/{course.id}/course-runs/?query=Cour",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
 
@@ -305,7 +305,7 @@ class CourseRunAdminApiTest(TestCase):
         response = self.client.get(
             f"/api/v1.0/admin/courses/{course.id}/course-runs/?start={now.strftime(format_time)}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["id"], str(course_run.id))
@@ -317,7 +317,7 @@ class CourseRunAdminApiTest(TestCase):
                 f"?start={past_date.strftime(format_time)}"
             ),
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
 
@@ -328,7 +328,7 @@ class CourseRunAdminApiTest(TestCase):
                 f"?start={future_date.strftime(format_time)}"
             ),
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 0)
 
@@ -370,7 +370,7 @@ class CourseRunAdminApiTest(TestCase):
                     f"?state={state_id}"
                 ),
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertEqual(content["count"], len(sorted_course_runs[state_id]))
             for course_run in sorted_course_runs[state_id]:
@@ -380,6 +380,6 @@ class CourseRunAdminApiTest(TestCase):
         response = self.client.get(
             f"/api/v1.0/admin/courses/{course.id}/course-runs/?state=-1",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 0)

--- a/src/backend/joanie/tests/core/test_api_admin_courses.py
+++ b/src/backend/joanie/tests/core/test_api_admin_courses.py
@@ -2,6 +2,7 @@
 Test suite for Course Admin API.
 """
 import random
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -22,7 +23,7 @@ class CourseAdminApiTest(TestCase):
         """
         response = self.client.get("/api/v1.0/admin/courses/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -37,7 +38,7 @@ class CourseAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/courses/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -54,7 +55,7 @@ class CourseAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/courses/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertCountEqual(
             response.json(),
             {
@@ -82,18 +83,18 @@ class CourseAdminApiTest(TestCase):
         [course, *_] = factories.CourseFactory.create_batch(courses_count)
 
         response = self.client.get("/api/v1.0/admin/courses/?query=")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], courses_count)
 
         response = self.client.get(f"/api/v1.0/admin/courses/?query={course.title}")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["id"], str(course.id))
 
         response = self.client.get(f"/api/v1.0/admin/courses/?query={course.code}")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["id"], str(course.id))
@@ -109,7 +110,7 @@ class CourseAdminApiTest(TestCase):
         item.translations.create(language_code="fr-fr", title="Leçon 1")
 
         response = self.client.get("/api/v1.0/admin/courses/?query=lesson")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Lesson 1")
@@ -117,7 +118,7 @@ class CourseAdminApiTest(TestCase):
         response = self.client.get(
             "/api/v1.0/admin/courses/?query=Leçon", HTTP_ACCEPT_LANGUAGE="fr-fr"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Leçon 1")
@@ -125,7 +126,7 @@ class CourseAdminApiTest(TestCase):
         response = self.client.get(
             "/api/v1.0/admin/courses/?query=Lesson", HTTP_ACCEPT_LANGUAGE="fr-fr"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Leçon 1")
@@ -147,7 +148,7 @@ class CourseAdminApiTest(TestCase):
         factories.UserCourseAccessFactory.create_batch(accesses_count, course=course)
 
         response = self.client.get(f"/api/v1.0/admin/courses/{course.id}/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -234,7 +235,7 @@ class CourseAdminApiTest(TestCase):
             "/api/v1.0/admin/courses/", content_type="application/json", data=data
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
 
         self.assertIsNotNone(content["code"])
@@ -271,7 +272,7 @@ class CourseAdminApiTest(TestCase):
             data=payload,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(course.id))
         self.assertEqual(content["code"], "UPDATED-COURSE-001")
@@ -312,7 +313,7 @@ class CourseAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(course.id))
         self.assertEqual(content["title"], "Updated Course 00001")
@@ -329,4 +330,4 @@ class CourseAdminApiTest(TestCase):
 
         response = self.client.delete(f"/api/v1.0/admin/courses/{course.id}/")
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)

--- a/src/backend/joanie/tests/core/test_api_admin_order_group.py
+++ b/src/backend/joanie/tests/core/test_api_admin_order_group.py
@@ -1,7 +1,7 @@
 """
 Test suite for OrderGroup Admin API.
 """
-
+from http import HTTPStatus
 from operator import itemgetter
 
 from django.test import TestCase
@@ -24,7 +24,7 @@ class OrderGroupAdminApiTest(TestCase):
 
         relation = factories.CourseProductRelationFactory()
         response = self.client.get(f"{self.base_url}/{relation.id}/order-groups/")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -45,7 +45,7 @@ class OrderGroupAdminApiTest(TestCase):
 
         with self.assertNumQueries(10):
             response = self.client.get(f"{self.base_url}/{relation.id}/order-groups/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         expected_return = [
             {
@@ -75,7 +75,7 @@ class OrderGroupAdminApiTest(TestCase):
 
         response = self.client.get(f"{self.base_url}/{relation.id}/order-groups/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -93,7 +93,7 @@ class OrderGroupAdminApiTest(TestCase):
         response = self.client.get(
             f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -114,7 +114,7 @@ class OrderGroupAdminApiTest(TestCase):
                 f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/"
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         expected_return = {
             "id": str(order_group.id),
@@ -140,7 +140,7 @@ class OrderGroupAdminApiTest(TestCase):
             content_type="application/json",
             data=data,
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -165,7 +165,7 @@ class OrderGroupAdminApiTest(TestCase):
                 data=data,
             )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertEqual(content["nb_seats"], data["nb_seats"])
         self.assertEqual(content["is_active"], data["is_active"])
@@ -183,7 +183,7 @@ class OrderGroupAdminApiTest(TestCase):
         response = self.client.put(
             f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -208,7 +208,7 @@ class OrderGroupAdminApiTest(TestCase):
                 content_type="application/json",
                 data=data,
             )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["nb_seats"], data["nb_seats"])
         self.assertEqual(content["is_active"], data["is_active"])
@@ -226,7 +226,7 @@ class OrderGroupAdminApiTest(TestCase):
         response = self.client.patch(
             f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -252,7 +252,7 @@ class OrderGroupAdminApiTest(TestCase):
                 content_type="application/json",
                 data=data,
             )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["nb_seats"], order_group.nb_seats)
         self.assertEqual(content["is_active"], data["is_active"])
@@ -275,7 +275,7 @@ class OrderGroupAdminApiTest(TestCase):
         response = self.client.delete(
             f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         with self.assertNumQueries(0):
             self.assertEqual(
@@ -295,7 +295,7 @@ class OrderGroupAdminApiTest(TestCase):
             response = self.client.delete(
                 f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/",
             )
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertFalse(models.OrderGroup.objects.filter(id=order_group.id).exists())
 
     def test_admin_api_order_group_delete_cannot_edit(self):
@@ -311,5 +311,5 @@ class OrderGroupAdminApiTest(TestCase):
             response = self.client.delete(
                 f"{self.base_url}/{relation.id}/order-groups/{order_group.id}/",
             )
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertFalse(models.OrderGroup.objects.filter(id=order_group.id).exists())

--- a/src/backend/joanie/tests/core/test_api_admin_organization_access.py
+++ b/src/backend/joanie/tests/core/test_api_admin_organization_access.py
@@ -2,6 +2,7 @@
 Test suite for OrganizationAccess Admin API.
 """
 import uuid
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -22,7 +23,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             f"/api/v1.0/admin/organizations/{organization.id}/accesses/"
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -42,7 +43,7 @@ class OrganizationAccessAdminApiTest(TestCase):
         self.assertContains(
             response,
             "You do not have permission to perform this action.",
-            status_code=403,
+            status_code=HTTPStatus.FORBIDDEN,
         )
 
     def test_admin_api_organization_accesses_request_list(self):
@@ -59,7 +60,7 @@ class OrganizationAccessAdminApiTest(TestCase):
         self.assertContains(
             response,
             'Method \\"GET\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_admin_api_organization_accesses_request_get(self):
@@ -79,7 +80,7 @@ class OrganizationAccessAdminApiTest(TestCase):
         self.assertContains(
             response,
             'Method \\"GET\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_admin_api_organization_accesses_request_create(self):
@@ -100,7 +101,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(organization.accesses.count(), 1)
         organization_access = organization.accesses.first()
         content = response.json()
@@ -135,7 +136,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.json(), {"user_id": ["Resource does not exist."]})
 
     def test_admin_api_organization_accesses_request_create_with_unknown_course_id(
@@ -158,7 +159,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertContains(response, "Not found.", status_code=404)
+        self.assertContains(response, "Not found.", status_code=HTTPStatus.NOT_FOUND)
 
     def test_admin_api_organization_accesses_request_create_with_invalid_role(self):
         """
@@ -178,7 +179,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             response.json(), {"role": ['"invalid_role" is not a valid choice.']}
         )
@@ -204,7 +205,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(
             content,
@@ -239,7 +240,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertContains(response, "Not found.", status_code=404)
+        self.assertContains(response, "Not found.", status_code=HTTPStatus.NOT_FOUND)
 
     def test_admin_api_organization_accesses_request_update_with_partial_payload(self):
         """
@@ -261,7 +262,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         content = response.json()
         self.assertEqual(content, {"user_id": ["This field is required."]})
 
@@ -283,7 +284,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.json(), {"user_id": ["Resource does not exist."]})
 
     def test_admin_api_organization_accesses_request_partial_update(self):
@@ -306,7 +307,7 @@ class OrganizationAccessAdminApiTest(TestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(
             content,
@@ -337,5 +338,5 @@ class OrganizationAccessAdminApiTest(TestCase):
             f"/api/v1.0/admin/organizations/{organization.id}/accesses/{organization_access.id}/"
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(organization.accesses.count(), 0)

--- a/src/backend/joanie/tests/core/test_api_admin_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_admin_organizations.py
@@ -3,6 +3,7 @@ Test suite for Organization Admin API.
 """
 import random
 import re
+from http import HTTPStatus
 from unittest import mock
 
 from django.core.files.base import ContentFile
@@ -25,7 +26,7 @@ class OrganizationAdminApiTest(TestCase):
         """
         response = self.client.get("/api/v1.0/admin/organizations/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -40,7 +41,7 @@ class OrganizationAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/organizations/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -55,22 +56,22 @@ class OrganizationAdminApiTest(TestCase):
         self.client.login(username=admin.username, password="password")
 
         response = self.client.get("/api/v1.0/admin/organizations/")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         response = self.client.get("/api/v1.0/admin/organizations/abc/")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         response = self.client.post("/api/v1.0/admin/organizations/")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
         response = self.client.put("/api/v1.0/admin/organizations/")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
         response = self.client.patch("/api/v1.0/admin/organizations/")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
         response = self.client.delete("/api/v1.0/admin/organizations/")
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
     def test_admin_api_organization_list(self):
         """
@@ -84,7 +85,7 @@ class OrganizationAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/organizations/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertCountEqual(
             response.json(),
             {
@@ -120,21 +121,21 @@ class OrganizationAdminApiTest(TestCase):
         )
 
         response = self.client.get("/api/v1.0/admin/organizations/?query=")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], organization_count)
 
         response = self.client.get(
             f"/api/v1.0/admin/organizations/?query={organization.title}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
 
         response = self.client.get(
             f"/api/v1.0/admin/organizations/?query={organization.code}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
 
@@ -165,7 +166,7 @@ class OrganizationAdminApiTest(TestCase):
         item.translations.create(language_code="fr-fr", title="Université")
 
         response = self.client.get("/api/v1.0/admin/organizations/?query=Uni")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "University")
@@ -174,7 +175,7 @@ class OrganizationAdminApiTest(TestCase):
             "/api/v1.0/admin/organizations/?query=Université",
             HTTP_ACCEPT_LANGUAGE="fr-fr",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Université")
@@ -183,7 +184,7 @@ class OrganizationAdminApiTest(TestCase):
             "/api/v1.0/admin/organizations/?query=university",
             HTTP_ACCEPT_LANGUAGE="fr-fr",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Université")
@@ -205,7 +206,7 @@ class OrganizationAdminApiTest(TestCase):
 
         response = self.client.get(f"/api/v1.0/admin/organizations/{organization.id}/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         assert (
             response.json()
@@ -274,7 +275,7 @@ class OrganizationAdminApiTest(TestCase):
 
         response = self.client.post("/api/v1.0/admin/organizations/", data=data)
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertIsNotNone(content["id"])
         self.assertEqual(content["code"], "ORG-001")
@@ -306,7 +307,7 @@ class OrganizationAdminApiTest(TestCase):
             data=payload,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(organization.id))
         self.assertEqual(content["code"], "UPDATED-ORG-001")
@@ -328,7 +329,7 @@ class OrganizationAdminApiTest(TestCase):
             data={"title": "Updated Organization 001"},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(organization.id))
         self.assertEqual(content["title"], "Updated Organization 001")
@@ -345,4 +346,4 @@ class OrganizationAdminApiTest(TestCase):
             f"/api/v1.0/admin/organizations/{organization.id}/"
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -2,6 +2,7 @@
 Test suite for Product Admin API.
 """
 import random
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -19,7 +20,7 @@ class ProductAdminApiTest(TestCase):
         """
         response = self.client.get("/api/v1.0/admin/products/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -34,7 +35,7 @@ class ProductAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/products/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -51,7 +52,7 @@ class ProductAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/products/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], product_count)
 
@@ -86,7 +87,7 @@ class ProductAdminApiTest(TestCase):
 
         response = self.client.get(f"/api/v1.0/admin/products/{product.id}/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(product.id))
         expected_result = {
@@ -219,7 +220,7 @@ class ProductAdminApiTest(TestCase):
 
         response = self.client.post("/api/v1.0/admin/products/", data=data)
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertIsNotNone(content["id"])
         self.assertEqual(content["title"], "Product 001")
@@ -242,7 +243,7 @@ class ProductAdminApiTest(TestCase):
 
         response = self.client.post("/api/v1.0/admin/products/", data=data)
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertIsNotNone(content["id"])
         self.assertEqual(content["title"], "Product 001")
@@ -265,7 +266,7 @@ class ProductAdminApiTest(TestCase):
 
         response = self.client.post("/api/v1.0/admin/products/", data=data)
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
         self.assertIsNotNone(content["id"])
         self.assertEqual(content["title"], "Product 001")
@@ -294,7 +295,7 @@ class ProductAdminApiTest(TestCase):
             data=payload,
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(product.id))
         self.assertEqual(content["price"], 100)
@@ -314,7 +315,7 @@ class ProductAdminApiTest(TestCase):
             data={"price": 100.57, "price_currency": "EUR"},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(product.id))
         self.assertEqual(content["price"], 100.57)
@@ -329,7 +330,7 @@ class ProductAdminApiTest(TestCase):
 
         response = self.client.delete(f"/api/v1.0/admin/products/{product.id}/")
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
 
     def test_admin_api_product_add_target_course_without_authentication(self):
         """
@@ -343,7 +344,7 @@ class ProductAdminApiTest(TestCase):
             content_type="application/json",
             data={"course": str(course.id)},
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertFalse(models.ProductTargetCourseRelation.objects.exists())
 
     def test_admin_api_product_add_target_course(self):
@@ -360,7 +361,7 @@ class ProductAdminApiTest(TestCase):
             content_type="application/json",
             data={"course": str(course.id)},
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         relation = models.ProductTargetCourseRelation.objects.get()
         expected_result = {
             "id": str(relation.id),
@@ -399,7 +400,7 @@ class ProductAdminApiTest(TestCase):
             content_type="application/json",
             data={"course": str(course.id), "course_runs": ""},
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         relation = models.ProductTargetCourseRelation.objects.get()
         expected_result = {
             "id": str(relation.id),
@@ -433,7 +434,7 @@ class ProductAdminApiTest(TestCase):
         response = self.client.delete(
             f"/api/v1.0/admin/products/{product.id}/target-courses/{course.id}/",
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(models.ProductTargetCourseRelation.objects.count(), 1)
 
     def test_admin_api_product_delete_target_course(self):
@@ -449,7 +450,7 @@ class ProductAdminApiTest(TestCase):
         response = self.client.delete(
             f"/api/v1.0/admin/products/{product.id}/target-courses/{course.id}/",
         )
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(models.ProductTargetCourseRelation.objects.count(), 0)
         product.refresh_from_db()
         self.assertEqual(product.target_courses.count(), 0)
@@ -474,7 +475,7 @@ class ProductAdminApiTest(TestCase):
             data={"is_graded": True},
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         relation.refresh_from_db()
         self.assertTrue(relation.is_graded)
 
@@ -498,7 +499,7 @@ class ProductAdminApiTest(TestCase):
             data={"is_graded": True, "course_runs": ""},
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         relation.refresh_from_db()
         self.assertEqual(relation.course_runs.count(), 0)
 
@@ -526,7 +527,7 @@ class ProductAdminApiTest(TestCase):
             },
             content_type="application/json",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         relations = models.ProductTargetCourseRelation.objects.filter(product=product)
         self.assertEqual(relations.get(course=courses[1]).position, 0)
         self.assertEqual(relations.get(course=courses[3]).position, 1)
@@ -550,7 +551,7 @@ class ProductAdminApiTest(TestCase):
             data={"instructions": ""},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["instructions"], "")
         product.refresh_from_db()
@@ -570,7 +571,7 @@ class ProductAdminApiTest(TestCase):
             data={"instructions": "Test whitespace   "},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["instructions"], "Test whitespace   ")
 
@@ -580,6 +581,6 @@ class ProductAdminApiTest(TestCase):
             data={"instructions": "Test newline\n\n"},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["instructions"], "Test newline\n\n")

--- a/src/backend/joanie/tests/core/test_api_admin_users.py
+++ b/src/backend/joanie/tests/core/test_api_admin_users.py
@@ -2,6 +2,7 @@
 Test suite for User Admin API.
 """
 import random
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -19,7 +20,7 @@ class UserAdminApiTest(TestCase):
         """
         response = self.client.get("/api/v1.0/admin/users/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content["detail"], "Authentication credentials were not provided."
@@ -34,7 +35,7 @@ class UserAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/users/")
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         content = response.json()
         self.assertEqual(
             content["detail"], "You do not have permission to perform this action."
@@ -51,7 +52,7 @@ class UserAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/users/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 0)
 
@@ -84,14 +85,14 @@ class UserAdminApiTest(TestCase):
 
         # An empty search should return no results
         response = self.client.get("/api/v1.0/admin/users/?query=")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 0)
 
         # Search by username
         response = self.client.get("/api/v1.0/admin/users/?query=fnz")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(
@@ -105,13 +106,13 @@ class UserAdminApiTest(TestCase):
 
         # Search by email
         response = self.client.get("/api/v1.0/admin/users/?query=@example.fr")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
 
         # Search by firstname
         response = self.client.get("/api/v1.0/admin/users/?query=joanie")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(
@@ -125,7 +126,7 @@ class UserAdminApiTest(TestCase):
 
         # Search by lastname
         response = self.client.get("/api/v1.0/admin/users/?query=Cunningham")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
         self.assertCountEqual(
@@ -146,7 +147,7 @@ class UserAdminApiTest(TestCase):
         self.assertContains(
             response,
             "The requested resource was not found on this server.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_admin_api_user_create(self):
@@ -161,7 +162,7 @@ class UserAdminApiTest(TestCase):
         self.assertContains(
             response,
             'Method \\"POST\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_admin_api_user_update(self):
@@ -177,7 +178,7 @@ class UserAdminApiTest(TestCase):
         self.assertContains(
             response,
             "The requested resource was not found on this server.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_admin_api_user_partially_update(self):
@@ -193,7 +194,7 @@ class UserAdminApiTest(TestCase):
         self.assertContains(
             response,
             "The requested resource was not found on this server.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_admin_api_user_delete(self):
@@ -209,7 +210,7 @@ class UserAdminApiTest(TestCase):
         self.assertContains(
             response,
             "The requested resource was not found on this server.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_admin_api_user_me_anonymous(self):
@@ -219,7 +220,7 @@ class UserAdminApiTest(TestCase):
         factories.UserFactory(is_staff=True, is_superuser=True)
         response = self.client.get("/api/v1.0/admin/users/me/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_admin_api_user_me_no_access(self):
         """
@@ -230,7 +231,7 @@ class UserAdminApiTest(TestCase):
 
         response = self.client.get("/api/v1.0/admin/users/me/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -260,7 +261,7 @@ class UserAdminApiTest(TestCase):
         factories.UserCourseAccessFactory(user=admin)
         response = self.client.get("/api/v1.0/admin/users/me/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -290,7 +291,7 @@ class UserAdminApiTest(TestCase):
         factories.UserOrganizationAccessFactory(user=admin)
         response = self.client.get("/api/v1.0/admin/users/me/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -1,5 +1,6 @@
 """Tests for the Certificate API"""
 import uuid
+from http import HTTPStatus
 from io import BytesIO
 from unittest import mock
 
@@ -22,7 +23,7 @@ class CertificateApiTest(BaseAPITestCase):
         factories.OrderCertificateFactory.create_batch(2)
         response = self.client.get("/api/v1.0/certificates/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
@@ -63,7 +64,7 @@ class CertificateApiTest(BaseAPITestCase):
                 "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         order = certificate.order
         self.assertDictEqual(
             response.json(),
@@ -182,7 +183,7 @@ class CertificateApiTest(BaseAPITestCase):
             "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
         self.assertEqual(
@@ -199,7 +200,7 @@ class CertificateApiTest(BaseAPITestCase):
             "/api/v1.0/certificates/?page=2", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -220,7 +221,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         response = self.client.get(f"/api/v1.0/certificates/{certificate.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
@@ -249,7 +250,7 @@ class CertificateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertDictEqual(response.json(), {"detail": "Not found."})
 
         # - Try to retrieve an owned certificate should return the certificate id
@@ -258,7 +259,7 @@ class CertificateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertDictEqual(
             response.json(),
@@ -299,7 +300,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         response = self.client.get(f"/api/v1.0/certificates/{certificate.id}/download/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
@@ -332,7 +333,7 @@ class CertificateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         self.assertDictEqual(
             response.json(),
@@ -345,7 +346,7 @@ class CertificateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.headers["Content-Type"], "application/pdf")
         self.assertEqual(
             response.headers["Content-Disposition"],
@@ -375,7 +376,7 @@ class CertificateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         self.assertDictEqual(
             response.json(),
@@ -388,7 +389,7 @@ class CertificateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.headers["Content-Type"], "application/pdf")
         self.assertEqual(
             response.headers["Content-Disposition"],
@@ -428,7 +429,7 @@ class CertificateApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, HTTPStatus.UNPROCESSABLE_ENTITY)
         self.assertEqual(
             response.json(),
             {"detail": f"Unable to generate certificate {str(certificate.id)}."},
@@ -445,7 +446,7 @@ class CertificateApiTest(BaseAPITestCase):
             {"id": uuid.uuid4()},
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
 
         self.assertDictEqual(response.json(), {"detail": 'Method "POST" not allowed.'})
 
@@ -461,7 +462,7 @@ class CertificateApiTest(BaseAPITestCase):
             {"id": uuid.uuid4()},
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
 
         self.assertDictEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
@@ -477,7 +478,7 @@ class CertificateApiTest(BaseAPITestCase):
             {"id": uuid.uuid4()},
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
 
         self.assertDictEqual(
             response.json(), {"detail": 'Method "DELETE" not allowed.'}

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -30,7 +30,7 @@ class ContractApiTest(BaseAPITestCase):
         with self.assertNumQueries(0):
             response = self.client.get("/api/v1.0/contracts/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_contracts_list_with_accesses(self):
         """
@@ -73,7 +73,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -108,7 +108,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         expected_contracts = sorted(contracts, key=lambda x: x.created_on, reverse=True)
         assert response.json() == {
             "count": 5,
@@ -313,7 +313,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
 
@@ -324,7 +324,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -338,7 +338,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -384,7 +384,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
 
@@ -395,7 +395,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -409,7 +409,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -451,7 +451,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
 
@@ -462,7 +462,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -476,7 +476,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -556,7 +556,7 @@ class ContractApiTest(BaseAPITestCase):
         with self.assertNumQueries(0):
             response = self.client.get(f"/api/v1.0/contracts/{str(contract.id)}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_contracts_retrieve_with_accesses(self):
         """
@@ -588,7 +588,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     @mock.patch.object(
         fields.ThumbnailDetailField,
@@ -611,7 +611,7 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         assert response.json() == {
             "id": str(contract.id),
@@ -698,7 +698,7 @@ class ContractApiTest(BaseAPITestCase):
         with self.assertNumQueries(0):
             response = self.client.post("/api/v1.0/contracts/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_contracts_create_authenticated(self):
         """Authenticated user cannot create a contract."""
@@ -711,7 +711,11 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contracts_update_anonymous(self):
         """Anonymous user cannot update a contract."""
@@ -720,7 +724,7 @@ class ContractApiTest(BaseAPITestCase):
         with self.assertNumQueries(0):
             response = self.client.put(f"/api/v1.0/contracts/{str(contract.id)}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_contracts_update_authenticated(self):
         """Authenticated user cannot update a contract."""
@@ -734,7 +738,11 @@ class ContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contracts_patch_anonymous(self):
         """Anonymous user cannot patch a contract."""
@@ -743,7 +751,7 @@ class ContractApiTest(BaseAPITestCase):
         with self.assertNumQueries(0):
             response = self.client.patch(f"/api/v1.0/contracts/{str(contract.id)}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_contracts_patch_authenticated(self):
         """Authenticated user cannot patch a contract."""
@@ -758,7 +766,9 @@ class ContractApiTest(BaseAPITestCase):
             )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contracts_delete_anonymous(self):
@@ -768,7 +778,7 @@ class ContractApiTest(BaseAPITestCase):
         with self.assertNumQueries(0):
             response = self.client.delete(f"/api/v1.0/contracts/{str(contract.id)}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_contracts_delete_authenticated(self):
         """Authenticated user cannot delete a contract."""
@@ -783,7 +793,9 @@ class ContractApiTest(BaseAPITestCase):
             )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contract_download_anonymous(self):
@@ -796,7 +808,7 @@ class ContractApiTest(BaseAPITestCase):
             f"/api/v1.0/contracts/{str(contract.id)}/download/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         content = response.json()
         self.assertDictEqual(
@@ -835,7 +847,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.headers["Content-Type"], "application/pdf")
         self.assertEqual(
             response.headers["Content-Disposition"],
@@ -902,7 +914,11 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_download_authenticated_cannot_update(self):
         """
@@ -924,7 +940,11 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_download_authenticated_cannot_delete(self):
         """
@@ -947,7 +967,9 @@ class ContractApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contract_download_authenticated_should_fail_if_owner_is_not_the_actual_user(
@@ -983,7 +1005,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, "Not found.", status_code=404)
+        self.assertContains(response, "Not found.", status_code=HTTPStatus.NOT_FOUND)
 
     def test_api_contract_download_authenticated_should_fail_if_contract_is_not_signed(
         self,
@@ -1019,7 +1041,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Cannot download a contract when it is not yet fully signed.",
-            status_code=400,
+            status_code=HTTPStatus.BAD_REQUEST,
         )
 
     def test_api_contract_generate_zip_archive_anonymous(self):
@@ -1030,7 +1052,7 @@ class ContractApiTest(BaseAPITestCase):
             "/api/v1.0/contracts/zip-archive/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         content = response.json()
         self.assertEqual(
@@ -1052,7 +1074,11 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"GET\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"GET\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_generate_zip_archive_authenticated_put_method_not_allowed(
         self,
@@ -1069,7 +1095,11 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_generate_zip_archive_authenticated_patch_method_not_allowed(
         self,
@@ -1087,7 +1117,9 @@ class ContractApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contract_generate_zip_archive_authenticated_delete_method_not_allowed(
@@ -1106,7 +1138,9 @@ class ContractApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contract_generate_zip_archive_authenticated_post_without_parsing_parameters(
@@ -1127,7 +1161,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertEqual(
             response.json(),
@@ -1164,7 +1198,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertEqual(
             response.json(),
@@ -1198,7 +1232,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertEqual(response.json(), ["No zip to generate"])
 
@@ -1251,7 +1285,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.status_code, HTTPStatus.ACCEPTED)
 
         content = response.content.decode("utf-8")
         content_json = json.loads(content)
@@ -1272,7 +1306,7 @@ class ContractApiTest(BaseAPITestCase):
         """
         response = self.client.get(f"/api/v1.0/contracts/zip-archive/{uuid4()}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         content = response.json()
         self.assertEqual(
@@ -1294,7 +1328,11 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_get_zip_archive_authenticated_patch_method_not_allowed(
         self,
@@ -1312,7 +1350,9 @@ class ContractApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contract_get_zip_archive_authenticated_delete_method_not_allowed(
@@ -1331,7 +1371,9 @@ class ContractApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contract_get_zip_archive_authenticated_get_method_but_zip_archive_not_ready(
@@ -1352,7 +1394,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_contract_get_zip_archive_authenticated_invalid_zip_id(
         self,
@@ -1370,7 +1412,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_contract_get_zip_archive_authenticated_get_method_zip_archive_is_ready(
         self,
@@ -1396,7 +1438,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.headers["Content-Type"], "application/zip")
         self.assertEqual(
             response.headers["Content-Disposition"],
@@ -1426,7 +1468,7 @@ class ContractApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         # Prepare ZIP archive in storage
         zip_archive_name = contract_utility.generate_zip_archive(
@@ -1438,7 +1480,7 @@ class ContractApiTest(BaseAPITestCase):
             f"/api/v1.0/contracts/zip-archive/{zip_uuid}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.headers["Content-Type"], "application/zip")
         self.assertEqual(
             response.headers["Content-Disposition"],

--- a/src/backend/joanie/tests/core/test_api_contract_definitions.py
+++ b/src/backend/joanie/tests/core/test_api_contract_definitions.py
@@ -1,6 +1,7 @@
 """
 Test suite for Contract Definition API.
 """
+from http import HTTPStatus
 from io import BytesIO
 
 from pdfminer.high_level import extract_text as pdf_extract_text
@@ -24,7 +25,7 @@ class ContractDefinitionApiTest(BaseAPITestCase):
             f"/api/v1.0/contract_definitions/{str(contract_definition.id)}/preview_template/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         content = response.json()
         self.assertEqual(
@@ -48,7 +49,11 @@ class ContractDefinitionApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_definition_preview_template_method_put_should_fail(
         self,
@@ -67,7 +72,11 @@ class ContractDefinitionApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_definition_preview_template_method_patch_should_fail(
         self,
@@ -86,7 +95,11 @@ class ContractDefinitionApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"PATCH\\" not allowed', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PATCH\\" not allowed',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_contract_definition_preview_template_method_delete_should_fail(
         self,
@@ -106,7 +119,9 @@ class ContractDefinitionApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_contract_definition_preview_template_success(
@@ -128,7 +143,7 @@ class ContractDefinitionApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.headers["Content-Type"], "application/pdf")
         self.assertEqual(
             response.headers["Content-Disposition"],

--- a/src/backend/joanie/tests/core/test_api_course.py
+++ b/src/backend/joanie/tests/core/test_api_course.py
@@ -2,6 +2,7 @@
 Test suite for Course API endpoint.
 """
 import random
+from http import HTTPStatus
 from unittest import mock
 
 from joanie.core import enums, factories, models
@@ -23,7 +24,7 @@ class CourseApiTest(BaseAPITestCase):
         factories.CourseFactory()
         response = self.client.get("/api/v1.0/courses/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -46,7 +47,7 @@ class CourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 2)
         self.assertCountEqual(
@@ -79,7 +80,7 @@ class CourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -149,7 +150,7 @@ class CourseApiTest(BaseAPITestCase):
         )
 
         # It should return courses[0] only
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["id"], str(courses[0].id))
@@ -161,7 +162,7 @@ class CourseApiTest(BaseAPITestCase):
         )
 
         # It should return courses[1] and courses[2]
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
         self.assertCountEqual(
@@ -192,7 +193,7 @@ class CourseApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/?product_type={enums.PRODUCT_TYPE_CREDENTIAL}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
 
@@ -200,7 +201,7 @@ class CourseApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/?product_type={enums.PRODUCT_TYPE_ENROLLMENT}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
 
@@ -208,7 +209,7 @@ class CourseApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/?product_type={enums.PRODUCT_TYPE_CERTIFICATE}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
 
@@ -219,7 +220,7 @@ class CourseApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/?product_type={enums.PRODUCT_TYPE_CREDENTIAL}",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 4)
 
@@ -231,7 +232,7 @@ class CourseApiTest(BaseAPITestCase):
 
         response = self.client.get(f"/api/v1.0/courses/{course.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -251,7 +252,7 @@ class CourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertDictEqual(response.json(), {"detail": "Not found."})
 
     @mock.patch.object(
@@ -281,7 +282,7 @@ class CourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertTrue(content.pop("abilities")["get"])
         self.assertDictEqual(
@@ -336,7 +337,7 @@ class CourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(course.id))
 
@@ -351,7 +352,7 @@ class CourseApiTest(BaseAPITestCase):
 
         response = self.client.post("/api/v1.0/courses/", data=data)
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertFalse(models.Course.objects.exists())
 
     def test_api_course_create_authenticated(self):
@@ -375,7 +376,7 @@ class CourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertFalse(models.Course.objects.exists())
 
     def test_api_course_update_anonymous(self):
@@ -391,7 +392,7 @@ class CourseApiTest(BaseAPITestCase):
 
         response = self.client.put(f"/api/v1.0/courses/{course.id}/", data=data)
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -423,7 +424,7 @@ class CourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertDictEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
         course.refresh_from_db()
@@ -458,7 +459,7 @@ class CourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertDictEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
         course.refresh_from_db()
@@ -473,7 +474,7 @@ class CourseApiTest(BaseAPITestCase):
 
         response = self.client.delete(f"/api/v1.0/courses/{course.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(models.Course.objects.count(), 1)
 
     def test_api_course_delete_authenticated_without_access(self):
@@ -493,7 +494,7 @@ class CourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Course.objects.count(), 1)
 
     def test_api_course_delete_authenticated_with_access(self):
@@ -519,5 +520,5 @@ class CourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Course.objects.count(), 1)

--- a/src/backend/joanie/tests/core/test_api_course_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_course_accesses.py
@@ -2,6 +2,7 @@
 Tests course access API endpoints in Joanie's core app.
 """
 import random
+from http import HTTPStatus
 from unittest import mock
 from uuid import uuid4
 
@@ -25,7 +26,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
         access = factories.UserCourseAccessFactory()
 
         response = self.client.get(f"/api/v1.0/courses/{access.course.id!s}/accesses/")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -51,7 +52,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json()["results"], [])
 
     def test_api_course_accesses_list_authenticated_instructor(self):
@@ -93,7 +94,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 5)
         self.assertCountEqual(
@@ -139,7 +140,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 6)
         self.assertCountEqual(
@@ -187,7 +188,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 6)
         self.assertCountEqual(
@@ -233,7 +234,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 6)
         self.assertCountEqual(
@@ -264,7 +265,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -284,7 +285,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -309,7 +310,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{access.course.id!s}/accesses/{access.id!s}/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -331,7 +332,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 f"/api/v1.0/courses/{course.id!s}/accesses/{access.id!s}/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             self.assertEqual(
                 response.json(),
                 {"detail": "You do not have permission to perform this action."},
@@ -357,7 +358,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertTrue(content.pop("abilities")["get"])
             self.assertEqual(
@@ -389,7 +390,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertTrue(content.pop("abilities")["get"])
             self.assertEqual(
@@ -419,7 +420,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertTrue(content.pop("abilities")["get"])
             self.assertEqual(
@@ -449,7 +450,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertTrue(content.pop("abilities")["get"])
             self.assertEqual(
@@ -476,7 +477,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     # Create
 
@@ -494,7 +495,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 ),
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -517,7 +518,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(
             response.json(),
             {"detail": ("You are not allowed to manage accesses for this course.")},
@@ -545,7 +546,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(
             response.json(),
             {"detail": ("You are not allowed to manage accesses for this course.")},
@@ -573,7 +574,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(
             response.json(),
             {"detail": ("You are not allowed to manage accesses for this course.")},
@@ -599,7 +600,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(CourseAccess.objects.count(), 2)
         self.assertTrue(CourseAccess.objects.filter(user=other_user).exists())
 
@@ -621,7 +622,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertFalse(CourseAccess.objects.filter(user=other_user).exists())
 
     def test_api_course_accesses_create_owner_all_roles(self):
@@ -645,7 +646,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, HTTPStatus.CREATED)
             self.assertEqual(CourseAccess.objects.count(), i + 2)
             self.assertTrue(CourseAccess.objects.filter(user=other_user).exists())
 
@@ -669,7 +670,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 data={**old_values, field: value},
                 content_type="application/json",
             )
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -696,7 +697,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -727,7 +728,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -758,7 +759,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -797,9 +798,9 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             if (
                 new_data["role"] == old_values["role"]
             ):  # we are not not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
@@ -838,7 +839,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -876,9 +877,9 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             )
             # We are not allowed or not really updating the role
             if field == "role" or new_data["role"] == old_values["role"]:
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
@@ -918,9 +919,9 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             if (
                 new_data["role"] == old_values["role"]
             ):  # we are not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
@@ -957,7 +958,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -983,7 +984,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         access.refresh_from_db()
         self.assertEqual(access.role, "owner")
 
@@ -997,7 +998,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         access.refresh_from_db()
         self.assertEqual(access.role, new_role)
 
@@ -1021,7 +1022,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 data={field: value},
                 content_type="application/json",
             )
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1048,7 +1049,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1079,7 +1080,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1110,7 +1111,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1147,9 +1148,9 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
             if field == "role" and value == old_values["role"]:
                 # We are not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
@@ -1188,7 +1189,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
@@ -1225,9 +1226,9 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             if field == "role":
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1264,9 +1265,9 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
 
             if field == "role" and value == old_values["role"]:
                 # We are not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
@@ -1303,7 +1304,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
             access.refresh_from_db()
             updated_values = CourseAccessSerializer(instance=access).data
@@ -1329,7 +1330,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         access.refresh_from_db()
         self.assertEqual(access.role, "owner")
 
@@ -1343,7 +1344,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         access.refresh_from_db()
         self.assertEqual(access.role, new_role)
 
@@ -1357,7 +1358,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{access.course.id!s}/accesses/{access.id!s}/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(CourseAccess.objects.count(), 1)
 
     def test_api_course_accesses_delete_authenticated(self):
@@ -1374,7 +1375,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(CourseAccess.objects.count(), 1)
 
     def test_api_course_accesses_delete_instructors(self):
@@ -1395,7 +1396,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(CourseAccess.objects.count(), 2)
 
     def test_api_course_accesses_delete_managers(self):
@@ -1416,7 +1417,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(CourseAccess.objects.count(), 2)
 
     def test_api_course_accesses_delete_administrators(self):
@@ -1439,7 +1440,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(CourseAccess.objects.count(), 1)
 
     def test_api_course_accesses_delete_owners_except_owners(self):
@@ -1462,7 +1463,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(CourseAccess.objects.count(), 1)
 
     def test_api_course_accesses_delete_owners_for_owners(self):
@@ -1483,7 +1484,7 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(CourseAccess.objects.count(), 2)
 
     def test_api_course_accesses_delete_owners_last_owner(self):
@@ -1504,5 +1505,5 @@ class CourseAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(CourseAccess.objects.count(), 1)

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -2,6 +2,7 @@
 """Test suite for the Course Product Relation API."""
 import random
 import uuid
+from http import HTTPStatus
 from unittest import mock
 
 from django.conf import settings
@@ -21,7 +22,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         """
         response = self.client.get("/api/v1.0/course-product-relations/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content, {"detail": "Authentication credentials were not provided."}
@@ -39,7 +40,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.get(
             "/api/v1.0/course-product-relations/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(
             content,
@@ -94,7 +95,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(len(content["results"]), 1)
         self.assertEqual(
@@ -228,7 +229,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         course = factories.CourseFactory()
         response = self.client.get(f"/api/v1.0/courses/{course.id}/products/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content, {"detail": "Authentication credentials were not provided."}
@@ -261,7 +262,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(len(content["results"]), 1)
 
@@ -281,7 +282,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id}/products/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(
             content,
@@ -306,7 +307,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         )
 
         response = self.client.get(f"/api/v1.0/course-product-relations/{relation.id}/")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_course_product_relation_read_detail_anonymous_with_course_id(self):
         """
@@ -316,7 +317,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         response = self.client.get(
             f"/api/v1.0/courses/{uuid.uuid4()}/products/{uuid.uuid4()}/"
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_course_product_relation_read_detail_with_product_id_anonymous(self):
         """
@@ -341,7 +342,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{course.code}/products/{product.id}/"
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         content = response.json()
         self.assertEqual(content["id"], str(relation.id))
@@ -354,7 +355,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{course.code}/products/{product.id}/"
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # Then cache should be language sensitive
         with self.assertNumQueries(15):
@@ -385,7 +386,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Not found.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
         # Authenticated user with course access should not be able
@@ -405,7 +406,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Not found.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
         response = self.client.get(
@@ -416,7 +417,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Not found.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_api_course_product_relation_read_detail_without_accesses(self):
@@ -437,7 +438,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     @mock.patch.object(
         fields.ThumbnailDetailField,
@@ -472,7 +473,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         content = response.json()
         self.assertEqual(
@@ -619,7 +620,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         content = response.json()
         self.assertEqual(
@@ -658,7 +659,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/course-product-relations/{relation.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         content = response.json()
         self.assertEqual(
@@ -682,7 +683,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertEqual(
             response.json()["order_groups"],
@@ -704,7 +705,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/course-product-relations/{relation.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertEqual(
             response.json()["order_groups"],
@@ -735,7 +736,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content, {"detail": "Authentication credentials were not provided."}
@@ -763,7 +764,11 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
         self.assertEqual(models.CourseProductRelation.objects.count(), 0)
 
     def test_api_course_product_relation_create_with_accesses(self):
@@ -791,7 +796,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"POST\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_course_product_relation_update_anonymous(self):
@@ -814,7 +819,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Authentication credentials were not provided.",
-            status_code=401,
+            status_code=HTTPStatus.UNAUTHORIZED,
         )
 
     def test_api_course_product_relation_update_authenticated(self):
@@ -841,7 +846,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"PUT\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_course_product_relation_update_with_accesses(self):
@@ -869,7 +874,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"PUT\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_course_product_relation_partially_update_anonymous(self):
@@ -891,7 +896,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Authentication credentials were not provided.",
-            status_code=401,
+            status_code=HTTPStatus.UNAUTHORIZED,
         )
 
     def test_api_course_product_relation_partially_update_authenticated(self):
@@ -917,7 +922,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"PATCH\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_course_product_relation_partially_update_with_accesses(self):
@@ -944,7 +949,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"PATCH\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_course_product_relation_delete_anonymous(self):
@@ -963,7 +968,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Authentication credentials were not provided.",
-            status_code=401,
+            status_code=HTTPStatus.UNAUTHORIZED,
         )
         self.assertEqual(models.CourseProductRelation.objects.count(), 1)
 
@@ -987,7 +992,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"DELETE\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         self.assertEqual(models.CourseProductRelation.objects.count(), 1)
 
@@ -1012,6 +1017,6 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"DELETE\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         self.assertEqual(models.CourseProductRelation.objects.count(), 1)

--- a/src/backend/joanie/tests/core/test_api_course_run.py
+++ b/src/backend/joanie/tests/core/test_api_course_run.py
@@ -1,4 +1,5 @@
 """Test suite for the CourseRun API"""
+from http import HTTPStatus
 from unittest import mock
 
 from joanie.core import factories, models
@@ -21,7 +22,7 @@ class CourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "The requested resource was not found on this server.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_api_course_run_read_list_authenticated(self):
@@ -40,7 +41,7 @@ class CourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "The requested resource was not found on this server.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     @mock.patch.object(
@@ -66,7 +67,7 @@ class CourseRunApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(
@@ -117,7 +118,7 @@ class CourseRunApiTest(BaseAPITestCase):
         with self.assertNumQueries(1):
             response = self.client.get(f"/api/v1.0/course-runs/{course_run.id}/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -173,7 +174,7 @@ class CourseRunApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{courses[0].id}/course-runs/{course_run.id}/"
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -219,7 +220,7 @@ class CourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Not found.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_api_course_run_read_detail_not_listed_authenticated(self):
@@ -238,7 +239,7 @@ class CourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             "Not found.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_api_course_run_create_anonymous(self):
@@ -254,7 +255,7 @@ class CourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"POST\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         self.assertEqual(models.CourseRun.objects.count(), 0)
 
@@ -276,7 +277,7 @@ class CourseRunApiTest(BaseAPITestCase):
         self.assertContains(
             response,
             'Method \\"POST\\" not allowed.',
-            status_code=405,
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         self.assertEqual(models.CourseRun.objects.count(), 0)
 
@@ -299,7 +300,11 @@ class CourseRunApiTest(BaseAPITestCase):
 
         response = self.client.put(f"/api/v1.0/course-runs/{course_run.id}/", data=data)
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.resource_link,
@@ -331,7 +336,11 @@ class CourseRunApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
         course_run.refresh_from_db()
         self.assertEqual(
             course_run.resource_link,
@@ -353,7 +362,9 @@ class CourseRunApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         course_run.refresh_from_db()
         self.assertEqual(
@@ -380,7 +391,9 @@ class CourseRunApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         course_run.refresh_from_db()
         self.assertEqual(
@@ -395,7 +408,9 @@ class CourseRunApiTest(BaseAPITestCase):
         response = self.client.delete(f"/api/v1.0/course-runs/{course_run.id}/")
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         self.assertEqual(models.CourseRun.objects.count(), 1)
 
@@ -411,6 +426,8 @@ class CourseRunApiTest(BaseAPITestCase):
         )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
         self.assertEqual(models.CourseRun.objects.count(), 1)

--- a/src/backend/joanie/tests/core/test_api_course_wishes.py
+++ b/src/backend/joanie/tests/core/test_api_course_wishes.py
@@ -1,6 +1,8 @@
 """
 Test suite for wish API
 """
+from http import HTTPStatus
+
 import arrow
 
 from joanie.core import factories, models
@@ -16,7 +18,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
         course = factories.CourseFactory()
         response = self.client.get(f"/api/v1.0/courses/{course.id}/wish/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -29,7 +31,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION="Bearer nawak",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.json()["code"], "token_not_valid")
 
     def test_api_course_wish_get_expired_token(self):
@@ -45,7 +47,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.json()["code"], "token_not_valid")
 
     def test_api_course_wish_get_new_user(self):
@@ -64,7 +66,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json(), {"status": False})
         self.assertTrue(models.User.objects.filter(username=username).exists())
 
@@ -83,7 +85,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
         self.assertContains(
             response,
             "Not found.",
-            status_code=404,
+            status_code=HTTPStatus.NOT_FOUND,
         )
 
     def test_api_course_wish_get_existing(self):
@@ -99,7 +101,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json(), {"status": True})
 
     def test_api_course_wish_get_absent(self):
@@ -113,7 +115,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json(), {"status": False})
 
     def test_api_course_wish_create_anonymous(self):
@@ -124,7 +126,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{course.id}/wish/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -139,7 +141,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             content_type="application/json",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.json()["code"], "token_not_valid")
 
     def test_api_course_wish_create_with_expired_token(self):
@@ -157,7 +159,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.json()["code"], "token_not_valid")
 
     def test_api_course_wish_create_success(self):
@@ -172,7 +174,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json(), {"status": True})
 
     def test_api_course_wish_create_success_with_course_code(self):
@@ -187,7 +189,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json(), {"status": True})
 
     def test_api_course_wish_create_existing(self):
@@ -203,7 +205,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json(), {"status": True})
 
     def test_api_course_wish_update_success(self):
@@ -219,7 +221,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
     def test_api_course_wish_delete_anonymous(self):
@@ -231,7 +233,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             f"/api/v1.0/courses/{wish.course.id}/wish/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -247,7 +249,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION="Bearer nawak",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.json()["code"], "token_not_valid")
         self.assertTrue(models.CourseWish.objects.exists())
 
@@ -265,7 +267,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.json()["code"], "token_not_valid")
         self.assertTrue(models.CourseWish.objects.exists())
 
@@ -280,7 +282,7 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertFalse(models.CourseWish.objects.exists())
 
     def test_api_course_wish_delete_absent(self):
@@ -294,5 +296,5 @@ class CourseWishAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertFalse(models.CourseWish.objects.exists())

--- a/src/backend/joanie/tests/core/test_api_courses_contract.py
+++ b/src/backend/joanie/tests/core/test_api_courses_contract.py
@@ -24,7 +24,7 @@ class CourseContractApiTest(BaseAPITestCase):
         with self.assertNumQueries(0):
             response = self.client.get(f"/api/v1.0/courses/{str(course.id)}/contracts/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_courses_contracts_list_without_access(self):
         """
@@ -51,7 +51,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -115,7 +115,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         contracts = models.Contract.objects.filter(
             order__course=courses[0],
             order__state=enums.ORDER_STATE_VALIDATED,
@@ -292,7 +292,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{str(course.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_courses_contracts_retrieve_without_access(self):
         """
@@ -321,7 +321,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     @mock.patch.object(
         fields.ThumbnailDetailField,
@@ -368,7 +368,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         assert response.json() == {
             "id": str(contract.id),
@@ -479,7 +479,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, str(contract.id), status_code=200)
+        self.assertContains(response, str(contract.id), status_code=HTTPStatus.OK)
 
     def test_api_courses_contracts_create_anonymous(self):
         """Anonymous user cannot create an organization's contract."""
@@ -490,7 +490,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{str(course.id)}/contracts/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_courses_contracts_create_authenticated(self):
         """Authenticated user cannot create an organization's contract."""
@@ -504,7 +504,11 @@ class CourseContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_courses_contracts_update_anonymous(self):
         """Anonymous user cannot update an organization's contract."""
@@ -516,7 +520,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{str(course.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_courses_contracts_update_authenticated(self):
         """Authenticated user cannot update an organization's contract."""
@@ -531,7 +535,11 @@ class CourseContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_courses_contracts_patch_anonymous(self):
         """Anonymous user cannot patch an organization's contract."""
@@ -543,7 +551,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{str(course.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_courses_contracts_patch_authenticated(self):
         """Authenticated user cannot patch an organization's contract."""
@@ -559,7 +567,9 @@ class CourseContractApiTest(BaseAPITestCase):
             )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_courses_contracts_delete_anonymous(self):
@@ -572,7 +582,7 @@ class CourseContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/courses/{str(course.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_courses_contracts_delete_authenticated(self):
         """Authenticated user cannot delete an organization's contract."""
@@ -588,5 +598,7 @@ class CourseContractApiTest(BaseAPITestCase):
             )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -4,6 +4,7 @@ import itertools
 import json
 import random
 import uuid
+from http import HTTPStatus
 from logging import Logger
 from unittest import mock
 
@@ -89,7 +90,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         response = self.client.get(
             "/api/v1.0/enrollments/",
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = json.loads(response.content)
 
         self.assertDictEqual(
@@ -117,7 +118,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -189,7 +190,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertDictEqual(
             response.json(),
@@ -308,7 +309,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = json.loads(response.content)
         self.assertEqual(len(content["results"]), 3)
 
@@ -404,7 +405,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = json.loads(response.content)
 
         self.assertEqual(len(content["results"]), 1)
@@ -433,7 +434,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
         self.assertEqual(
@@ -452,7 +453,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -491,7 +492,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -564,7 +565,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertDictEqual(
             response.json(), {"course_run_id": ["Enter a valid UUID."]}
         )
@@ -601,7 +602,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 2)
 
@@ -611,7 +612,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 1)
 
@@ -623,7 +624,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         )
 
         response = self.client.get(f"/api/v1.0/enrollments/{enrollment.id}/")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(),
@@ -662,7 +663,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         self.assertDictEqual(
             response.json(),
@@ -734,7 +735,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertListEqual(
@@ -792,7 +793,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
         self.assertDictEqual(response.json(), {"detail": "Not found."})
 
@@ -803,7 +804,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         response = self.client.post(
             "/api/v1.0/enrollments/", data=data, content_type="application/json"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
@@ -840,7 +841,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         content = response.json()
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
@@ -932,7 +933,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(),
@@ -974,7 +975,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
         self.assertFalse(mock_set.called)
@@ -1068,7 +1069,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
         enrollment = models.Enrollment.objects.get()
@@ -1137,7 +1138,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(),
@@ -1160,7 +1161,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(),
@@ -1192,7 +1193,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(),
@@ -1232,7 +1233,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         course_run_id = target_course_runs[0].id
         self.assertDictEqual(
@@ -1266,7 +1267,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         course_run_id = target_course_runs[0].id
         self.assertDictEqual(
@@ -1313,7 +1314,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             data=data,
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
 
         self.assertEqual(models.Enrollment.objects.count(), 1)
         enrollment = models.Enrollment.objects.get()
@@ -1390,7 +1391,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(),
@@ -1420,7 +1421,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(),
@@ -1451,7 +1452,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         self.assertDictEqual(
             response.json(),
@@ -1467,7 +1468,7 @@ class EnrollmentApiTest(BaseAPITestCase):
 
         response = self.client.delete(f"/api/v1.0/enrollments/{enrollment.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
         self.assertDictEqual(
             response.json(),
@@ -1495,7 +1496,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Enrollment.objects.count(), 1)
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment")
@@ -1510,7 +1511,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             f"/api/v1.0/enrollments/{enrollment.id}/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Enrollment.objects.count(), 1)
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment")
@@ -1538,7 +1539,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 data={"state": new_state[0]},
                 content_type="application/json",
             )
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
             self.assertDictEqual(
                 response.json(),
@@ -1577,7 +1578,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-            self.assertEqual(response.status_code, 404)
+            self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
             self.assertDictEqual(response.json(), {"detail": "Not found."})
 
@@ -1612,7 +1613,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
 
             self.assertDictEqual(
                 response.json(),
@@ -1725,7 +1726,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         actual_data = json.loads(response.content)
         self.assertEqual(
             actual_data.pop("state"),
-            "set" if http_code == 200 else initial_data["state"],
+            "set" if http_code == HTTPStatus.OK else initial_data["state"],
         )
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment", return_value="enrolled")
@@ -1750,7 +1751,9 @@ class EnrollmentApiTest(BaseAPITestCase):
             is_active=True,
             was_created_by_order=True,
         )
-        self._check_api_enrollment_update_detail(enrollment, None, 401)
+        self._check_api_enrollment_update_detail(
+            enrollment, None, HTTPStatus.UNAUTHORIZED
+        )
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment", return_value="enrolled")
     def test_api_enrollment_update_detail_authenticated_superuser(self, _mock_set):
@@ -1776,7 +1779,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             is_active=True,
             was_created_by_order=True,
         )
-        self._check_api_enrollment_update_detail(enrollment, user, 404)
+        self._check_api_enrollment_update_detail(enrollment, user, HTTPStatus.NOT_FOUND)
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment", return_value="enrolled")
     def test_api_enrollment_update_detail_authenticated_owner(self, _mock_set):
@@ -1800,7 +1803,7 @@ class EnrollmentApiTest(BaseAPITestCase):
         enrollment = factories.EnrollmentFactory(
             course_run=course_run1, user=user, is_active=True, was_created_by_order=True
         )
-        self._check_api_enrollment_update_detail(enrollment, user, 200)
+        self._check_api_enrollment_update_detail(enrollment, user, HTTPStatus.OK)
 
     @mock.patch.object(OpenEdXLMSBackend, "set_enrollment", return_value="enrolled")
     @mock.patch.object(
@@ -1832,7 +1835,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {user_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -1917,7 +1920,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {user_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -1994,7 +1997,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {user_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -2089,7 +2092,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {user_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -2155,7 +2158,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {user_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {

--- a/src/backend/joanie/tests/core/test_api_organization_accesses.py
+++ b/src/backend/joanie/tests/core/test_api_organization_accesses.py
@@ -2,6 +2,7 @@
 Tests organization access API endpoints in Joanie's core app.
 """
 import random
+from http import HTTPStatus
 from unittest import mock
 from uuid import uuid4
 
@@ -27,7 +28,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
         response = self.client.get(
             f"/api/v1.0/organizations/{access.organization.id!s}/accesses/"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -54,7 +55,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json()["results"], [])
 
     def test_api_organization_accesses_list_authenticated_member(self):
@@ -106,7 +107,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 4)
         self.assertCountEqual(
@@ -164,7 +165,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 5)
         self.assertCountEqual(
@@ -222,7 +223,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 5)
         self.assertCountEqual(
@@ -255,7 +256,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id!s}/accesses/",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -275,7 +276,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -300,7 +301,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/organizations/{access.organization.id!s}/accesses/{access.id!s}/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -324,7 +325,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 f"/api/v1.0/organizations/{organization.id!s}/accesses/{access.id!s}/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             self.assertEqual(
                 response.json(),
                 {"detail": "You do not have permission to perform this action."},
@@ -351,7 +352,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 f"/api/v1.0/organizations/{organization.id!s}/accesses/{access.id!s}/",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertTrue(content.pop("abilities")["get"])
             self.assertEqual(
@@ -383,7 +384,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertTrue(content.pop("abilities")["get"])
             self.assertEqual(
@@ -415,7 +416,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
             content = response.json()
             self.assertTrue(content.pop("abilities")["get"])
             self.assertEqual(
@@ -444,7 +445,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     # Create
 
@@ -460,7 +461,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 "role": random.choice(["member", "administrator", "owner"]),
             },
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -481,7 +482,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(
             response.json(),
             {
@@ -511,7 +512,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(
             response.json(),
             {
@@ -541,7 +542,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertEqual(OrganizationAccess.objects.count(), 2)
         self.assertTrue(OrganizationAccess.objects.filter(user=other_user).exists())
 
@@ -563,7 +564,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             },
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertFalse(OrganizationAccess.objects.filter(user=other_user).exists())
 
     def test_api_organization_accesses_create_owner_all_roles(self):
@@ -587,7 +588,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
 
-            self.assertEqual(response.status_code, 201)
+            self.assertEqual(response.status_code, HTTPStatus.CREATED)
             self.assertEqual(OrganizationAccess.objects.count(), i + 2)
             self.assertTrue(OrganizationAccess.objects.filter(user=other_user).exists())
 
@@ -611,7 +612,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 data={**old_values, field: value},
                 content_type="application/json",
             )
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -640,7 +641,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -673,7 +674,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -713,9 +714,9 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             if (
                 new_data["role"] == old_values["role"]
             ):  # we are not not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
@@ -756,7 +757,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -796,9 +797,9 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             )
             # We are not allowed or not really updating the role
             if field == "role" or new_data["role"] == old_values["role"]:
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
@@ -839,9 +840,9 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             if (
                 new_data["role"] == old_values["role"]
             ):  # we are not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
@@ -882,7 +883,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -908,7 +909,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         access.refresh_from_db()
         self.assertEqual(access.role, "owner")
 
@@ -922,7 +923,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         access.refresh_from_db()
         self.assertEqual(access.role, new_role)
 
@@ -946,7 +947,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 data={field: value},
                 content_type="application/json",
             )
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -975,7 +976,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1008,7 +1009,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1046,9 +1047,9 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
             if field == "role" and value == old_values["role"]:
                 # We are not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
@@ -1089,7 +1090,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1127,9 +1128,9 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
             if field == "role":
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1167,9 +1168,9 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
 
             if field == "role" and value == old_values["role"]:
                 # We are not really updating the role
-                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             else:
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
 
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
@@ -1210,7 +1211,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
                 content_type="application/json",
                 HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
             )
-            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
             access.refresh_from_db()
             updated_values = OrganizationAccessSerializer(instance=access).data
             self.assertEqual(updated_values, old_values)
@@ -1235,7 +1236,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         access.refresh_from_db()
         self.assertEqual(access.role, "owner")
 
@@ -1249,7 +1250,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         access.refresh_from_db()
         self.assertEqual(access.role, new_role)
 
@@ -1263,7 +1264,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             f"/api/v1.0/organizations/{access.organization.id!s}/accesses/{access.id!s}/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(OrganizationAccess.objects.count(), 1)
 
     def test_api_organization_accesses_delete_authenticated(self):
@@ -1280,7 +1281,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(OrganizationAccess.objects.count(), 1)
 
     def test_api_organization_accesses_delete_members(self):
@@ -1301,7 +1302,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(OrganizationAccess.objects.count(), 2)
 
     def test_api_organization_accesses_delete_administrators(self):
@@ -1324,7 +1325,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(OrganizationAccess.objects.count(), 1)
 
     def test_api_organization_accesses_delete_owners_except_owners(self):
@@ -1347,7 +1348,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
         self.assertEqual(OrganizationAccess.objects.count(), 1)
 
     def test_api_organization_accesses_delete_owners_for_owners(self):
@@ -1370,7 +1371,7 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(OrganizationAccess.objects.count(), 2)
 
     def test_api_organization_accesses_delete_owners_last_owner(self):
@@ -1391,5 +1392,5 @@ class OrganizationAccessesAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(OrganizationAccess.objects.count(), 1)

--- a/src/backend/joanie/tests/core/test_api_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations.py
@@ -25,7 +25,7 @@ class OrganizationApiTest(BaseAPITestCase):
         factories.OrganizationFactory()
         response = self.client.get("/api/v1.0/organizations/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -52,7 +52,7 @@ class OrganizationApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         results = response.json()["results"]
         self.assertEqual(len(results), 2)
         self.assertCountEqual(
@@ -80,7 +80,7 @@ class OrganizationApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -124,7 +124,7 @@ class OrganizationApiTest(BaseAPITestCase):
 
         response = self.client.get(f"/api/v1.0/organizations/{organization.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -144,7 +144,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertEqual(response.json(), {"detail": "Not found."})
 
     @mock.patch.object(
@@ -168,7 +168,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertTrue(content.pop("abilities")["get"])
         self.assertEqual(
@@ -192,7 +192,7 @@ class OrganizationApiTest(BaseAPITestCase):
 
         response = self.client.post("/api/v1.0/organizations/", data=data)
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertFalse(models.Organization.objects.exists())
 
     def test_api_organization_create_authenticated(self):
@@ -216,7 +216,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertFalse(models.Organization.objects.exists())
 
     def test_api_organization_update_anonymous(self):
@@ -234,7 +234,7 @@ class OrganizationApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/", data=data
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -266,7 +266,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
         organization.refresh_from_db()
@@ -302,7 +302,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(response.json(), {"detail": 'Method "PUT" not allowed.'})
 
         organization.refresh_from_db()
@@ -317,7 +317,7 @@ class OrganizationApiTest(BaseAPITestCase):
 
         response = self.client.delete(f"/api/v1.0/organizations/{organization.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(models.Organization.objects.count(), 1)
 
     def test_api_organization_delete_authenticated_no_access(self):
@@ -337,7 +337,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Organization.objects.count(), 1)
 
     def test_api_organization_delete_authenticated_with_access(self):
@@ -363,7 +363,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertEqual(models.Organization.objects.count(), 1)
 
     def test_api_organization_contracts_signature_link_without_owner(self):
@@ -427,7 +427,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertIn(
             "https://dummysignaturebackend.fr/?requestToken=",
@@ -462,7 +462,7 @@ class OrganizationApiTest(BaseAPITestCase):
             data={"contract_ids": [order.contract.id]},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertIn(
             "https://dummysignaturebackend.fr/?requestToken=",
@@ -515,7 +515,7 @@ class OrganizationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         assert response.json() == {
             "detail": "No contract to sign for this organization."
         }

--- a/src/backend/joanie/tests/core/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_contract.py
@@ -28,7 +28,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_contracts_list_without_access(self):
         """
@@ -55,7 +55,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertDictEqual(
             response.json(),
             {
@@ -115,7 +115,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         contracts = models.Contract.objects.filter(
             order__organization=organizations[0],
             order__state=enums.ORDER_STATE_VALIDATED,
@@ -230,7 +230,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 9)
 
@@ -244,7 +244,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -263,7 +263,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -279,7 +279,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         count = content["count"]
         result_ids = [result["id"] for result in content["results"]]
@@ -298,7 +298,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_contracts_retrieve_without_access(self):
         """
@@ -324,7 +324,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     @mock.patch.object(
         fields.ThumbnailDetailField,
@@ -370,7 +370,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         assert response.json() == {
             "id": str(contract.id),
@@ -493,7 +493,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, str(contract.id), status_code=200)
+        self.assertContains(response, str(contract.id), status_code=HTTPStatus.OK)
 
     def test_api_organizations_contracts_create_anonymous(self):
         """Anonymous user cannot create an organization's contract."""
@@ -504,7 +504,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_contracts_create_authenticated(self):
         """Authenticated user cannot create an organization's contract."""
@@ -518,7 +518,11 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_organizations_contracts_update_anonymous(self):
         """Anonymous user cannot update an organization's contract."""
@@ -530,7 +534,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_contracts_update_authenticated(self):
         """Authenticated user cannot update an organization's contract."""
@@ -545,7 +549,11 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertContains(response, 'Method \\"PUT\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"PUT\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
 
     def test_api_organizations_contracts_patch_anonymous(self):
         """Anonymous user cannot patch an organization's contract."""
@@ -557,7 +565,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_contracts_patch_authenticated(self):
         """Authenticated user cannot patch an organization's contract."""
@@ -573,7 +581,9 @@ class OrganizationContractApiTest(BaseAPITestCase):
             )
 
         self.assertContains(
-            response, 'Method \\"PATCH\\" not allowed.', status_code=405
+            response,
+            'Method \\"PATCH\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
     def test_api_organizations_contracts_delete_anonymous(self):
@@ -586,7 +596,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/{str(contract.id)}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_contracts_delete_authenticated(self):
         """Authenticated user cannot delete an organization's contract."""
@@ -602,5 +612,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             )
 
         self.assertContains(
-            response, 'Method \\"DELETE\\" not allowed.', status_code=405
+            response,
+            'Method \\"DELETE\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
         )

--- a/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_course_product_relations.py
@@ -1,6 +1,7 @@
 """
 Test suite for Organization's CourseProductRelation API endpoint.
 """
+from http import HTTPStatus
 
 from joanie.core import factories, models
 from joanie.tests.base import BaseAPITestCase
@@ -32,7 +33,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/",
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_course_product_relations_read_list_with_accesses(self):
         """
@@ -67,7 +68,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 5)
         self.assertEqual(
@@ -100,7 +101,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 0)
 
@@ -126,7 +127,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                 f"{relations[0].id}/"
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_organizations_course_product_relations_read_details_with_accesses(
         self,
@@ -169,7 +170,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(str(relations[0].id), content["id"])
 
@@ -202,7 +203,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                 ),
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_organizations_course_product_relations_create_authenticated(self):
         """
@@ -224,7 +225,11 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertContains(response, 'Method \\"POST\\" not allowed.', status_code=405)
+        self.assertContains(
+            response,
+            'Method \\"POST\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
         self.assertEqual(models.CourseProductRelation.objects.count(), 0)
 
     def test_api_organizations_course_product_relations_create_anonymous(self):
@@ -244,7 +249,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(models.CourseProductRelation.objects.count(), 0)
 
     def test_api_organizations_course_product_relations_update_authenticated(self):
@@ -270,7 +275,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         relation.refresh_from_db()
         self.assertEqual(relation.course.id, course.id)
 
@@ -295,7 +300,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         relation.refresh_from_db()
         self.assertEqual(relation.course.id, course.id)
 
@@ -321,7 +326,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         relation.refresh_from_db()
         self.assertEqual(relation.course.id, course.id)
 
@@ -345,7 +350,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         relation.refresh_from_db()
         self.assertEqual(relation.course.id, course.id)
 
@@ -368,7 +373,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertTrue(
             models.CourseProductRelation.objects.filter(id=relation.id).exists()
         )
@@ -390,7 +395,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/course-product-relations/{relation.id}/",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertTrue(
             models.CourseProductRelation.objects.filter(id=relation.id).exists()
         )

--- a/src/backend/joanie/tests/core/test_api_organizations_courses.py
+++ b/src/backend/joanie/tests/core/test_api_organizations_courses.py
@@ -1,8 +1,8 @@
 """
 Test suite for Organization's courses API endpoint.
 """
-
 import random
+from http import HTTPStatus
 
 from joanie.core import factories, models
 from joanie.tests.base import BaseAPITestCase
@@ -23,7 +23,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         response = self.client.get(
             f"/api/v1.0/organizations/{organization.id}/courses/"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content, {"detail": "Authentication credentials were not provided."}
@@ -68,7 +68,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             )
 
         # It should return all courses from the first org
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
         self.assertEqual(
@@ -105,7 +105,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 0)
 
@@ -114,7 +114,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 0)
 
@@ -124,7 +124,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 0)
 
@@ -133,7 +133,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{organizations[1].id}/courses/{courses[0].id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_organizations_courses_read_details_authenticated(self):
         """
@@ -159,7 +159,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["id"], str(courses[0].id))
 
@@ -185,7 +185,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_organizations_courses_read_details_anonymous(self):
         """
@@ -206,7 +206,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
                 f"/api/v1.0/organizations/{organizations[0].id}/courses/{courses[0].id}/",
             )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         content = response.json()
         self.assertEqual(
             content, {"detail": "Authentication credentials were not provided."}
@@ -246,7 +246,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         # It should return only the course with a listed CourseRun
         self.assertEqual(content["count"], 1)
@@ -274,7 +274,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertFalse(models.Course.objects.exists())
 
     def test_api_organizations_courses_create_anonymous(self):
@@ -293,7 +293,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             data=data,
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -317,7 +317,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertFalse(models.Course.objects.filter(code="notacode").exists())
 
         course.refresh_from_db()
@@ -339,7 +339,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/courses/{course.id}/", data=data
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -366,7 +366,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertFalse(models.Course.objects.filter(code="notacode").exists())
 
         course.refresh_from_db()
@@ -387,7 +387,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/courses/{course.id}/", data=data
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )
@@ -410,7 +410,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertTrue(models.Course.objects.filter(id=course.id).exists())
 
     def test_api_organizations_courses_delete_anonymous(self):
@@ -424,7 +424,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
             f"/api/v1.0/organizations/{organization.id}/courses/{course.id}/"
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.json(), {"detail": "Authentication credentials were not provided."}
         )

--- a/src/backend/joanie/tests/core/test_api_users.py
+++ b/src/backend/joanie/tests/core/test_api_users.py
@@ -1,6 +1,7 @@
 """
 Test suite for User API.
 """
+from http import HTTPStatus
 
 from joanie.core import factories
 from joanie.tests.base import BaseAPITestCase
@@ -18,7 +19,7 @@ class UserApiTest(BaseAPITestCase):
         factories.UserFactory()
         response = self.client.get("/api/v1.0/users/me/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_user_root_route(self):
         """
@@ -32,7 +33,7 @@ class UserApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_user_me_no_access(self):
         """
@@ -46,7 +47,7 @@ class UserApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -80,7 +81,7 @@ class UserApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {
@@ -114,7 +115,7 @@ class UserApiTest(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {jwt_token}",
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
             {

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -5,6 +5,7 @@ Test suite for order models
 import json
 import random
 from datetime import timedelta
+from http import HTTPStatus
 from unittest import mock
 
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -794,7 +795,7 @@ class OrderModelsTestCase(TestCase):
         responses.add(
             responses.POST,
             url,
-            status=200,
+            status=HTTPStatus.OK,
             json={"is_active": enrollment.is_active},
         )
 
@@ -867,7 +868,7 @@ class OrderModelsTestCase(TestCase):
         responses.add(
             responses.POST,
             url,
-            status=200,
+            status=HTTPStatus.OK,
             json={"is_active": enrollment.is_active},
         )
 

--- a/src/backend/joanie/tests/core/test_utils_webhooks_synchronize_course_runs.py
+++ b/src/backend/joanie/tests/core/test_utils_webhooks_synchronize_course_runs.py
@@ -4,6 +4,7 @@ Test suite for the "synchronize_course_runs" utility
 import json
 import random
 import re
+from http import HTTPStatus
 from logging import Logger
 from unittest import mock
 
@@ -61,7 +62,7 @@ class SynchronizeCourseRunsUtilsTestCase(TestCase):
             rsp = rsps.post(
                 re.compile("http://richie.education/webhook{1}"),
                 body="{}",
-                status=200,
+                status=HTTPStatus.OK,
                 content_type="application/json",
             )
 
@@ -145,7 +146,13 @@ class SynchronizeCourseRunsUtilsTestCase(TestCase):
             rsp = rsps.post(
                 re.compile("http://richie.education/webhook"),
                 body="{}",
-                status=random.choice([404, 502, 301]),
+                status=random.choice(
+                    [
+                        HTTPStatus.NOT_FOUND,
+                        HTTPStatus.BAD_GATEWAY,
+                        HTTPStatus.MOVED_PERMANENTLY,
+                    ]
+                ),
                 content_type="application/json",
             )
 
@@ -216,10 +223,10 @@ class SynchronizeCourseRunsUtilsTestCase(TestCase):
             # Make webhook fail 3 times before succeeding using "responses"
             url = "http://richie.education/webhook"
             all_rsps = [
-                rsps.post(url, status=500),
-                rsps.post(url, status=500),
-                rsps.post(url, status=500),
-                rsps.post(url, status=200),
+                rsps.post(url, status=HTTPStatus.INTERNAL_SERVER_ERROR),
+                rsps.post(url, status=HTTPStatus.INTERNAL_SERVER_ERROR),
+                rsps.post(url, status=HTTPStatus.INTERNAL_SERVER_ERROR),
+                rsps.post(url, status=HTTPStatus.OK),
             ]
 
             webhooks.synchronize_course_runs([self._get_serialized_course_run(1)])
@@ -255,7 +262,7 @@ class SynchronizeCourseRunsUtilsTestCase(TestCase):
             rsp = rsps.post(
                 re.compile("http://richie.education/webhook"),
                 body="{}",
-                status=500,
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
                 content_type="application/json",
             )
 

--- a/src/backend/joanie/tests/core/test_views_backoffice_redirect.py
+++ b/src/backend/joanie/tests/core/test_views_backoffice_redirect.py
@@ -1,4 +1,5 @@
 """BackOfficeRedirectView test suite."""
+from http import HTTPStatus
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -21,7 +22,7 @@ class BackofficeRedirectViewTestCase(TestCase):
 
         response = self.client.get(url)
 
-        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.status_code, HTTPStatus.MOVED_PERMANENTLY)
         self.assertEqual(
             response["Location"],
             "https://bo.joanie.test/admin/core/organizations/",

--- a/src/backend/joanie/tests/lms_handler/test_api_course_run_sync_edx.py
+++ b/src/backend/joanie/tests/lms_handler/test_api_course_run_sync_edx.py
@@ -2,6 +2,7 @@
 Tests for CourseRun web hook.
 """
 import json
+from http import HTTPStatus
 
 from django.conf import settings
 from django.test import TestCase, override_settings
@@ -42,7 +43,7 @@ class SyncCourseRunApiTestCase(TestCase):
             "/api/v1.0/course-runs-sync", data, content_type="application/json"
         )
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
         self.assertEqual(json.loads(response.content), "Missing authentication.")
         self.assertEqual(CourseRun.objects.count(), 0)
         self.assertEqual(Course.objects.count(), 0)
@@ -65,7 +66,7 @@ class SyncCourseRunApiTestCase(TestCase):
             HTTP_AUTHORIZATION=("invalid authorization"),
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(json.loads(response.content), "Invalid authentication.")
         self.assertEqual(CourseRun.objects.count(), 0)
         self.assertEqual(Course.objects.count(), 0)
@@ -92,7 +93,7 @@ class SyncCourseRunApiTestCase(TestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             json.loads(response.content), {"resource_link": ["This field is required."]}
         )
@@ -123,7 +124,7 @@ class SyncCourseRunApiTestCase(TestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             json.loads(response.content),
             {
@@ -162,7 +163,7 @@ class SyncCourseRunApiTestCase(TestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 
@@ -200,7 +201,7 @@ class SyncCourseRunApiTestCase(TestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 
@@ -238,7 +239,7 @@ class SyncCourseRunApiTestCase(TestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 
@@ -269,7 +270,7 @@ class SyncCourseRunApiTestCase(TestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             json.loads(response.content), {"languages": ["This field is required."]}
         )
@@ -296,7 +297,7 @@ class SyncCourseRunApiTestCase(TestCase):
                 "SIG-HMAC-SHA256 313cefea7a14f26ed7dc249719bc5a86bce36b0c63a9d27b2e30e3a616e108d6"
             ),
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 
@@ -334,7 +335,7 @@ class SyncCourseRunApiTestCase(TestCase):
             ),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 
@@ -365,7 +366,7 @@ class SyncCourseRunApiTestCase(TestCase):
                 "SIG-HMAC-SHA256 1de9b46133a91eec3515d0df40f586b642cff16b79aa9d5fe4f7679a33767967"
             ),
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 
@@ -419,7 +420,7 @@ class SyncCourseRunApiTestCase(TestCase):
                 "SIG-HMAC-SHA256 338f7c262254e8220fea54467526f8f1f4562ee3adf1e3a71abaf23a20b739e4"
             ),
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content), {"success": True})
         self.assertEqual(CourseRun.objects.count(), 1)
 

--- a/src/backend/joanie/tests/lms_handler/test_backend_openedx.py
+++ b/src/backend/joanie/tests/lms_handler/test_backend_openedx.py
@@ -2,6 +2,7 @@
 import json
 import random
 from datetime import timedelta
+from http import HTTPStatus
 
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -66,7 +67,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
         responses.add(
             responses.GET,
             url,
-            status=200,
+            status=HTTPStatus.OK,
             json=expected_json_response,
         )
 
@@ -97,7 +98,10 @@ class OpenEdXLMSBackendTestCase(TestCase):
         )
 
         responses.add(
-            responses.GET, url, status=500, json={"error": "Something went wrong..."}
+            responses.GET,
+            url,
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+            json={"error": "Something went wrong..."},
         )
 
         backend = LMSHandler.select_lms(resource_link)
@@ -137,7 +141,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
         responses.add(
             responses.POST,
             url,
-            status=200,
+            status=HTTPStatus.OK,
             json={"is_active": is_active},
         )
 
@@ -172,7 +176,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
         responses.add(
             responses.POST,
             url,
-            status=200,
+            status=HTTPStatus.OK,
             json={"is_active": True},
         )
 
@@ -236,7 +240,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
         responses.add(
             responses.POST,
             url,
-            status=200,
+            status=HTTPStatus.OK,
             json={"is_active": is_active},
         )
 
@@ -328,7 +332,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
         responses.add(
             responses.POST,
             url,
-            status=200,
+            status=HTTPStatus.OK,
             json=expected_json_response,
         )
 
@@ -377,7 +381,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
         responses.add(
             responses.POST,
             url,
-            status=500,
+            status=HTTPStatus.INTERNAL_SERVER_ERROR,
             json={"is_active": is_active},
         )
 
@@ -422,7 +426,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
             "percent": 1.0 if grade_state else 0.0,
         }
 
-        responses.add(responses.GET, url, status=200, json=expected_response)
+        responses.add(responses.GET, url, status=HTTPStatus.OK, json=expected_response)
 
         backend = LMSHandler.select_lms(resource_link)
         self.assertIsInstance(backend, OpenEdXLMSBackend)
@@ -448,7 +452,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
         resource_link = f"http://openedx.test/courses/{course_id}/course"
         url = f"http://openedx.test/fun/api/grades/{course_id}/{username}"
 
-        responses.add(responses.GET, url, status=500)
+        responses.add(responses.GET, url, status=HTTPStatus.INTERNAL_SERVER_ERROR)
 
         backend = LMSHandler.select_lms(resource_link)
         self.assertIsInstance(backend, OpenEdXLMSBackend)

--- a/src/backend/joanie/tests/payment/test_admin_invoice.py
+++ b/src/backend/joanie/tests/payment/test_admin_invoice.py
@@ -1,4 +1,6 @@
 """Invoice admin test suite"""
+from http import HTTPStatus
+
 from django.test import TestCase
 from django.urls import reverse
 
@@ -31,7 +33,7 @@ class InvoiceAdminTestCase(TestCase):
             reverse("admin:payment_invoice_change", args=(credit_note.pk,)),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         html_parser = lxml.html.HTMLParser(encoding="utf-8")
         html = lxml.html.fromstring(response.content, parser=html_parser)
@@ -58,7 +60,7 @@ class InvoiceAdminTestCase(TestCase):
             reverse("admin:payment_invoice_change", args=(order.main_invoice.pk,)),
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         html_parser = lxml.html.HTMLParser(encoding="utf-8")
         html = lxml.html.fromstring(response.content, parser=html_parser)
@@ -97,7 +99,7 @@ class InvoiceAdminTestCase(TestCase):
 
         # - Invoice are ordered by creation date
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, order.main_invoice.reference)
 
         # - Check there are links to go to invoice children admin change view
@@ -145,7 +147,7 @@ class InvoiceAdminTestCase(TestCase):
 
         # - Invoice are ordered by creation date
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # - Check there are links to go to invoice children admin change view
         html_parser = lxml.html.HTMLParser(encoding="utf-8")

--- a/src/backend/joanie/tests/payment/test_api_credit_card.py
+++ b/src/backend/joanie/tests/payment/test_api_credit_card.py
@@ -1,6 +1,7 @@
 """
 Test suite for the Credit Card API
 """
+from http import HTTPStatus
 from unittest import mock
 
 from django.test.utils import override_settings
@@ -21,7 +22,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
     def test_api_credit_card_get_credit_cards_without_authorization(self):
         """Retrieve credit cards without authorization header is forbidden."""
         response = self.client.get("/api/v1.0/credit-cards/")
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(
             response.data, {"detail": "Authentication credentials were not provided."}
         )
@@ -31,7 +32,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         response = self.client.get(
             "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION="Bearer invalid_token"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.data["code"], "token_not_valid")
 
     def test_api_credit_card_get_credit_cards_with_expired_token(self):
@@ -43,7 +44,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         response = self.client.get(
             "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
         self.assertEqual(response.data["code"], "token_not_valid")
 
     def test_api_credit_card_get_credit_cards_for_new_user(self):
@@ -57,7 +58,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         response = self.client.get(
             "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(), {"count": 0, "next": None, "previous": None, "results": []}
         )
@@ -72,7 +73,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         response = self.client.get(
             "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         results = content.pop("results")
         cards.sort(key=lambda card: card.created_on, reverse=True)
@@ -100,7 +101,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertEqual(content["count"], 3)
         self.assertEqual(
@@ -117,7 +118,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             "/api/v1.0/credit-cards/?page=2", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
 
         self.assertEqual(content["count"], 3)
@@ -139,7 +140,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         response = self.client.get(
             f"/api/v1.0/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # - All fields except token has been serialized
         self.assertEqual(
@@ -164,7 +165,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         response = self.client.get(
             f"/api/v1.0/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_credit_card_get_not_owned_credit_card(self):
         """
@@ -178,7 +179,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         response = self.client.get(
             f"/api/v1.0/credit-cards/{card.id}/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_credit_card_create_credit_card_is_not_allowed(self):
         """Create a credit card is not allowed."""
@@ -187,7 +188,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             "/api/v1.0/credit-cards/", HTTP_AUTHORIZATION=f"Bearer {token}"
         )
 
-        self.assertEqual(response.status_code, 405)
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
 
     def test_api_credit_card_update_without_authorization(self):
         """Update a credit card without authorization header is forbidden."""
@@ -198,7 +199,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             data={"title": "Card title updated"},
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_credit_card_update_with_expired_token(self):
         """Update a credit card with an expired token is forbidden."""
@@ -215,7 +216,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             data={"title": "Card title updated"},
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_credit_card_update_with_bad_payload(self):
         """
@@ -231,7 +232,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             data=[],
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             response.data,
             {
@@ -253,7 +254,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             data={"title": "Credit card title updated!"},
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_api_credit_card_demote_credit_card_is_forbidden(self):
         """Demote a main credit card is forbidden"""
@@ -267,7 +268,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             data={"is_main": False},
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(
             response.data, {"__all__": ["Demote a main credit card is forbidden"]}
         )
@@ -286,7 +287,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             data={"is_main": True},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # - Before update state
         self.assertTrue(main_card.is_main)
@@ -321,7 +322,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             },
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # - Only title has been updated
         card.refresh_from_db()
@@ -336,7 +337,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
         card = CreditCardFactory()
         response = self.client.delete(f"/api/v1.0/credit-cards/{card.id}/")
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_credit_card_delete_with_invalid_authorization(self):
         """Delete credit card with invalid authorization header is forbidden."""
@@ -346,7 +347,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION="Bearer invalid-token",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_credit_card_delete_with_expired_token(self):
         """Delete credit card with an expired token is forbidden."""
@@ -360,7 +361,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_api_credit_card_delete_with_bad_user(self):
         """Delete credit card not owned by the authenticated user is forbidden."""
@@ -371,7 +372,7 @@ class CreditCardAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     @override_settings(
         JOANIE_PAYMENT_BACKEND={
@@ -389,4 +390,4 @@ class CreditCardAPITestCase(BaseAPITestCase):
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
-        self.assertEqual(response.status_code, 204)
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)

--- a/src/backend/joanie/tests/payment/test_api_payment.py
+++ b/src/backend/joanie/tests/payment/test_api_payment.py
@@ -1,4 +1,5 @@
 """Test suite for the payment api"""
+from http import HTTPStatus
 from unittest import mock
 
 from django.test.utils import override_settings
@@ -32,7 +33,7 @@ class PaymentApiTestCase(BaseAPITestCase):
             data={"id": "pay_0000"},
         )
 
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
         self.assertEqual(response.data, "Payment does not exist")
         mock_notification.assert_called_once()
 
@@ -49,6 +50,6 @@ class PaymentApiTestCase(BaseAPITestCase):
             data={"id": "pay_0000"},
         )
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertIsNone(response.data)
         mock_notification.assert_called_once()

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_delete_signing_procedure.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_delete_signing_procedure.py
@@ -1,4 +1,6 @@
 """Test suite for the Lex Persona Signature Backend delete_signing_procedure"""
+from http import HTTPStatus
+
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -37,7 +39,7 @@ class LexPersonaBackendTestCase(TestCase):
             responses.DELETE,
             api_url,
             json=expected_response_data,
-            status=200,
+            status=HTTPStatus.OK,
         )
         result = backend.delete_signing_procedure(reference_id="wfl_id_fake")
 
@@ -63,7 +65,7 @@ class LexPersonaBackendTestCase(TestCase):
         responses.add(
             responses.DELETE,
             api_url,
-            status=404,
+            status=HTTPStatus.NOT_FOUND,
             json={
                 "status": 404,
                 "error": "Not Found",

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signature_invitation_link.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signature_invitation_link.py
@@ -1,4 +1,6 @@
 """Test suite for the Lex Persona Signature Backend get_signature_invitation_link"""
+from http import HTTPStatus
+
 from django.test import TestCase
 from django.test.utils import override_settings
 
@@ -33,7 +35,7 @@ class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):
             responses.POST,
             "https://lex_persona.test01.com/api/workflows/wfl_id_fake/invite",
             json={"inviteUrl": "https://example.com/invite?token=jwt_token"},
-            status=200,
+            status=HTTPStatus.OK,
             match=[
                 responses.matchers.header_matcher(
                     {
@@ -69,7 +71,7 @@ class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):
             responses.POST,
             "https://lex_persona.test01.com/api/requests/",
             json=expected_response_data,
-            status=200,
+            status=HTTPStatus.OK,
             match=[
                 responses.matchers.header_matcher(
                     {
@@ -111,7 +113,7 @@ class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):
             responses.POST,
             api_url,
             json={"error": "Failed to create invitation link"},
-            status=400,
+            status=HTTPStatus.BAD_REQUEST,
         )
         with self.assertRaises(exceptions.InvitationSignatureFailed) as context:
             backend.get_signature_invitation_link(
@@ -135,7 +137,7 @@ class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):
         responses.add(
             responses.POST,
             api_url,
-            status=404,
+            status=HTTPStatus.NOT_FOUND,
             json={
                 "status": 404,
                 "error": "Not Found",
@@ -150,7 +152,7 @@ class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):
             responses.POST,
             "https://lex_persona.test01.com/api/workflows/wfl_id_fake_not_exist/invite",
             json={"inviteUrl": "https://example.com/invite?token=jwt_token"},
-            status=200,
+            status=HTTPStatus.OK,
         )
 
         with self.assertRaises(exceptions.InvitationSignatureFailed) as context:
@@ -200,7 +202,7 @@ class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):
             responses.POST,
             api_url,
             json=expected_response_data,
-            status=200,
+            status=HTTPStatus.OK,
         )
 
         # Managed invitation link
@@ -208,7 +210,7 @@ class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):
             responses.POST,
             "https://lex_persona.test01.com/api/workflows/wfl_id_fake/invite",
             json={"inviteUrl": "https://example.com/invite"},
-            status=200,
+            status=HTTPStatus.OK,
         )
 
         backend = get_signature_backend()

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signed_file.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signed_file.py
@@ -1,4 +1,6 @@
 """Test suite for the Lex Persona Signature Backend get_signed_file"""
+from http import HTTPStatus
+
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -31,7 +33,7 @@ class LexPersonaBackendGetSignedFileTestCase(TestCase):
         reference_id = "wlf_dummy_id"
         url = f"https://lex_persona.test01.com/api/workflows/{reference_id}/downloadDocuments"
         pdf_content = b"Simulated PDF content in bytes from signature provider"
-        responses.add(responses.GET, url, body=pdf_content, status=200)
+        responses.add(responses.GET, url, body=pdf_content, status=HTTPStatus.OK)
         signature_backend = get_signature_backend()
 
         pdf_data = signature_backend.get_signed_file(reference_id)
@@ -56,7 +58,12 @@ class LexPersonaBackendGetSignedFileTestCase(TestCase):
             "requestId": "796f8fe0-1934599",
             "code": "WorkflowNotFound",
         }
-        responses.add(responses.GET, url, json=expected_failing_response, status=404)
+        responses.add(
+            responses.GET,
+            url,
+            json=expected_failing_response,
+            status=HTTPStatus.BAD_REQUEST,
+        )
         signature_backend = get_signature_backend()
 
         with self.assertRaises(ValidationError) as context:

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
@@ -1,6 +1,7 @@
 """Test suite for the Lex Persona Signature Backend handle_notification"""
 import json
 from datetime import timedelta
+from http import HTTPStatus
 
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest
@@ -69,7 +70,9 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
             "created": 1693404075146,
             "updated": 1693404075146,
         }
-        responses.add(responses.GET, api_url, json=expected_response_data, status=200)
+        responses.add(
+            responses.GET, api_url, json=expected_response_data, status=HTTPStatus.OK
+        )
 
         backend = get_signature_backend()
 
@@ -129,7 +132,9 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
             "created": 1693404075146,
             "updated": 1693404075146,
         }
-        responses.add(responses.GET, api_url, json=expected_response_data, status=200)
+        responses.add(
+            responses.GET, api_url, json=expected_response_data, status=HTTPStatus.OK
+        )
         backend = get_signature_backend()
 
         with self.assertRaises(ValidationError) as context:
@@ -265,7 +270,12 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
             "code": "WebhookEventNotFound",
         }
 
-        responses.add(responses.GET, api_url, json=expected_response_data, status=400)
+        responses.add(
+            responses.GET,
+            api_url,
+            json=expected_response_data,
+            status=HTTPStatus.BAD_REQUEST,
+        )
         backend = get_signature_backend()
 
         with self.assertRaises(ValidationError) as context:
@@ -336,7 +346,9 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
             "created": 1693404075146,
             "updated": 1693404075146,
         }
-        responses.add(responses.GET, api_url, json=expected_response_data, status=200)
+        responses.add(
+            responses.GET, api_url, json=expected_response_data, status=HTTPStatus.OK
+        )
 
         backend = get_signature_backend()
 
@@ -404,7 +416,9 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
             "created": 1693404075146,
             "updated": 1693404075146,
         }
-        responses.add(responses.GET, api_url, json=expected_response_data, status=200)
+        responses.add(
+            responses.GET, api_url, json=expected_response_data, status=HTTPStatus.OK
+        )
 
         backend = get_signature_backend()
 
@@ -474,7 +488,9 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase):
             "created": 1693404075146,
             "updated": 1693404075146,
         }
-        responses.add(responses.GET, api_url, json=expected_response_data, status=200)
+        responses.add(
+            responses.GET, api_url, json=expected_response_data, status=HTTPStatus.OK
+        )
 
         backend = get_signature_backend()
 

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
@@ -1,4 +1,6 @@
 """Lex Persona backend test for submit_for_signature."""
+from http import HTTPStatus
+
 from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -99,7 +101,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.POST,
             create_workflow_api_url,
-            status=200,
+            status=HTTPStatus.OK,
             json=create_workflow_response_data,
             match=[
                 responses.matchers.header_matcher(
@@ -211,7 +213,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.POST,
             upload_file_api_url,
-            status=200,
+            status=HTTPStatus.OK,
             json=upload_file_response_data,
             match=[
                 responses.matchers.header_matcher(
@@ -239,7 +241,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.PATCH,
             start_procedure_api_url,
-            status=200,
+            status=HTTPStatus.OK,
             json=start_procedure_response_data,
             match=[
                 responses.matchers.header_matcher(
@@ -283,7 +285,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.POST,
             create_workflow_api_url,
-            status=400,
+            status=HTTPStatus.BAD_REQUEST,
             json={
                 "status": 400,
                 "error": "Bad Request",
@@ -384,7 +386,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.POST,
             create_workflow_api_url,
-            status=200,
+            status=HTTPStatus.OK,
             json=create_workflow_response_data,
         )
 
@@ -397,7 +399,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.POST,
             upload_file_api_url,
-            status=403,
+            status=HTTPStatus.FORBIDDEN,
             json={
                 "status": 403,
                 "error": "Forbidden",
@@ -511,7 +513,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.POST,
             create_workflow_api_url,
-            status=200,
+            status=HTTPStatus.OK,
             json=create_workflow_response_data,
         )
 
@@ -559,7 +561,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
         responses.add(
             responses.POST,
             upload_file_api_url,
-            status=200,
+            status=HTTPStatus.OK,
             json=upload_file_response_data,
         )
 
@@ -572,7 +574,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
             responses.PATCH,
             start_procedure_api_url,
             json={"workflowStatus": "started"},
-            status=400,
+            status=HTTPStatus.BAD_REQUEST,
         )
         with self.assertRaises(exceptions.StartSignatureProcedureFailed) as context:
             lex_persona_backend.submit_for_signature(

--- a/src/backend/joanie/tests/swagger/test_openapi_schema.py
+++ b/src/backend/joanie/tests/swagger/test_openapi_schema.py
@@ -2,6 +2,7 @@
 Test suite for generated openapi schema.
 """
 import json
+from http import HTTPStatus
 
 from django.test import TestCase
 
@@ -19,8 +20,10 @@ class OpenApiSchemaTest(TestCase):
         """
         response = self.client.get("/v1.0/swagger.json")
 
-        self.assertEqual(response.status_code, 200)
-        with open("joanie/tests/swagger/swagger.json") as expected_schema:
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        with open(
+            "joanie/tests/swagger/swagger.json", encoding="utf-8"
+        ) as expected_schema:
             assert response.json() == json.load(expected_schema)
 
     def test_openapi_admin_schema(self):
@@ -29,6 +32,8 @@ class OpenApiSchemaTest(TestCase):
         """
         response = self.client.get("/v1.0/admin-swagger.json")
 
-        self.assertEqual(response.status_code, 200)
-        with open("joanie/tests/swagger/admin-swagger.json") as expected_schema:
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        with open(
+            "joanie/tests/swagger/admin-swagger.json", encoding="utf-8"
+        ) as expected_schema:
             assert response.json() == json.load(expected_schema)

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -108,7 +108,7 @@ exclude = [
     "__pycache__",
     "*/migrations/*",
 ]
-ignore= ["DJ001", "PLR2004"]
+ignore= ["DJ001"]
 line-length = 88
 
 


### PR DESCRIPTION
## Purpose

We are currently using integer values to set or compare HTTP status. For most common codes, it is convenient but for unconventional code it can be harder to understand without extra check All tests, exceptions and views were updated.

## Proposal

Furthermore several linters enforce this convention :

- https://docs.astral.sh/ruff/rules/magic-value-comparison/
- https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/magic-value-comparison.html

The http package, provide an interface HTTPStatus which allow us to remove the use of integer values.

e.g. :
```python
from http import HTTPStatus

assert 200 == HTTPStatus.OK
```

- [x] Update every test suites
- [x] Update every views in `joanie.core.api.client` and `joanie.core.api.admin`, and other views.
- [x] Update every API exceptions
- [x] Update `pyproject.toml` to ignore `PLR2004` warnings (added : `# noqa : PLR2004` on leftover magic values)

