### PR TITLE
✨(frontend) add contract definition product form

### DIFF
--- a/src/frontend/admin/src/components/presentational/hook-form/RHFAutocomplete.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFAutocomplete.tsx
@@ -84,7 +84,10 @@ export default function RHFAutocomplete<
           {...other}
           onChange={(event, newValue, reason, details) => {
             other.onChange?.(event, newValue, reason, details);
-            setValue(name, newValue, { shouldValidate: true });
+            setValue(name, newValue, {
+              shouldValidate: true,
+              shouldDirty: true,
+            });
           }}
         />
       )}

--- a/src/frontend/admin/src/components/templates/contract-definition/inputs/ContractDefinitionSearch.tsx
+++ b/src/frontend/admin/src/components/templates/contract-definition/inputs/ContractDefinitionSearch.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import {
+  RHFAutocompleteSearchProps,
+  RHFSearch,
+} from "@/components/presentational/hook-form/RHFSearch";
+import { Maybe, Nullable } from "@/types/utils";
+import { useModal } from "@/components/presentational/modal/useModal";
+import { useContractDefinitions } from "@/hooks/useContractDefinitions/useContractDefinitions";
+import { ContractDefinition } from "@/services/api/models/ContractDefinition";
+import { CreateOrEditContractDefinitionModal } from "@/components/templates/contract-definition/modals/CreateOrEditContractDefinitionModal";
+
+export function ContractDefinitionSearch(
+  props: RHFAutocompleteSearchProps<ContractDefinition>,
+) {
+  const { setValue, getValues } = useFormContext();
+  const contract: Nullable<ContractDefinition> = getValues(props.name);
+  const [query, setQuery] = useState("");
+  const contractDefinitionsQuery = useContractDefinitions({ query });
+  const [isCreateMode, setIsCreateMode] = useState(false);
+  const modal = useModal();
+
+  const onAddClick = (): void => {
+    setIsCreateMode(true);
+    modal.handleOpen();
+  };
+
+  const afterSubmit = (def: ContractDefinition) => {
+    modal.handleClose();
+    setIsCreateMode(false);
+    setValue(props.name, def, { shouldTouch: true, shouldValidate: true });
+  };
+
+  return (
+    <>
+      <RHFSearch
+        {...props}
+        filterOptions={(x) => x}
+        items={contractDefinitionsQuery.items}
+        loading={contractDefinitionsQuery.states.fetching}
+        onAddClick={onAddClick}
+        onEditClick={() => modal.handleOpen()}
+        onFilter={(term) => setQuery(term)}
+        getOptionLabel={(option: Maybe<ContractDefinition>) =>
+          option?.title ?? ""
+        }
+        isOptionEqualToValue={(option, value) => option.id === value.id}
+      />
+
+      <CreateOrEditContractDefinitionModal
+        afterSubmit={afterSubmit}
+        contractDefinitionId={
+          !isCreateMode && contract && props.enableEdit
+            ? contract.id
+            : undefined
+        }
+        modalUtils={modal}
+      />
+    </>
+  );
+}

--- a/src/frontend/admin/src/components/templates/contract-definition/modals/CreateOrEditContractDefinitionModal.tsx
+++ b/src/frontend/admin/src/components/templates/contract-definition/modals/CreateOrEditContractDefinitionModal.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { defineMessages, useIntl } from "react-intl";
+import { ModalUtils } from "@/components/presentational/modal/useModal";
+import { SimpleCard } from "@/components/presentational/card/SimpleCard";
+import { FullScreenModal } from "@/components/presentational/modal/FullScreenModal";
+import { useContractDefinition } from "@/hooks/useContractDefinitions/useContractDefinitions";
+import { ContractDefinition } from "@/services/api/models/ContractDefinition";
+import { ContractDefinitionForm } from "@/components/templates/contract-definition/form/ContractDefinitionForm";
+
+const messages = defineMessages({
+  add: {
+    id: "components.templates.contractDefinitions.modals.CreateOrEditContractDefinitionModal.add",
+    defaultMessage: "Add a contract definition",
+    description: "Title for add definition modal",
+  },
+
+  edit: {
+    id: "components.templates.contractDefinitions.modals.CreateOrEditContractDefinitionModal.edit",
+    defaultMessage: 'Edit the "{name}" contract template ',
+    description: "Title for add contract definition modal",
+  },
+});
+
+type Props = {
+  modalUtils: ModalUtils;
+  contractDefinitionId?: string;
+  afterSubmit: (definition: ContractDefinition) => void;
+};
+export function CreateOrEditContractDefinitionModal(props: Props) {
+  const intl = useIntl();
+  const contractDefinitionQuery = useContractDefinition(
+    props.contractDefinitionId ?? undefined,
+  );
+  return (
+    <FullScreenModal
+      disablePadding={true}
+      title={intl.formatMessage(messages.add)}
+      {...props.modalUtils}
+    >
+      <SimpleCard>
+        <ContractDefinitionForm
+          contractDefinition={
+            props.contractDefinitionId
+              ? contractDefinitionQuery.item
+              : undefined
+          }
+          afterSubmit={props.afterSubmit}
+        />
+      </SimpleCard>
+    </FullScreenModal>
+  );
+}

--- a/src/frontend/admin/src/components/templates/products/form/sections/main/ProductFormMain.tsx
+++ b/src/frontend/admin/src/components/templates/products/form/sections/main/ProductFormMain.tsx
@@ -27,6 +27,8 @@ import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
 import { RHFValuesChange } from "@/components/presentational/hook-form/RFHValuesChange";
 import { ProductFormInstructions } from "@/components/templates/products/form/sections/main/instructions/ProductFormInstructions";
 import { removeEOL } from "@/utils/string";
+import { ContractDefinition } from "@/services/api/models/ContractDefinition";
+import { ContractDefinitionSearch } from "@/components/templates/contract-definition/inputs/ContractDefinitionSearch";
 
 type Props = WizardStepProps & {
   product?: Product;
@@ -47,6 +49,7 @@ const Schema = Yup.object().shape({
   certificate_definition: Yup.mixed<CertificateDefinition>()
     .nullable()
     .optional(),
+  contract_definition: Yup.mixed<ContractDefinition>().nullable().optional(),
 });
 
 export type ProductFormMainValues = Omit<ProductFormValues, "target_courses">;
@@ -71,6 +74,7 @@ export function ProductFormMain({
       call_to_action: defaultProduct?.call_to_action ?? "",
       certificate_definition: defaultProduct?.certificate_definition ?? null,
       instructions: removeEOL(defaultProduct?.instructions),
+      contract_definition: defaultProduct?.contract_definition ?? null,
     };
   };
 
@@ -177,6 +181,20 @@ export function ProductFormMain({
               />
             </Grid>
           )}
+          <Grid xs={12}>
+            <ContractDefinitionSearch
+              placeholder={intl.formatMessage(
+                productFormMessages.contractDefinitionPlaceholder,
+              )}
+              enableAdd={true}
+              helperText={intl.formatMessage(
+                productFormMessages.contractDefinitionHelper,
+              )}
+              enableEdit={true}
+              name="contract_definition"
+              label={intl.formatMessage(productFormMessages.contractDefinition)}
+            />
+          </Grid>
         </Grid>
         <ProductFormFinancial />
         <ProductFormInstructions />

--- a/src/frontend/admin/src/components/templates/products/form/translations.ts
+++ b/src/frontend/admin/src/components/templates/products/form/translations.ts
@@ -49,6 +49,22 @@ export const productFormMessages = defineMessages({
       "Used for the generation of the certificate of completion of the course",
     description: "Helper text for the definition input",
   },
+  contractDefinition: {
+    id: "components.templates.products.form.translations.contractDefinition",
+    defaultMessage: "Contract definition",
+    description: "Label for the contract definition input",
+  },
+  contractDefinitionHelper: {
+    id: "components.templates.products.form.translations.contractDefinitionHelper",
+    defaultMessage:
+      "This is a contract template that will be used when purchasing the product",
+    description: "Helper text for the contract definition input",
+  },
+  contractDefinitionPlaceholder: {
+    id: "components.templates.products.form.translations.contractDefinitionPlaceholder",
+    defaultMessage: "Search a contract definition",
+    description: "placeholder text for the contract definition input",
+  },
   instructionsTitle: {
     id: "components.templates.products.form.translations.instructionsTitle",
     defaultMessage: "Product instructions",

--- a/src/frontend/admin/src/services/api/models/Product.ts
+++ b/src/frontend/admin/src/services/api/models/Product.ts
@@ -6,6 +6,7 @@ import {
 import { ProductRelationToCourse } from "./Relations";
 import { Nullable, Optional, ToFormValues } from "@/types/utils";
 import { ProductFormMainValues } from "@/components/templates/products/form/sections/main/ProductFormMain";
+import { ContractDefinition } from "@/services/api/models/ContractDefinition";
 
 export type Product = {
   id: string;
@@ -19,6 +20,7 @@ export type Product = {
   instructions?: string;
   certificate_definition?: CertificateDefinition;
   course_relations?: ProductRelationToCourse[];
+  contract_definition?: ContractDefinition;
 };
 
 export enum ProductType {
@@ -37,6 +39,7 @@ export type ProductFormValues = ToFormValues<{
   instructions?: string;
   price_currency?: string;
   certificate_definition?: Nullable<CertificateDefinition>;
+  contract_definition?: Nullable<ContractDefinition>;
 }>;
 
 export type DTOProduct = {
@@ -49,6 +52,7 @@ export type DTOProduct = {
   price?: number;
   price_currency?: string;
   certificate_definition?: string;
+  contract_definition?: string;
 };
 
 export const transformProductToDTO = (
@@ -57,6 +61,7 @@ export const transformProductToDTO = (
   return {
     ...product,
     certificate_definition: product.certificate_definition?.id,
+    contract_definition: product.contract_definition?.id,
   };
 };
 

--- a/src/frontend/admin/src/services/factories/product/index.ts
+++ b/src/frontend/admin/src/services/factories/product/index.ts
@@ -4,6 +4,7 @@ import { CertificateDefinitionFactory } from "@/services/factories/certificate-d
 import { randomNumber } from "@/utils/numbers";
 import { ProductTargetCourseRelationFactory } from "@/services/api/models/ProductTargetCourseRelation";
 import { ProductRelationToCourseFactory } from "@/services/api/models/Relations";
+import { ContractDefinitionFactory } from "@/services/factories/contract-definition";
 
 const build = (): Product => {
   return {
@@ -17,6 +18,7 @@ const build = (): Product => {
     certificate_definition: CertificateDefinitionFactory(),
     target_courses: ProductTargetCourseRelationFactory(randomNumber(2)),
     course_relations: ProductRelationToCourseFactory(2),
+    contract_definition: ContractDefinitionFactory(),
   };
 };
 

--- a/src/frontend/admin/src/tests/product/ProductTestScenario.ts
+++ b/src/frontend/admin/src/tests/product/ProductTestScenario.ts
@@ -13,10 +13,12 @@ import {
   DTOProductTargetCourseRelation,
   ProductTargetCourseRelation,
 } from "@/services/api/models/ProductTargetCourseRelation";
+import { ContractDefinition } from "@/services/api/models/ContractDefinition";
 
 type ProductStore = {
   products: Product[];
   certificateDefinitions: CertificateDefinition[];
+  contractsDefinitions: ContractDefinition[];
   courses: Course[];
   targetCourses: ProductTargetCourseRelation[];
   organizations: Organization[];
@@ -29,6 +31,11 @@ export const getProductScenarioStore = (): ProductStore => {
   const certificateDefinitions = products.map((product) => {
     return product.certificate_definition!;
   });
+
+  const contractsDefinitions = products.map((product) => {
+    return product.contract_definition!;
+  });
+
   const courses: Course[] = [];
   const organizations: Organization[] = [];
   const courseRuns: CourseRun[] = [];
@@ -48,12 +55,19 @@ export const getProductScenarioStore = (): ProductStore => {
   });
 
   const postUpdate = (payload: DTOProduct, item?: Product) => {
-    const { certificate_definition: newCertificateDefinition, ...restPayload } =
-      payload;
+    const {
+      certificate_definition: newCertificateDefinition,
+      contract_definition: newContractDefinition,
+      ...restPayload
+    } = payload;
 
     const certificateDef = certificateDefinitions.find(
       (certificateDefinition) =>
         certificateDefinition.id === newCertificateDefinition,
+    );
+
+    const contractDef = contractsDefinitions.find(
+      (contractDefinition) => contractDefinition.id === newContractDefinition,
     );
 
     let newProduct: Product;
@@ -62,12 +76,14 @@ export const getProductScenarioStore = (): ProductStore => {
         ...item,
         ...restPayload,
         certificate_definition: certificateDef ?? item.certificate_definition,
+        contract_definition: contractDef ?? item.contract_definition,
       };
     } else {
       newProduct = {
         id: faker.string.uuid(),
         ...restPayload,
         ...(certificateDef && { certificate_definition: certificateDef }),
+        ...(contractDef && { contract_definition: contractDef }),
       };
     }
     products.push(newProduct);
@@ -77,6 +93,7 @@ export const getProductScenarioStore = (): ProductStore => {
   return {
     products,
     certificateDefinitions,
+    contractsDefinitions,
     courses,
     organizations,
     courseRuns,


### PR DESCRIPTION
## Purpose

Today, we cannot link a product to a contract definition. We therefore add this possibility in the form

## Proposal

- [x] add contract definition search
- [x] use contract definition search inside the ProductFormMain
- [x] update tests
