### PR TITLE
✨(back) dedicated storage for easy_thumbnail using boto3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Dedicated storage for easy_thumbnail using boto3
 - Allow to override settings in tray
 - Add API endpoints for other services to fetch  data on course run
 - Allow to filter contracts by signature state,

--- a/src/backend/joanie/core/storages.py
+++ b/src/backend/joanie/core/storages.py
@@ -1,0 +1,14 @@
+"""Module containing specific storages."""
+from django.conf import settings
+
+from storages.backends.s3 import S3Storage
+
+
+# pylint: disable=abstract-method
+class JoanieEasyThumbnailS3Storage(S3Storage):
+    """
+    Storage used by easy thumbnail and defined in the settings THUMBNAIL_DEFAULT_STORAGE.
+    It uses the settings shared with the default storage. Only the location is redefined.
+    """
+
+    location = settings.THUMBNAIL_STORAGE_S3_LOCATION

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -412,6 +412,7 @@ class Base(Configuration):
             "128w": {"size": (128, 128), "crop": "scale", "upscale": True},
         },
     }
+    THUMBNAIL_STORAGE_S3_LOCATION = values.Value("thumbnails")
 
     # Signature Backend
     JOANIE_SIGNATURE_BACKEND = values.Value(
@@ -690,6 +691,10 @@ class Production(Base):
             },
         },
     }
+
+    THUMBNAIL_DEFAULT_STORAGE = values.Value(
+        "joanie.core.storages.JoanieEasyThumbnailS3Storage"
+    )
 
     # Privacy
     SECURE_REFERRER_POLICY = "same-origin"


### PR DESCRIPTION
## Purpose

We want to use a S3 storage with easy_thumbnail. We are already using it for the default storage, we just want to redefined the location. Easy_thumbnail lib is still not using the storages settings introduced in django 4 so we have to create a dedicated class extending boto3 class. Pylint is warning us to override some abstract method, but this is not our job to do that, it should be handle by boto3.

## Proposal

- [x] dedicated storage for easy_thumbnail using boto3
