### PR TITLE
✨(back) allow OPTIONS verb on zip-archive route testing zip creation

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -1143,7 +1143,7 @@ class ContractViewSet(GenericContractViewSet):
         )
 
     @action(
-        methods=["GET"],
+        methods=["GET", "OPTIONS"],
         detail=False,
         url_name="zip-archive",
         url_path=rf"zip-archive/(?P<zip_id>{UUID_REGEX})",
@@ -1166,12 +1166,15 @@ class ContractViewSet(GenericContractViewSet):
         if not zip_archive_exists:
             return Response(status=HTTPStatus.NOT_FOUND)
 
-        return FileResponse(
-            storage.open(f"{storage.location}/{zip_archive_name}", mode="rb"),
-            as_attachment=True,
-            filename=zip_archive_name,
-            content_type="application/zip",
-        )
+        if request.method == "GET":
+            return FileResponse(
+                storage.open(f"{storage.location}/{zip_archive_name}", mode="rb"),
+                as_attachment=True,
+                filename=zip_archive_name,
+                content_type="application/zip",
+            )
+
+        return Response(status=HTTPStatus.NO_CONTENT)
 
     @action(
         methods=["POST"],


### PR DESCRIPTION
## Purpose

The zip-archive route now accepts the OPTIONS verb. Whe this verb is used, the route returns a 204 if the zip exists. 404 otherwise. The behaviour for the GET is not changed.


## Proposal

- [x] allow OPTIONS verb on zip-archive route testing zip creation

Partially implementing feature in issue #546 