### PR TITLE
Fix dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,12 +70,9 @@ ENV PYTHONUNBUFFERED=1
 RUN apt-get update && \
     apt-get install -y \
       gettext \
-      libcairo2 \
-      libffi-dev \
-      libgdk-pixbuf2.0-0 \
       libpango-1.0-0 \
-      libpangocairo-1.0-0 \
-      shared-mime-info && \
+      libpangoft2-1.0-0 \
+      pango1.0-tools && \
   rm -rf /var/lib/apt/lists/*
 
 # Copy entrypoint

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "requests==2.31.0",
     "sentry-sdk==1.39.1",
     "url-normalize==1.4.3",
-    "WeasyPrint>=59.0",
+    "WeasyPrint>=60.2",
     "whitenoise==6.6.0",
 ]
 


### PR DESCRIPTION
## Purpose

The latest used version of Weasyprint did not use Cairo anymore.
The installation documentation of Weasyprint forgot to mention "pango1.0-tools" as a
dependency.

## Proposal

- [x] Upgrade Weasyprint to 60.2
- [x] Remove support of Cairo and add Pango1.0-tools
 
