### PR TITLE
🔧(backend) allow to configure CSRF_COOKIE_DOMAIN from env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow to set CSRF_COOKIE_DOMAIN through env vars
 - Dedicated storage for easy_thumbnail using boto3
 - Allow to override settings in tray
 - Add API endpoints for other services to fetch  data on course run

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -646,6 +646,7 @@ class Production(Base):
     # Security
     ALLOWED_HOSTS = values.ListValue(None)
     CSRF_TRUSTED_ORIGINS = values.ListValue([])
+    CSRF_COOKIE_DOMAIN = values.Value(None)
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
 

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -72,6 +72,8 @@ spec:
               value: "{{ joanie_django_configuration }}"
             - name: DJANGO_CORS_ALLOWED_ORIGINS
               value: "{{ richie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},{{ joanie_admin_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+            - name: DJANGO_CSRF_COOKIE_DOMAIN
+              value: ".{{ joanie_host }}"
             - name: DJANGO_SETTINGS_MODULE
               value: joanie.configs.settings
             - name: JOANIE_BACKOFFICE_BASE_URL


### PR DESCRIPTION
## Purpose

The admin backoffice must send CSRF Token provided by Joanie django app to RUD resources. The admin backoffice must be served on the sudmain of the Joanie django app but by default the CSRF Cookie is only accessible on the same domain.
 We must be able to configure the django setting `CSRF_COOKIE_DOMAIN` to share
 this cookie on all subdomains to make it work.

## Proposal

- [x] Allow to set `CSRF_COOKIE_DOMAIN` django settings through environment variables
