### PR TITLE
✨(tray) allow to override settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow to override settings in tray
 - Add API endpoints for other services to fetch  data on course run
 - Allow to filter contracts by signature state,
   product, course and organization and id

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -73,7 +73,7 @@ spec:
             - name: DJANGO_CORS_ALLOWED_ORIGINS
               value: "{{ richie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},{{ joanie_admin_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
             - name: DJANGO_SETTINGS_MODULE
-              value: joanie.settings
+              value: joanie.configs.settings
             - name: JOANIE_BACKOFFICE_BASE_URL
               value: {{joanie_admin_host}}
           envFrom:
@@ -82,9 +82,17 @@ spec:
             - configMapRef:
                 name: "joanie-app-dotenv-{{ deployment_stamp }}"
           resources: {{ joanie_app_resources }}
+          volumeMounts:
+            - name: joanie-configmap
+              mountPath: /app/joanie/configs
 {% if service_variant=="celery" %}
           command: {{ joanie_celery_command }}
 {% endif %}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}
+      volumes:
+        - name: joanie-configmap
+          configMap:
+            defaultMode: 420
+            name: joanie-app-{{ deployment_stamp }}


### PR DESCRIPTION
## Purpose

In the joanie app tray, the configs/settings.py.j2 file exists. This file is here to allow to override the settings class in arnold. But to exploit this feature, the Deployment must mount the associated ConfigMap in the the joanie container. This commit add this.

## Proposal

- [x] allow to override settings in tray