### PR TITLE
✨(backend) add contract_definition to product admin api

### DIFF
--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -219,6 +219,7 @@ class AdminProductSerializer(serializers.ModelSerializer):
             "type",
             "instructions",
             "certificate_definition",
+            "contract_definition",
             "target_courses",
         ]
         read_only_fields = ["id"]
@@ -248,19 +249,10 @@ class AdminProductLightSerializer(serializers.ModelSerializer):
             "price_currency",
             "type",
             "certificate_definition",
+            "contract_definition",
             "target_courses",
         ]
-        read_only_fields = [
-            "id",
-            "title",
-            "description",
-            "call_to_action",
-            "price",
-            "price_currency",
-            "type",
-            "certificate_definition",
-            "target_courses",
-        ]
+        read_only_fields = fields
 
     def get_price_currency(self, *args, **kwargs) -> str:
         """Return the code of currency used by the instance"""
@@ -767,7 +759,8 @@ class AdminProductTargetCourseRelationNestedSerializer(serializers.ModelSerializ
 class AdminProductDetailSerializer(serializers.ModelSerializer):
     """Serializer for Product details"""
 
-    certificate_definition = AdminCertificateDefinitionSerializer()
+    certificate_definition = AdminCertificateDefinitionSerializer(read_only=True)
+    contract_definition = AdminContractDefinitionSerializer(read_only=True)
     target_courses = serializers.SerializerMethodField(read_only=True)
     price = serializers.DecimalField(
         coerce_to_string=False, decimal_places=2, max_digits=9, min_value=0
@@ -786,6 +779,7 @@ class AdminProductDetailSerializer(serializers.ModelSerializer):
             "price",
             "price_currency",
             "certificate_definition",
+            "contract_definition",
             "target_courses",
             "course_relations",
             "instructions",

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
@@ -134,6 +134,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                         "title": product.certificate_definition.title,
                         "template": product.certificate_definition.template,
                     },
+                    "contract_definition": None,
                     "target_courses": [
                         {
                             "code": target_course.code,
@@ -346,6 +347,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                         "title": product.certificate_definition.title,
                         "template": product.certificate_definition.template,
                     },
+                    "contract_definition": None,
                     "target_courses": [
                         {
                             "code": target_course.code,

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
@@ -117,6 +117,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
                                 "title": relation.product.certificate_definition.title,
                                 "template": relation.product.certificate_definition.template,
                             },
+                            "contract_definition": None,
                             "target_courses": [
                                 {
                                     "code": target_course.code,

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
@@ -109,6 +109,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
                         "title": relation.product.certificate_definition.title,
                         "template": relation.product.certificate_definition.template,
                     },
+                    "contract_definition": None,
                     "target_courses": [
                         {
                             "code": target_course.code,

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
@@ -138,6 +138,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                         "title": product.certificate_definition.title,
                         "template": product.certificate_definition.template,
                     },
+                    "contract_definition": None,
                     "target_courses": [
                         {
                             "code": target_course.code,
@@ -345,6 +346,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                         "title": relation.product.certificate_definition.title,
                         "template": relation.product.certificate_definition.template,
                     },
+                    "contract_definition": None,
                     "target_courses": [
                         {
                             "code": target_course.code,
@@ -513,6 +515,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                     "title": relation.product.certificate_definition.title,
                     "template": relation.product.certificate_definition.template,
                 },
+                "contract_definition": None,
                 "target_courses": [
                     {
                         "code": target_course.code,

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -62,7 +62,8 @@ class ProductAdminApiTest(TestCase):
         """
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=admin.username, password="password")
-        product = factories.ProductFactory()
+        contract_definition = factories.ContractDefinitionFactory()
+        product = factories.ProductFactory(contract_definition=contract_definition)
         relation = models.CourseProductRelation.objects.get(product=product)
         courses = factories.CourseFactory.create_batch(3)
         relations = []
@@ -104,6 +105,14 @@ class ProductAdminApiTest(TestCase):
                 "name": product.certificate_definition.name,
                 "template": product.certificate_definition.template,
                 "title": product.certificate_definition.title,
+            },
+            "contract_definition": {
+                "id": str(contract_definition.id),
+                "title": contract_definition.title,
+                "description": contract_definition.description,
+                "name": contract_definition.name,
+                "language": contract_definition.language,
+                "body": contract_definition.body,
             },
             "target_courses": [
                 {

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -4586,6 +4586,12 @@
                         "description": "primary key for the record as UUID",
                         "nullable": true
                     },
+                    "contract_definition": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "nullable": true
+                    },
                     "target_courses": {
                         "type": "array",
                         "items": {
@@ -4655,6 +4661,13 @@
                         "readOnly": true,
                         "nullable": true
                     },
+                    "contract_definition": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "readOnly": true,
+                        "nullable": true
+                    },
                     "target_courses": {
                         "type": "array",
                         "items": {
@@ -4668,6 +4681,7 @@
                 "required": [
                     "call_to_action",
                     "certificate_definition",
+                    "contract_definition",
                     "description",
                     "id",
                     "price",
@@ -4756,6 +4770,12 @@
                         "type": "string"
                     },
                     "certificate_definition": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "nullable": true
+                    },
+                    "contract_definition": {
                         "type": "string",
                         "format": "uuid",
                         "description": "primary key for the record as UUID",
@@ -5795,6 +5815,12 @@
                         "type": "string"
                     },
                     "certificate_definition": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "nullable": true
+                    },
+                    "contract_definition": {
                         "type": "string",
                         "format": "uuid",
                         "description": "primary key for the record as UUID",


### PR DESCRIPTION
## Purpose

Admin api consumer should be able to set a contract definition to a product, currently ProductSerializer does not allow that. So we add contract definition to read and write Product serializers.

## Proposal

- [x] Bind `contract_definition` field to `Product` serializers
