### PR TITLE
:recycle:Replace generate_document in models Certificate and Contract Definition by the generic method in Issuers generate_document instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to
 
 ### Changed
 
+- Debug view for Certificate, Degree, Contract Definition and Invoice
 - Internalize invoice template
 - Use HTTPStatus instead of raw HTTP code value
 - If a product has a contract, delay auto enroll logic on leaner signature

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -652,13 +652,17 @@ class CertificateViewSet(
                 status=HTTPStatus.NOT_FOUND,
             )
 
-        (document, _) = certificate.generate_document()
-
-        if not document:
+        try:
+            context = certificate.get_document_context()
+        except ValueError:
             return Response(
                 {"detail": f"Unable to generate certificate {pk}."},
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
+
+        document = issuers.generate_document(
+            name=certificate.certificate_definition.template, context=context
+        )
 
         response = HttpResponse(
             document, content_type="application/pdf", status=HTTPStatus.OK

--- a/src/backend/joanie/core/models/certifications.py
+++ b/src/backend/joanie/core/models/certifications.py
@@ -131,26 +131,6 @@ class Certificate(BaseModel):
         """Returns the certificate owner depending from the related order or enrollment."""
         return self.order.owner if self.order else self.enrollment.user
 
-    def generate_document(self):
-        """
-        Generate the certificate document through the certificate definition template
-        and the document context.
-        """
-
-        try:
-            context = self.get_document_context()
-        except ValueError as exception:
-            logger.error(
-                "Cannot get document context to generate certificate.",
-                exc_info=exception,
-            )
-            return None, None
-
-        file_bytes = generate_document(
-            name=self.certificate_definition.template, context=context
-        )
-        return file_bytes, context
-
     def _set_localized_context(self):
         """
         Update or create the certificate context for all languages.
@@ -183,7 +163,6 @@ class Certificate(BaseModel):
         Build the certificate document context for the given language.
         If no language_code is provided, we use the active language.
         """
-
         language_settings = get_language_settings(language_code or get_language())
         site = Site.objects.get_current()
 
@@ -201,7 +180,7 @@ class Certificate(BaseModel):
             },
             "site": {
                 "name": site.name,
-                "hostname": "https://" + site.domain,
+                "hostname": f"https://{site.domain}",
             },
         }
 

--- a/src/backend/joanie/core/models/contracts.py
+++ b/src/backend/joanie/core/models/contracts.py
@@ -15,7 +15,6 @@ import markdown
 
 from joanie.core import enums
 from joanie.core.models.base import BaseModel
-from joanie.core.utils import contract_definition, issuers
 
 logger = logging.getLogger(__name__)
 
@@ -60,18 +59,6 @@ class ContractDefinition(BaseModel):
         if not self.body:
             return ""
         return markdown.markdown(textwrap.dedent(self.body))
-
-    def generate_document(self, order):
-        """
-        Generate the contract definition.
-        """
-        context = contract_definition.generate_document_context(
-            contract_definition=self, user=order.owner, order=order
-        )
-        file_bytes = issuers.generate_document(
-            name=order.product.contract_definition.name, context=context
-        )
-        return context, file_bytes
 
 
 class Contract(BaseModel):

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -31,7 +31,8 @@ from joanie.core.models.courses import (
     Enrollment,
     Organization,
 )
-from joanie.core.utils import webhooks
+from joanie.core.utils import contract_definition as contract_definition_utility
+from joanie.core.utils import issuers, webhooks
 from joanie.payment import get_payment_backend
 from joanie.payment.models import CreditCard
 from joanie.signature.backends import get_signature_backend
@@ -944,7 +945,14 @@ class Order(BaseModel):
             raise PermissionDenied("Contract is already signed, cannot resubmit.")
 
         backend_signature = get_signature_backend()
-        context, file_bytes = contract_definition.generate_document(self)
+        context = contract_definition_utility.generate_document_context(
+            contract_definition=contract_definition,
+            user=user,
+            order=contract.order,
+        )
+        file_bytes = issuers.generate_document(
+            name=contract_definition.name, context=context
+        )
 
         was_already_submitted = (
             contract.submitted_for_signature_on and contract.signature_backend_reference

--- a/src/backend/joanie/core/utils/contract_definition.py
+++ b/src/backend/joanie/core/utils/contract_definition.py
@@ -59,11 +59,6 @@ def generate_document_context(contract_definition, user, order=None):
                 if order
                 else organization_fallback_logo
             ),
-            "signature": (
-                image_to_base64(order.organization.signature)
-                if order
-                else organization_fallback_logo
-            ),
             "name": (
                 order.organization.safe_translation_getter(
                     "title", language_code=contract_definition.language

--- a/src/backend/joanie/core/utils/issuers.py
+++ b/src/backend/joanie/core/utils/issuers.py
@@ -17,6 +17,8 @@ def generate_document(name: str, context: dict) -> bytes:
         - The path will help us in finding the correct .html and
         .css file for the document in the app directory.
         Make sure that those files exist in the 'templates' folder.
+        - If the context is equal to 'None' or is an empty '{}', it
+        will render the document without the context data.
     """
     html_template_path = Path(f"issuers/{name}.html")
     css_template_name = Path(f"issuers/{name}.css")

--- a/src/backend/joanie/core/views.py
+++ b/src/backend/joanie/core/views.py
@@ -9,6 +9,7 @@ from django.views.generic.base import RedirectView, TemplateView
 from joanie.core import factories
 from joanie.core.enums import CERTIFICATE, DEGREE
 from joanie.core.models import Certificate
+from joanie.core.utils import issuers
 
 
 class DebugMailSuccessPayment(TemplateView):
@@ -52,7 +53,7 @@ class DebugCertificateDefinitionTemplateView(TemplateView):
 
     type = None
 
-    # pylint: disable=invalid-name
+    # pylint: disable=invalid-name, unused-argument
     def retrieve_certificate_from_pk(self, pk, site):
         """
         Retrieve a certificate from its pk and its certificate definition template
@@ -63,10 +64,14 @@ class DebugCertificateDefinitionTemplateView(TemplateView):
             certificate_definition__template=self.type,
         )
 
-        (document, _) = certificate.generate_document(site)
+        document = issuers.generate_document(
+            name=certificate.definition.template,
+            context=certificate.get_document_context(),
+        )
 
         return document
 
+    # pylint: disable=unused-argument
     def generate_certificate(self, site):
         """
         Generate an enrollment certificate document with hardcoded organization,
@@ -96,7 +101,10 @@ class DebugCertificateDefinitionTemplateView(TemplateView):
             organization=organization,
             enrollment=enrollment,
         )
-        (document, _) = certificate.generate_document(site)
+
+        document = issuers.generate_document(
+            name=definition.template, context=certificate.get_document_context()
+        )
 
         return document
 

--- a/src/backend/joanie/core/views.py
+++ b/src/backend/joanie/core/views.py
@@ -1,15 +1,28 @@
 """Views of the ``core`` app of the Joanie project."""
 import base64
+import datetime
+from logging import getLogger
 
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.contrib.sites.shortcuts import get_current_site
 from django.views.generic.base import RedirectView, TemplateView
 
 from joanie.core import factories
 from joanie.core.enums import CERTIFICATE, DEGREE
 from joanie.core.models import Certificate
 from joanie.core.utils import issuers
+
+logger = getLogger(__name__)
+
+
+LOGO_FALLBACK = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR"
+    "42mO8cPX6fwAIdgN9pHTGJwAAAABJRU5ErkJggg=="
+)
+SIGNATURE_FALLBACK = (
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR"
+    "4nGNgYPgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
+)
 
 
 class DebugMailSuccessPayment(TemplateView):
@@ -46,84 +59,56 @@ class DebugMailSuccessPaymentViewTxt(DebugMailSuccessPayment):
     template_name = "mail/text/order_validated.txt"
 
 
-class DebugCertificateDefinitionTemplateView(TemplateView):
+class DebugPdfTemplateView(TemplateView):
     """
-    Debug View to check the layout of certificate definition templates
+    Simple class to render the PDF template in bytes format of a document to preview.
+    Issuer document can be a : certificate, degree, invoice, or a contract definition.
     """
 
-    type = None
+    model = None
+    issuer_document = None
+    template_name = "debug/pdf_viewer.html"
 
-    # pylint: disable=invalid-name, unused-argument
-    def retrieve_certificate_from_pk(self, pk, site):
+    def get_document_context(self, pk=None):
         """
-        Retrieve a certificate from its pk and its certificate definition template
-        and generate its document
+        Base method to get document's context for a given document.
         """
-        certificate = Certificate.objects.get(
-            pk=pk,
-            certificate_definition__template=self.type,
-        )
+        raise NotImplementedError("subclasses must implement this method.")
 
-        document = issuers.generate_document(
-            name=certificate.definition.template,
-            context=certificate.get_document_context(),
-        )
-
-        return document
-
-    # pylint: disable=unused-argument
-    def generate_certificate(self, site):
+    def retrieve_document_from_pk(self, pk):
         """
-        Generate an enrollment certificate document with hardcoded organization,
-        course, enrollment and certificate definition to prevent to create a lot of
-        objects in the database.
+        Retrieve the object from its 'pk', and generate the context and create
+        the document in PDF bytes in return.
         """
-        organization = factories.OrganizationFactory(
-            code=f"DEV_{self.type.upper()}_ORGANIZATION",
-        )
+        object_to_render = self.model.objects.get(pk=pk)
+        if isinstance(object_to_render, ContractDefinition):
+            contract = object_to_render.contracts.all()[0]
+            context = contract_definition_utility.generate_document_context(
+                contract_definition=object_to_render,
+                user=contract.order.owner,
+                order=contract.order,
+            )
+        else:
+            context = object_to_render.get_document_context()
 
-        course = factories.CourseFactory(
-            code=f"DEV_{self.type.upper()}_COURSE",
-            organizations=[organization],
+        return issuers.generate_document(
+            name=self.issuer_document,
+            context=context,
         )
-
-        enrollment = factories.EnrollmentFactory(
-            course_run__course=course,
-        )
-
-        definition = factories.CertificateDefinitionFactory.create(
-            name=f"DEV_{self.type.upper()}_DEFINITION",
-            template=self.type,
-        )
-
-        certificate = factories.EnrollmentCertificateFactory.create(
-            certificate_definition=definition,
-            organization=organization,
-            enrollment=enrollment,
-        )
-
-        document = issuers.generate_document(
-            name=definition.template, context=certificate.get_document_context()
-        )
-
-        return document
 
     def get_context_data(self, **kwargs):
         """
-        Generates sample datas to have a valid debug certificate/degree definition.
-
-        If the request contains a pk query parameter, we retrieve the certificate
-        from its pk and its certificate definition template otherwise we generate on the
-        fly a certificate document.
+        Base method to prepare the document to render in the debug view in base64.
         """
         context = super().get_context_data()
-        current_site = get_current_site(self.request)
 
         # pylint: disable=invalid-name
         if pk := self.request.GET.get("pk"):
-            document = self.retrieve_certificate_from_pk(pk, current_site)
+            document = self.retrieve_document_from_pk(pk)
         else:
-            document = self.generate_certificate(current_site)
+            document = issuers.generate_document(
+                name=self.issuer_document, context=self.get_document_context()
+            )
 
         context.update(
             **{
@@ -134,22 +119,232 @@ class DebugCertificateDefinitionTemplateView(TemplateView):
         return context
 
 
-class DebugCertificateTemplateView(DebugCertificateDefinitionTemplateView):
+class DebugCertificateTemplateView(DebugPdfTemplateView):
     """
-    Debug view to check the layout of "certificate" template
-    """
-
-    template_name = "debug/pdf_viewer.html"
-    type = CERTIFICATE
-
-
-class DebugDegreeTemplateView(DebugCertificateDefinitionTemplateView):
-    """
-    Debug view to check the layout of "degree" template
+    Debug view to check the layout of "certificate" template.
     """
 
-    template_name = "debug/pdf_viewer.html"
-    type = DEGREE
+    model = Certificate
+    issuer_document = CERTIFICATE
+
+    def get_document_context(self, pk=None):
+        """
+        Build a realistic context to have data similar to a real document generated.
+        If a primary key (pk) is provided, retrieve the corresponding Certificate document
+        context. If the Certificate does not exist, we will use a basic fallback for the document
+        context. Otherwise, if no primary key is provided, we return the basic fallback document
+        context.
+        """
+        if not pk:
+            return self.get_basic_document_context()
+
+        certificate = Certificate.objects.get(
+            pk=pk, certificate_definition__template=self.issuer_document
+        )
+
+        return certificate.get_document_context()
+
+    def get_basic_document_context(self):
+        """Returns a basic document context to preview the template of a `certificate`."""
+
+        return {
+            "id": "b4e8afcf-077f-4bb3-b0d4-8caad4c7b5c1",
+            "creation_date": datetime.datetime(
+                2024, 1, 5, 13, 57, 53, 274266, tzinfo=datetime.timezone.utc
+            ),
+            "delivery_stamp": datetime.datetime(
+                2024, 1, 5, 13, 57, 53, 275708, tzinfo=datetime.timezone.utc
+            ),
+            "student": {"name": "John Doe"},
+            "organization": {
+                "representative": "Joanie Cunningham",
+                "signature": SIGNATURE_FALLBACK,
+                "logo": LOGO_FALLBACK,
+                "name": "Organization 0",
+            },
+            "site": {"name": "example.com", "hostname": "https://example.com"},
+            "course": {"name": "Full Stack Pancake, Full Stack Developer"},
+        }
+
+
+class DebugDegreeTemplateView(DebugPdfTemplateView):
+    """
+    Debug view to check the layout of "degree" template.
+    """
+
+    model = Certificate
+    issuer_document = DEGREE
+
+    def get_document_context(self, pk=None):
+        """
+        Build a realistic context to have data similar to a real document generated.
+        If a primary key (pk) is provided, retrieve the corresponding Degree document
+        context. If the Degree (Certificate object) does not exist, we will use a basic fallback
+        for the document context. Otherwise, if no primary key is provided, we return the basic
+        fallback document context.
+        """
+        if not pk:
+            return self.get_basic_document_context()
+
+        certificate_type_degree = Certificate.objects.get(
+            pk=pk, certificate_definition__template=self.issuer_document
+        )
+
+        return certificate_type_degree.get_document_context()
+
+    def get_basic_document_context(self):
+        """Returns a basic document context to preview the template of a `degree`."""
+        return {
+            "id": "8c4a2469-78db-4785-8eec-7690a096b5bf",
+            "creation_date": datetime.datetime(
+                2024, 1, 5, 10, 40, 54, 47499, tzinfo=datetime.timezone.utc
+            ),
+            "delivery_stamp": datetime.datetime(
+                2024, 1, 5, 10, 40, 54, 50357, tzinfo=datetime.timezone.utc
+            ),
+            "student": {"name": "Joanie Cunningham"},
+            "organization": {
+                "representative": "Joanie Cunningham",
+                "signature": SIGNATURE_FALLBACK,
+                "logo": LOGO_FALLBACK,
+                "name": "Organization Test",
+            },
+            "site": {"name": "example.com", "hostname": "https://example.com"},
+            "course": {"name": "Full Stack Pancake, Full Stack Developer"},
+        }
+
+
+class DebugContractTemplateView(DebugPdfTemplateView):
+    """
+    Debug view to check the layout of "contract_definition" template.
+    """
+
+    model = ContractDefinition
+    issuer_document = CONTRACT_DEFINITION
+
+    def get_document_context(self, pk=None):
+        """
+        Build a realistic context to have data similar to real data.
+        If a primary key (pk) is provided, retrieve the corresponding Contract Definition document
+        context.
+        If the Contract Definition is not found, fall back to a basic document context.
+        If no pk is provided, return a basic document context.
+        """
+
+        if not pk:
+            return self.get_basic_document_context()
+
+        try:
+            contract_definition = ContractDefinition.objects.get(
+                pk=pk, name=self.issuer_document
+            )
+        except ContractDefinition.DoesNotExist as e:
+            logger.error("Contract Definition with pk %s not found: %s", pk, e)
+            return self.get_basic_document_context()
+
+        contract = contract_definition.contracts.all()[0]
+        return contract_definition_utility.generate_document_context(
+            contract_definition=contract_definition,
+            user=contract.order.owner,
+            order=contract.order,
+        )
+
+    def get_basic_document_context(self, **kwargs):
+        """Returns a basic document context to preview the template of a `contract_definition`."""
+
+        return {
+            "contract": {
+                "body": "Some condition article content",
+                "title": "Contract Definition",
+            },
+            "course": {
+                "name": "Full Stack Pancake, Full Stack Developer",
+            },
+            "student": {
+                "name": "John Cunningham",
+                "address": {
+                    "address": ("<STUDENT_ADDRESS_STREET_NAME>"),
+                    "city": ("<STUDENT_ADDRESS_CITY>"),
+                    "country": ("<STUDENT_ADDRESS_COUNTRY>"),
+                    "last_name": ("<STUDENT_LAST_NAME>"),
+                    "first_name": ("<STUDENT_FIRST_NAME>"),
+                    "postcode": ("<STUDENT_ADDRESS_POSTCODE>"),
+                    "title": "Some address title",
+                },
+            },
+            "organization": {
+                "logo": LOGO_FALLBACK,
+                "name": "Organization 0",
+            },
+        }
+
+
+class DebugInvoiceTemplateView(DebugPdfTemplateView):
+    """
+    Debug view to check the layout of "invoice" template.
+    """
+
+    model = Invoice
+    issuer_document = INVOICE_TYPE_INVOICE
+
+    def get_document_context(self, pk=None):
+        """
+        Build a realistic context to have data similar to real data.
+        Returns the context of an invoice (credit note by default).
+        If you parse a 'pk' in the URL, you will be able to preview your object
+        (invoice type or credit note type) if it exists locally in your database.
+        Else, we provide a sample of context for your Invoice.
+        """
+
+        if not pk:
+            return self.get_basic_document_context()
+
+        try:
+            invoice = Invoice.objects.get(pk=pk)
+        except Invoice.DoesNotExist as e:
+            logger.error("Invoice with pk %s not found: %s", pk, e)
+            return self.get_basic_document_context()
+
+        return invoice.get_document_context()
+
+    def get_basic_document_context(self, **kwargs):
+        """Returns a basic document context to preview the tempalte of an `invoice`"""
+
+        return {
+            "metadata": {
+                "issued_on": datetime.datetime(
+                    2024, 1, 5, 16, 21, 11, 816450, tzinfo=datetime.timezone.utc
+                ),
+                "reference": "6ba340f1-1704471671814",
+                "type": "credit_note",
+            },
+            "order": {
+                "amount": {
+                    "currency": "€",
+                    "subtotal": "-280.752",
+                    "total": "-350.94",
+                    "vat_amount": "-70.188",
+                    "vat": "20",
+                },
+                "company": (
+                    "10 rue Stine, 75001 Paris\n"
+                    "RCS Paris XXX XXX XXX - SIRET XXX XXX XXX XXXXX - APE XXXXX\n"
+                    "VAT Number XXXXXXXXX"
+                ),
+                "customer": {
+                    "address": "94099 Moreno Port Apt. 012\n33715 New Frank\nTanzania",
+                    "name": "Vanessa Wood",
+                },
+                "seller": {
+                    "address": (
+                        "France Université Numérique\n"
+                        "10 Rue Stine,\n"
+                        "75001 Paris, FR"
+                    ),
+                },
+                "product": {"name": "deploy turn-key partnerships", "description": ""},
+            },
+        }
 
 
 class BackOfficeRedirectView(RedirectView):

--- a/src/backend/joanie/core/views.py
+++ b/src/backend/joanie/core/views.py
@@ -12,12 +12,14 @@ from joanie.core.enums import CERTIFICATE, CONTRACT_DEFINITION, DEGREE
 from joanie.core.models import Certificate, Contract
 from joanie.core.utils import contract_definition as contract_definition_utility
 from joanie.core.utils import issuers
+from joanie.payment.enums import INVOICE_TYPE_INVOICE
+from joanie.payment.models import Invoice
 
 logger = getLogger(__name__)
 
 
 LOGO_FALLBACK = (
-    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR"
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR"
     "42mO8cPX6fwAIdgN9pHTGJwAAAABJRU5ErkJggg=="
 )
 SIGNATURE_FALLBACK = (
@@ -281,26 +283,22 @@ class DebugInvoiceTemplateView(DebugPdfTemplateView):
 
     def get_document_context(self, pk=None):
         """
-        Build a realistic context to have data similar to real data.
-        Returns the context of an invoice (credit note by default).
-        If you parse a 'pk' in the URL, you will be able to preview your object
-        (invoice type or credit note type) if it exists locally in your database.
-        Else, we provide a sample of context for your Invoice.
+        Build a realistic context to have data similar to a real document generated.
+        If a primary key (pk) is provided, retrieve the corresponding Invoice.
+        If the Invoice does not exist, we will use a basic fallback for the document
+        context (a credit note by default). Otherwise, if no primary key is provided, we return
+        the basic fallback document context.
         """
 
         if not pk:
             return self.get_basic_document_context()
 
-        try:
-            invoice = Invoice.objects.get(pk=pk)
-        except Invoice.DoesNotExist as e:
-            logger.error("Invoice with pk %s not found: %s", pk, e)
-            return self.get_basic_document_context()
+        invoice = Invoice.objects.get(pk=pk)
 
         return invoice.get_document_context()
 
     def get_basic_document_context(self, **kwargs):
-        """Returns a basic document context to preview the tempalte of an `invoice`"""
+        """Returns a basic document context to preview the template of an `invoice`"""
 
         return {
             "metadata": {

--- a/src/backend/joanie/signature/backends/dummy.py
+++ b/src/backend/joanie/signature/backends/dummy.py
@@ -8,6 +8,8 @@ from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 
 from joanie.core import models
+from joanie.core.utils import contract_definition as contract_definition_utility
+from joanie.core.utils import issuers
 
 from .base import BaseSignatureBackend
 
@@ -120,6 +122,13 @@ class DummySignatureBackend(BaseSignatureBackend):
             )
 
         contract = models.Contract.objects.get(signature_backend_reference=reference_id)
-        _, file_bytes = contract.definition.generate_document(contract.order)
+        file_bytes = issuers.generate_document(
+            name=contract.definition.name,
+            context=contract_definition_utility.generate_document_context(
+                contract_definition=contract.definition,
+                user=contract.order.owner,
+                order=contract.order,
+            ),
+        )
 
         return file_bytes

--- a/src/backend/joanie/tests/core/test_models_contract.py
+++ b/src/backend/joanie/tests/core/test_models_contract.py
@@ -1,6 +1,5 @@
 """Tests for the Contract Model"""
 from datetime import datetime, timedelta
-from io import BytesIO
 from zoneinfo import ZoneInfo
 
 from django.contrib.auth.models import AnonymousUser
@@ -9,10 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone as django_timezone
 
-from pdfminer.high_level import extract_text as pdf_extract_text
-
 from joanie.core import enums, factories, models
-from joanie.payment.factories import InvoiceFactory
 
 # pylint: disable=too-many-public-methods
 
@@ -487,39 +483,6 @@ class ContractModelTestCase(TestCase):
                 " 'Make sure to complete all fields before signing contract.']}"
             ),
         )
-
-    def test_models_contract_definition_generate_document(self):
-        """
-        Contract Definition 'generate document' method should generate a document.
-        """
-        user = factories.UserFactory(
-            email="student@example.fr", first_name="John", last_name="Doe"
-        )
-        address = factories.AddressFactory(
-            owner=user,
-            address="1 Rue de L'Exemple",
-            postcode="75000",
-            city="Paris",
-            is_reusable=False,
-            title="Office",
-            country="FR",
-        )
-        order = factories.OrderFactory(
-            owner=user,
-            product__contract_definition=factories.ContractDefinitionFactory(),
-            state=enums.ORDER_STATE_VALIDATED,
-            main_invoice=InvoiceFactory(recipient_address=address),
-        )
-        contract = factories.ContractFactory(order=order)
-
-        _, file_bytes = contract.definition.generate_document(order)
-        document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
-
-        self.assertRegex(document_text, r"John Doe")
-        self.assertRegex(document_text, r"1 Rue de L'Exemple 75000, Paris")
-        self.assertRegex(document_text, r"Student's signature")
-        self.assertRegex(document_text, r"Representative's signature")
-        self.assertRegex(document_text, r"Your order is delivered by the organization")
 
     def test_models_contract_tag_submission_for_signature(self):
         """

--- a/src/backend/joanie/tests/core/test_utils_contract_definition_generate_document_context.py
+++ b/src/backend/joanie/tests/core/test_utils_contract_definition_generate_document_context.py
@@ -65,7 +65,6 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
             "organization": {
                 "logo": image_to_base64(order.organization.logo),
                 "name": order.organization.title,
-                "signature": image_to_base64(order.organization.signature),
             },
         }
 
@@ -114,7 +113,6 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
             "organization": {
                 "logo": organization_fallback_logo,
                 "name": "<ORGANIZATION_NAME>",
-                "signature": organization_fallback_logo,
             },
         }
 
@@ -167,7 +165,6 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
             "organization": {
                 "logo": organization_fallback_logo,
                 "name": "<ORGANIZATION_NAME>",
-                "signature": organization_fallback_logo,
             },
         }
 

--- a/src/backend/joanie/tests/core/test_utils_issuers_certificate_and_degree_generate_document.py
+++ b/src/backend/joanie/tests/core/test_utils_issuers_certificate_and_degree_generate_document.py
@@ -1,0 +1,134 @@
+"""Test suite for utility method to generate document of Certificate/Degree in PDF bytes format."""
+from io import BytesIO
+
+from django.test import TestCase
+
+from parler.utils.context import switch_language
+from pdfminer.high_level import extract_text as pdf_extract_text
+
+from joanie.core import enums, factories
+from joanie.core.utils import issuers
+
+
+class UtilsIssuersCertificateAndDegreeGenerateDocumentTestCase(TestCase):
+    """
+    Test suite for utility method to generate document of Certificate/Degree in PDF bytes format.
+    """
+
+    def test_utils_issuers_generate_document_certificate_degree_document(self):
+        """
+        The generated document in PDF bytes format should be rendered into the active language
+        of the certificate's context. The method `get_document_context` will prepare the data
+        in the appropriate language.
+        """
+        organization = factories.OrganizationFactory(
+            title="University X", representative="Joanie Cunningham"
+        )
+        course = factories.CourseFactory()
+        certificate_definition = factories.CertificateDefinitionFactory(
+            template=enums.DEGREE
+        )
+        product = factories.ProductFactory(
+            courses=[],
+            title="Graded product",
+            certificate_definition=certificate_definition,
+        )
+        factories.CourseProductRelationFactory(
+            course=course, product=product, organizations=[organization]
+        )
+
+        # - Add French translations
+        organization.translations.create(language_code="fr-fr", title="Université X")
+        product.translations.create(language_code="fr-fr", title="Produit certifiant")
+
+        order = factories.OrderFactory(product=product)
+        certificate = factories.OrderCertificateFactory(order=order)
+
+        document = issuers.generate_document(
+            name=certificate.certificate_definition.template,
+            context=certificate.get_document_context(),
+        )
+
+        document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+        self.assertRegex(document_text, "Certificate")
+        self.assertRegex(document_text, rf"Certificate ID: {str(certificate.id)}")
+        self.assertRegex(
+            document_text, r"Joanie Cunningham.*University X.*Graded product"
+        )
+
+        with switch_language(product, "fr-fr"):
+            document = issuers.generate_document(
+                name=certificate.certificate_definition.template,
+                context=certificate.get_document_context(),
+            )
+            document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+            self.assertRegex(document_text, r"Joanie Cunningham.*Université X")
+
+        with switch_language(product, "de-de"):
+            # - Finally, unknown language should use the default language as fallback
+            document = issuers.generate_document(
+                name=certificate.certificate_definition.template,
+                context=certificate.get_document_context(),
+            )
+            document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+            self.assertRegex(document_text, r"Joanie Cunningham.*University X")
+
+    def test_utils_issuers_generate_document_certificate_document(self):
+        """
+        The generated document in PDF bytes format should be rendered into the active language
+        of the certificate's context. When we force the language to French, we should find
+        translated strings into the given code language. By default, the language is in English,
+        and the fallback language as well.
+        """
+        organization = factories.OrganizationFactory(title="University X")
+        user = factories.UserFactory(first_name="Joanie Cunningham")
+        course = factories.CourseFactory(title="Course with attestation")
+        enrollment = factories.EnrollmentFactory(user=user, course_run__course=course)
+        certificate_definition = factories.CertificateDefinitionFactory(
+            template=enums.CERTIFICATE
+        )
+
+        # - Add French translations
+        organization.translations.create(language_code="fr-fr", title="Université X")
+        course.translations.create(
+            language_code="fr-fr", title="Cours avec attestation"
+        )
+
+        certificate = factories.EnrollmentCertificateFactory(
+            certificate_definition=certificate_definition,
+            enrollment=enrollment,
+            organization=organization,
+        )
+
+        document = issuers.generate_document(
+            name=certificate.certificate_definition.template,
+            context=certificate.get_document_context(),
+        )
+        document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+        self.assertRegex(document_text, "ATTESTATION OF ACHIEVEMENT")
+        self.assertRegex(
+            document_text, r"Joanie Cunningham.*Course with attestation.*University X"
+        )
+
+        with switch_language(course, "fr-fr"):
+            document = issuers.generate_document(
+                name=certificate.certificate_definition.template,
+                context=certificate.get_document_context(),
+            )
+            document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+            self.assertRegex(
+                document_text,
+                r"Joanie Cunningham.*Cours avec attestation.*Université X",
+            )
+
+        with switch_language(course, "de-de"):
+            # - Finally, unknown language should use the default language as fallback
+            document = issuers.generate_document(
+                name=certificate.certificate_definition.template,
+                context=certificate.get_document_context(),
+            )
+            document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+            self.assertRegex(
+                document_text,
+                r"Joanie Cunningham.*Course with attestation.*University X",
+            )

--- a/src/backend/joanie/tests/core/test_utils_issuers_contract_definition_generate_document.py
+++ b/src/backend/joanie/tests/core/test_utils_issuers_contract_definition_generate_document.py
@@ -1,0 +1,55 @@
+"""Test suite for utility method to generate document of Contract Definition in PDF bytes format"""
+from io import BytesIO
+
+from django.test import TestCase
+
+from pdfminer.high_level import extract_text as pdf_extract_text
+
+from joanie.core import enums, factories
+from joanie.core.utils import contract_definition as contract_definition_utility
+from joanie.core.utils import issuers
+from joanie.payment.factories import InvoiceFactory
+
+
+class UtilsIssuersContractDefinitionGenerateDocument(TestCase):
+    """
+    Test suite for issuer utility method to generate document of contract definition in PDF bytes
+    format.
+    """
+
+    def test_utils_contract_definition_generate_document(self):
+        """
+        Issuer 'generate document' method should generate a contract definition document.
+        """
+        user = factories.UserFactory(
+            email="student@example.fr", first_name="John", last_name="Doe"
+        )
+        address = factories.AddressFactory(
+            owner=user,
+            address="1 Rue de L'Exemple",
+            postcode="75000",
+            city="Paris",
+            is_reusable=False,
+            title="Office",
+            country="FR",
+        )
+        order = factories.OrderFactory(
+            owner=user,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+            state=enums.ORDER_STATE_VALIDATED,
+            main_invoice=InvoiceFactory(recipient_address=address),
+        )
+        contract = factories.ContractFactory(order=order)
+        file_bytes = issuers.generate_document(
+            name=contract.definition.name,
+            context=contract_definition_utility.generate_document_context(
+                contract_definition=contract.definition, user=user, order=contract.order
+            ),
+        )
+        document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
+
+        self.assertRegex(document_text, r"John Doe")
+        self.assertRegex(document_text, r"1 Rue de L'Exemple 75000, Paris")
+        self.assertRegex(document_text, r"Student's signature")
+        self.assertRegex(document_text, r"Representative's signature")
+        self.assertRegex(document_text, r"Your order is delivered by the organization")

--- a/src/backend/joanie/tests/core/test_utils_issuers_invoice_generate_document.py
+++ b/src/backend/joanie/tests/core/test_utils_issuers_invoice_generate_document.py
@@ -28,9 +28,9 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         )
         invoice = InvoiceFactory(order__product=product, total=product.price)
 
-        context = invoice.get_document_context()
         file_bytes = issuers.generate_document(
-            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            name=payment_enums.INVOICE_TYPE_INVOICE,
+            context=invoice.get_document_context(),
         )
 
         # - The default language is used first
@@ -40,18 +40,18 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         # - Then if we switch to an existing language, it should generate
         #   a document with the context in the active language
         with override("fr-fr", deactivate=True):
-            context = invoice.get_document_context()
             file_bytes = issuers.generate_document(
-                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+                name=payment_enums.INVOICE_TYPE_INVOICE,
+                context=invoice.get_document_context(),
             )
             document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
             self.assertRegex(document_text, r"Produit 1.*Description du produit 1")
 
         # # - Finally, unknown language should use the default language as fallback
         with override("de-de", deactivate=True):
-            context = invoice.get_document_context()
             file_bytes = issuers.generate_document(
-                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+                name=payment_enums.INVOICE_TYPE_INVOICE,
+                context=invoice.get_document_context(),
             )
             document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
             self.assertRegex(document_text, r"Product 1.*Product 1 description")
@@ -62,9 +62,9 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         """
         invoice = InvoiceFactory()
 
-        context = invoice.get_document_context()
         file_bytes = issuers.generate_document(
-            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            name=payment_enums.INVOICE_TYPE_INVOICE,
+            context=invoice.get_document_context(),
         )
 
         # - The default language is used first
@@ -74,9 +74,9 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         # - Then if we switch to an existing language, it should generate
         #   a document with the context in the active language
         with override("fr-fr", deactivate=True):
-            context = invoice.get_document_context()
             file_bytes = issuers.generate_document(
-                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+                name=payment_enums.INVOICE_TYPE_INVOICE,
+                context=invoice.get_document_context(),
             )
             document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
             self.assertRegex(document_text, r"FACTURE")
@@ -93,9 +93,9 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         )
 
         # - The default language is used first
-        context = credit_note.get_document_context()
         file_bytes = issuers.generate_document(
-            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            name=payment_enums.INVOICE_TYPE_INVOICE,
+            context=credit_note.get_document_context(),
         )
 
         document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
@@ -104,9 +104,9 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         # - Then if we switch to an existing language, it should generate
         #   a document with the context in the active language
         with override("fr-fr", deactivate=True):
-            context = credit_note.get_document_context()
             file_bytes = issuers.generate_document(
-                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+                name=payment_enums.INVOICE_TYPE_INVOICE,
+                context=credit_note.get_document_context(),
             )
             document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
             self.assertRegex(document_text, r"AVOIR")
@@ -124,9 +124,9 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         invoice = InvoiceFactory(order__product=product, total=product.price)
 
         # - The default language is used first
-        context = invoice.get_document_context()
         file_bytes = issuers.generate_document(
-            name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+            name=payment_enums.INVOICE_TYPE_INVOICE,
+            context=invoice.get_document_context(),
         )
 
         document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
@@ -134,18 +134,18 @@ class UtilsIssuersInvoiceGenerateDocumentTestCase(TestCase):
         # - Then if we switch to an existing language, it should generate
         #   a document with the context in the active language
         with override("fr-fr", deactivate=True):
-            context = invoice.get_document_context()
             file_bytes = issuers.generate_document(
-                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+                name=payment_enums.INVOICE_TYPE_INVOICE,
+                context=invoice.get_document_context(),
             )
             document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
             self.assertRegex(document_text, r"Produit 1.*Description du produit 1")
 
         # - Finally, unknown language should use the default language as fallback
         with override("de-de", deactivate=True):
-            context = invoice.get_document_context()
             file_bytes = issuers.generate_document(
-                name=payment_enums.INVOICE_TYPE_INVOICE, context=context
+                name=payment_enums.INVOICE_TYPE_INVOICE,
+                context=invoice.get_document_context(),
             )
             document_text = pdf_extract_text(BytesIO(file_bytes)).replace("\n", "")
             self.assertRegex(document_text, r"Product 1.*Product 1 description")

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -32,6 +32,7 @@ from joanie.core.views import (
     DebugCertificateTemplateView,
     DebugContractTemplateView,
     DebugDegreeTemplateView,
+    DebugInvoiceTemplateView,
     DebugMailSuccessPaymentViewHtml,
     DebugMailSuccessPaymentViewTxt,
 )
@@ -80,6 +81,11 @@ if settings.DEBUG:
                 "__debug__/pdf-templates/contract",
                 DebugContractTemplateView.as_view(),
                 name="debug.contract.definition",
+            ),
+            path(
+                "__debug__/pdf-templates/invoice",
+                DebugInvoiceTemplateView.as_view(),
+                name="debug.invoice_template.invoice",
             ),
         ]
         + staticfiles_urlpatterns()

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -30,6 +30,7 @@ from joanie import admin_urls, client_urls, remote_endpoints_urls
 from joanie.core.views import (
     BackOfficeRedirectView,
     DebugCertificateTemplateView,
+    DebugContractTemplateView,
     DebugDegreeTemplateView,
     DebugMailSuccessPaymentViewHtml,
     DebugMailSuccessPaymentViewTxt,
@@ -74,6 +75,11 @@ if settings.DEBUG:
                 "__debug__/pdf-templates/degree",
                 DebugDegreeTemplateView.as_view(),
                 name="debug.certificate_definition.degree",
+            ),
+            path(
+                "__debug__/pdf-templates/contract",
+                DebugContractTemplateView.as_view(),
+                name="debug.contract.definition",
             ),
         ]
         + staticfiles_urlpatterns()


### PR DESCRIPTION
## Purpose

For consistency in the code, we would like to use the **generic method** in Issuers (`joanie.core.issuers`) `generate_document(name=name, context=context)` instead of the methods within the models `Certificate` and `Contract Definition` : `generate_document()` for PDF bytes format document.

## Proposal
**Refactor/replace generate document in models by issuer**
Take away from models `Certificate` and `Contract Definition` the method : `def generate_document()` with the generic method in issuers (`joanie.core.issuers`) .

You will need to update every tests, and also where the model method is called.

**Contract Definition**
- [x] update the method in Contract Definition Model  (erase `generate_document`)
- [x] take away signature logo since it will not be an image on the document anymore, it will be a real signature (for legal concerns)
- [x] update every tests and where the method is called for contract definition.

**Certificate/Degree**
- [x] update the method in Certificate Model (erase `generate_document`)
- [x] update every tests and where the method is called for certificates/degrees

**Debug views to preview templates in Joanie (Bonus)**
- [x] provide a debug view for : invoice, certificate, degree and contract definition
- [x] create a base class `DebugPDFTemplateView` and make children for each type of document to debug. 

