### PR TITLE
🩹(backend) do not use user.last_name to create org signatory step

### DIFF
--- a/src/backend/joanie/signature/backends/lex_persona.py
+++ b/src/backend/joanie/signature/backends/lex_persona.py
@@ -79,7 +79,11 @@ class LexPersonaBackend(BaseSignatureBackend):
             {
                 "email": access.user.email,
                 "firstName": access.user.first_name,
-                "lastName": access.user.last_name,
+                # Currently, we only have the `full_name` from OpenEdx that we set in the user's
+                # `first_name` in Joanie. We don't have yet the `last_name` and `first_name` that
+                # are separated in our database. In order to prepare the awaited payload for the
+                # signature provider, we set a dot : ".", for the `lastName` key.
+                "lastName": ".",
                 "country": country.upper(),
                 "preferred_locale": access.user.language.lower(),
                 "consentPageId": consent_page_id,

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
@@ -80,7 +80,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
                             "country": "FR",
                             "email": "johnnydoe@example.fr",
                             "firstName": "Johnny",
-                            "lastName": "Doe",
+                            "lastName": ".",
                             "preferredLocale": "fr",
                         }
                     ],
@@ -141,7 +141,7 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
                                     {
                                         "email": access.user.email,
                                         "firstName": access.user.first_name,
-                                        "lastName": access.user.last_name,
+                                        "lastName": ".",
                                         "country": order.organization.country.code.upper(),
                                         "preferred_locale": access.user.language.lower(),
                                         "consentPageId": "cop_id_fake",


### PR DESCRIPTION
## Purpose

Our user does not have lastname fulfilled, indeed, on our authentication platform, there is only a full name that we store into the first name field. To submit a contract to organization signature, we were using the `user.last_name` but as this field was blank, Lex Persona returned an error.

## Proposal

- [x] Remove the user of user.last_name to create the Lex Persona step for the organization 
