### PR TITLE
✨(frontend) add many filters

### DIFF
--- a/src/frontend/admin/src/components/presentational/filters/SearchFilters.tsx
+++ b/src/frontend/admin/src/components/presentational/filters/SearchFilters.tsx
@@ -1,0 +1,238 @@
+import * as React from "react";
+import {
+  PropsWithChildren,
+  ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import InputAdornment from "@mui/material/InputAdornment";
+import CircularProgress from "@mui/material/CircularProgress";
+import SearchOutlined from "@mui/icons-material/SearchOutlined";
+import TextField from "@mui/material/TextField";
+import { useDebouncedCallback } from "use-debounce";
+import { FilterList } from "@mui/icons-material";
+import Chip from "@mui/material/Chip";
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import CloseIcon from "@mui/icons-material/Close";
+import { defineMessages, FormattedMessage, useIntl } from "react-intl";
+import Alert from "@mui/material/Alert";
+import { useModal } from "@/components/presentational/modal/useModal";
+import { CustomModal } from "@/components/presentational/modal/Modal";
+import { Maybe } from "@/types/utils";
+
+const messages = defineMessages({
+  filtersLabelButton: {
+    id: "components.presentational.filters.searchFilters.filtersLabelButton",
+    defaultMessage: "Filters",
+    description: "Label for the filters button",
+  },
+  clear: {
+    id: "components.presentational.filters.searchFilters.clear",
+    defaultMessage: "Clear",
+    description: "Label for the clear filters button",
+  },
+  filtersModalTitle: {
+    id: "components.presentational.filters.searchFilters.filtersModalTitle",
+    defaultMessage: "Add filters",
+    description: "Label for the filter modal title",
+  },
+  filtersModalInfo: {
+    id: "components.presentational.filters.searchFilters.filtersModalInfo",
+    defaultMessage:
+      'In this part, you can add filters to filter entities based on different parameters. On a multiple choice filter, an "OR" is applied',
+    description: "Label for the filter modal alert info",
+  },
+  searchPlaceholder: {
+    id: "components.presentational.filters.searchFilters.searchPlaceholder",
+    defaultMessage: "Search...",
+    description: "Label for the search input",
+  },
+});
+
+type FilterChip = {
+  name: string;
+  label: string;
+  value: string;
+  onDelete: (name: string) => void;
+};
+
+export type MandatorySearchFilterProps = {
+  searchInputPlaceholder?: string;
+  onSearch?: (term: string) => void;
+  loading?: boolean;
+};
+
+export type SearchFilterProps = MandatorySearchFilterProps & {
+  renderContent?: (
+    addChip: (chip: FilterChip) => void,
+    removeChip: (chipName: string) => void,
+  ) => ReactNode;
+};
+export function SearchFilters(props: PropsWithChildren<SearchFilterProps>) {
+  const intl = useIntl();
+  const modal = useModal();
+  const [chips, setChips] = useState<FilterChip[]>([]);
+
+  const onChangeSearchInput = useDebouncedCallback((term: string) => {
+    props.onSearch?.(term);
+  });
+
+  const addChip = (newChip: FilterChip) => {
+    const newChips = [...chips];
+    const index = newChips.findIndex((chip) => {
+      return chip.name === newChip.name;
+    });
+    if (index < 0) {
+      newChips.push(newChip);
+    } else {
+      newChips[index] = newChip;
+    }
+    setChips(newChips);
+  };
+
+  const deleteChip = (chip: FilterChip, index: number): void => {
+    const newChips = [...chips];
+    newChips.splice(index, 1);
+    setChips(newChips);
+    chip.onDelete(chip.name);
+  };
+
+  const onRemoveChip = (name: string): void => {
+    const newChips = [...chips];
+    const index = newChips.findIndex((chip) => {
+      return chip.name === name;
+    });
+    if (index < 0) {
+      return;
+    }
+    newChips.splice(index, 1);
+    setChips(newChips);
+  };
+
+  const providerValue = useMemo(() => {
+    return { addChip, removeChip: onRemoveChip };
+  }, [chips, addChip, onRemoveChip]);
+
+  const clearAll = () => {
+    chips.forEach((chip) => {
+      chip.onDelete(chip.name);
+    });
+    setChips([]);
+  };
+
+  return (
+    <SearchFilterContext.Provider value={providerValue}>
+      <div>
+        <Box display="flex" alignItems="center">
+          <TextField
+            margin="none"
+            autoComplete="off"
+            defaultValue=""
+            onChange={(event) => onChangeSearchInput(event.target.value)}
+            fullWidth
+            placeholder={
+              props.searchInputPlaceholder ??
+              intl.formatMessage(messages.searchPlaceholder)
+            }
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  {props.loading ? (
+                    <CircularProgress size="19px" />
+                  ) : (
+                    <SearchOutlined />
+                  )}
+                </InputAdornment>
+              ),
+            }}
+          />
+          {props.renderContent && (
+            <Button
+              sx={{ ml: 2 }}
+              startIcon={<FilterList />}
+              onClick={modal.handleOpen}
+            >
+              <FormattedMessage {...messages.filtersLabelButton} />
+            </Button>
+          )}
+        </Box>
+        {props.renderContent && (
+          <Box display="flex" alignItems="center">
+            <CustomModal
+              keepMounted={true}
+              fullWidth={true}
+              maxWidth="md"
+              title={intl.formatMessage(messages.filtersModalTitle)}
+              {...modal}
+            >
+              <Stack>
+                <Alert severity="info">
+                  <FormattedMessage {...messages.filtersModalInfo} />
+                </Alert>
+                <Box>{props.renderContent(addChip, onRemoveChip)}</Box>
+              </Stack>
+            </CustomModal>
+            {chips.length > 0 && (
+              <Stack
+                sx={{ p: "8px 16px 0 16px" }}
+                direction="row"
+                alignItems="center"
+                spacing={1}
+                flexWrap="wrap"
+              >
+                {chips.map((chip, index) => (
+                  <Chip
+                    key={chip.name}
+                    label={`${chip.label}: ${chip.value}`}
+                    color="secondary"
+                    variant="outlined"
+                    size="small"
+                    onDelete={() => deleteChip(chip, index)}
+                  />
+                ))}
+                <Button
+                  size="small"
+                  endIcon={<CloseIcon fontSize="small" />}
+                  onClick={clearAll}
+                >
+                  <FormattedMessage {...messages.clear} />
+                </Button>
+              </Stack>
+            )}
+          </Box>
+        )}
+      </div>
+    </SearchFilterContext.Provider>
+  );
+}
+
+export type SearchFilterComponentProps = {
+  isFilterContext?: boolean;
+};
+
+export interface SearchFilterContextInterface {
+  removeChip: (name: string) => void;
+  addChip: (chip: FilterChip) => void;
+}
+
+export const SearchFilterContext =
+  React.createContext<Maybe<SearchFilterContextInterface>>(undefined);
+
+export const useSearchFilterContext = (enable: boolean = false) => {
+  const searchFilterContext = useContext(SearchFilterContext);
+
+  if (!enable) {
+    return null;
+  }
+
+  if (!searchFilterContext) {
+    throw new Error(
+      `useSearchFilterContext must be used within a SearchFilterContext`,
+    );
+  }
+
+  return searchFilterContext;
+};

--- a/src/frontend/admin/src/components/presentational/hook-form/RFHValuesChange.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RFHValuesChange.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { PropsWithChildren, useEffect } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useDebouncedCallback } from "use-debounce";
 import { FieldValues } from "react-hook-form/dist/types/fields";
@@ -7,28 +7,42 @@ import { FieldValues } from "react-hook-form/dist/types/fields";
 type Props<T extends FieldValues> = {
   onSubmit: (values: T) => void;
   debounceTime?: number;
+  useAnotherValueReference?: boolean;
 };
 export function RHFValuesChange<T extends FieldValues>({
   debounceTime = 800,
+  useAnotherValueReference = false,
   ...props
 }: PropsWithChildren<Props<T>>) {
   const {
     handleSubmit,
     watch,
-    formState: { isDirty, isValid },
+    formState: { isValid },
   } = useFormContext<T>();
   const values = watch();
+  const [oldValues, setOldValues] = useState<T>();
 
   const onValuesChange = useDebouncedCallback(() => {
-    if (!isDirty || !isValid) {
+    if (!isValid) {
       return;
     }
 
-    handleSubmit(props.onSubmit)();
+    /**
+     * Because with the react hook form, the reference does not change, so if we want to perform a particular behavior
+     * with a setState for example, the setState does not trigger a rerender, because the reference has not changed.
+     */
+    if (useAnotherValueReference) {
+      handleSubmit(() => props.onSubmit({ ...values }))();
+    } else {
+      handleSubmit(props.onSubmit)();
+    }
   }, debounceTime);
 
   useEffect(() => {
-    onValuesChange();
+    if (JSON.stringify(values) !== JSON.stringify(oldValues)) {
+      setOldValues(values);
+      onValuesChange();
+    }
   }, [values]);
 
   return <div>{props.children}</div>;

--- a/src/frontend/admin/src/components/presentational/hook-form/RHFSearch.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFSearch.tsx
@@ -10,14 +10,17 @@ import RHFAutocomplete, {
   RHFAutocompleteProps,
 } from "@/components/presentational/hook-form/RHFAutocomplete";
 import { Maybe, Nullable } from "@/types/utils";
+import { SearchFilterComponentProps } from "@/components/presentational/filters/SearchFilters";
 
-export interface RHFAutocompleteSearchProps<T>
-  extends Omit<RHFAutocompleteProps<T, Maybe<boolean>>, "options"> {
+export type RHFAutocompleteSearchProps<T> = Omit<
+  RHFAutocompleteProps<T, Maybe<boolean>>,
+  "options"
+> & {
   enableAdd?: boolean;
   enableEdit?: boolean;
   onAddClick?: () => void;
   onEditClick?: () => void;
-}
+};
 
 export interface RHFSearchProps<T> extends RHFAutocompleteSearchProps<T> {
   items: T[];
@@ -32,7 +35,7 @@ export function RHFSearch<T>({
   items,
   onFilter,
   ...props
-}: RHFSearchProps<T>) {
+}: RHFSearchProps<T> & SearchFilterComponentProps) {
   const { getValues } = useFormContext();
   const value: Nullable<T> = getValues(props.name);
   const [search, setSearch] = useState("");

--- a/src/frontend/admin/src/components/presentational/hook-form/RHFSelect.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFSelect.tsx
@@ -6,32 +6,49 @@ import MenuItem from "@mui/material/MenuItem";
 import Box from "@mui/material/Box";
 import InputAdornment from "@mui/material/InputAdornment";
 import Divider from "@mui/material/Divider";
+import { FormattedMessage } from "react-intl";
+import ClearIcon from "@mui/icons-material/Clear";
+import IconButton from "@mui/material/IconButton";
 import { Maybe } from "@/types/utils";
+import { commonTranslations } from "@/translations/common/commonTranslations";
+import {
+  SearchFilterComponentProps,
+  useSearchFilterContext,
+} from "@/components/presentational/filters/SearchFilters";
 
-export interface SelectOption {
+export interface SelectOption<OptionValue = any> {
   label: string;
-  value: any;
+  value: OptionValue;
 }
 
-export type RHFSelectProps = TextFieldProps & {
-  name: string;
-  native?: boolean;
-  maxHeight?: boolean | number;
-  children?: React.ReactNode;
-  options?: SelectOption[];
-  leftIcons?: ReactNode;
-};
+export type RHFSelectProps = Omit<TextFieldProps, "label"> &
+  SearchFilterComponentProps & {
+    name: string;
+    label?: string;
+    getOptionLabel?: (value: any) => string;
+    native?: boolean;
+    noneOption?: boolean;
+    maxHeight?: boolean | number;
+    children?: React.ReactNode;
+    options?: SelectOption[];
+    leftIcons?: ReactNode;
+    afterChange?: (newValue: any | null) => void;
+  };
 
 export function RHFSelect({
   name,
   helperText,
   children,
   options = [],
+  noneOption = false,
   leftIcons,
+  getOptionLabel,
+  isFilterContext,
+  afterChange,
   ...other
 }: RHFSelectProps) {
-  const { control } = useFormContext();
-
+  const searchFilterContext = useSearchFilterContext(isFilterContext);
+  const { control, setValue } = useFormContext();
   const leftIconsElement = useMemo((): Maybe<ReactNode> => {
     if (leftIcons === undefined) {
       return undefined;
@@ -49,6 +66,30 @@ export function RHFSelect({
     );
   }, [leftIcons]);
 
+  const addOrRemoveChip = (newValue?: string) => {
+    if (!isFilterContext) {
+      return;
+    }
+
+    if (afterChange) {
+      afterChange(newValue);
+    } else if (newValue) {
+      searchFilterContext?.addChip({
+        name,
+        label: other.label ?? "",
+        value: getOptionLabel ? getOptionLabel(newValue) : newValue,
+        onDelete: (chipName: string) => setValue(chipName, ""),
+      });
+    } else {
+      searchFilterContext?.removeChip(name);
+    }
+  };
+
+  const clickOnDelete = () => {
+    afterChange?.("");
+    addOrRemoveChip(undefined);
+  };
+
   return (
     <Controller
       name={name}
@@ -56,9 +97,36 @@ export function RHFSelect({
       render={({ field, fieldState: { error } }) => (
         <TextField
           {...field}
+          onChange={(e) => {
+            field.onChange(e);
+            addOrRemoveChip?.(e.target.value);
+          }}
+          sx={{
+            "&:hover": {
+              ".clear-select-button": {
+                opacity: 1,
+              },
+            },
+          }}
           select
           InputProps={{
             startAdornment: leftIconsElement,
+            endAdornment: (
+              <IconButton
+                size="small"
+                className="clear-select-button"
+                sx={{
+                  mr: 2,
+                  opacity: 0,
+                }}
+                onClick={() => {
+                  field.onChange({ target: { value: "" } });
+                  clickOnDelete();
+                }}
+              >
+                <ClearIcon fontSize="small" />
+              </IconButton>
+            ),
             inputProps: {
               "data-testid": "select-value",
             },
@@ -68,6 +136,13 @@ export function RHFSelect({
           helperText={error ? error?.message : helperText}
           {...other}
         >
+          {noneOption && (
+            <MenuItem value="">
+              <em>
+                <FormattedMessage {...commonTranslations.none} />
+              </em>
+            </MenuItem>
+          )}
           {options?.map((option) => {
             return (
               <MenuItem key={option.label} value={option.value}>

--- a/src/frontend/admin/src/components/presentational/hook-form/RHFToggleButtonGroup.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFToggleButtonGroup.tsx
@@ -5,20 +5,13 @@ import FormHelperText from "@mui/material/FormHelperText";
 import FormLabel from "@mui/material/FormLabel";
 import Radio from "@mui/material/Radio";
 import RadioGroup, { RadioGroupProps } from "@mui/material/RadioGroup";
-import { SelectOption } from "@/components/presentational/hook-form/RHFSelect";
-import {
-  SearchFilterComponentProps,
-  useSearchFilterContext,
-} from "@/components/presentational/filters/SearchFilters";
 
-type Props<> = RadioGroupProps &
-  SearchFilterComponentProps & {
-    name: string;
-    options: SelectOption[];
-    label?: string;
-    helperText?: React.ReactNode;
-    getValueLabel?: (value: string) => string;
-  };
+type Props = RadioGroupProps & {
+  name: string;
+  options: { label: string; value: any }[];
+  label?: string;
+  helperText?: React.ReactNode;
+};
 
 export default function RHFRadioGroup({
   row,
@@ -26,36 +19,11 @@ export default function RHFRadioGroup({
   label,
   options,
   helperText,
-  isFilterContext,
-  getValueLabel,
   ...other
 }: Props) {
-  const { control, setValue } = useFormContext();
-  const searchFilterContext = useSearchFilterContext(isFilterContext);
+  const { control } = useFormContext();
 
   const labelledby = label ? `${name}-${label}` : "";
-
-  const afterChange = (newValue?: string) => {
-    if (!searchFilterContext) {
-      return;
-    }
-    if (newValue && newValue !== "none" && newValue !== "") {
-      const hasNoneOption =
-        options.filter((option) => option.value === "none").length > 0;
-      searchFilterContext.addChip({
-        name,
-        label: label ?? "",
-        value: getValueLabel ? getValueLabel(newValue) : "",
-        onDelete: () =>
-          setValue(name, hasNoneOption ? "none" : "", {
-            shouldValidate: true,
-            shouldDirty: true,
-          }),
-      });
-    } else {
-      searchFilterContext.removeChip(name);
-    }
-  };
 
   return (
     <Controller
@@ -71,10 +39,6 @@ export default function RHFRadioGroup({
 
           <RadioGroup
             {...field}
-            onChange={(e, v) => {
-              field.onChange(e, v);
-              afterChange(v);
-            }}
             aria-labelledby={labelledby}
             row={row}
             {...other}

--- a/src/frontend/admin/src/components/presentational/modal/Modal.tsx
+++ b/src/frontend/admin/src/components/presentational/modal/Modal.tsx
@@ -4,6 +4,8 @@ import Dialog, { DialogProps } from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
+import IconButton from "@mui/material/IconButton";
+import CloseIcon from "@mui/icons-material/Close";
 
 export interface CustomModalProps extends DialogProps {
   title: string;
@@ -29,6 +31,18 @@ export function CustomModal({
   return (
     <Dialog {...props} open={open} onClose={handleClose}>
       <DialogTitle>{title}</DialogTitle>
+      <IconButton
+        aria-label="close"
+        onClick={handleClose}
+        sx={{
+          position: "absolute",
+          right: 8,
+          top: 8,
+          color: (theme) => theme.palette.grey[500],
+        }}
+      >
+        <CloseIcon />
+      </IconButton>
       <DialogContent sx={{ padding: disablePadding ? 0 : 3 }}>
         {children}
       </DialogContent>

--- a/src/frontend/admin/src/components/presentational/table/TableComponent.tsx
+++ b/src/frontend/admin/src/components/presentational/table/TableComponent.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
-import { useState } from "react";
+import { ReactElement, useState } from "react";
 import { DataGrid, GridColDef, GridRowSelectionModel } from "@mui/x-data-grid";
 import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
-import InputAdornment from "@mui/material/InputAdornment";
-import TextField from "@mui/material/TextField";
-import SearchOutlined from "@mui/icons-material/SearchOutlined";
 import { useIntl } from "react-intl";
 import { useDebouncedCallback } from "use-debounce";
 import { DataGridProps } from "@mui/x-data-grid/models/props/DataGridProps";
 import { GridValidRowModel } from "@mui/x-data-grid/models/gridRows";
+import TextField from "@mui/material/TextField";
+import InputAdornment from "@mui/material/InputAdornment";
+import SearchOutlined from "@mui/icons-material/SearchOutlined";
 import {
   TableDefaultActions,
   TableDefaultMenuItem,
@@ -24,9 +24,11 @@ export type DefaultTableProps<T extends GridValidRowModel> = {
   selectAllByDefault?: boolean;
   onSelectRows?: (ids: string[], items: T[]) => void;
   defaultSelectedRows?: string[];
-  multiSelectActions?: React.ReactElement;
-  topActions?: React.ReactElement;
+  filters?: ReactElement;
+  multiSelectActions?: ReactElement;
+  topActions?: ReactElement;
   enableSearch?: boolean;
+  changeUrlOnPageChange?: boolean;
 };
 
 export type TableComponentProps<T extends GridValidRowModel> =
@@ -40,7 +42,7 @@ export type TableComponentProps<T extends GridValidRowModel> =
       onRemoveClick?: (row: T) => void;
       getEntityName?: (row: T) => string;
       onSearch?: (term: string) => void;
-      multiSelectActions?: React.ReactElement;
+      multiSelectActions?: ReactElement;
       loading?: boolean;
       columnBuffer?: number;
       getOptions?: (row: T) => TableDefaultMenuItem[];
@@ -143,7 +145,9 @@ export function TableComponent<T extends GridValidRowModel>({
         {props.topActions && (
           <Box mb={enableSearch ? 2 : 0}>{props.topActions}</Box>
         )}
-        {enableSearch && props.onSearch && (
+
+        {props.filters}
+        {enableSearch && props.onSearch && !props.filters && (
           <TextField
             margin="none"
             autoComplete="off"
@@ -226,13 +230,13 @@ export function TableComponent<T extends GridValidRowModel>({
               },
             },
           }}
-          pageSizeOptions={[20]}
           autoHeight={true}
           localeText={{
             noRowsLabel: intl.formatMessage(tableTranslations.noRows),
             footerRowSelected: (count) =>
               intl.formatMessage(tableTranslations.rowsSelected, { count }),
           }}
+          pageSizeOptions={[DEFAULT_PAGE_SIZE]}
           checkboxSelection={enableSelect}
           onRowSelectionModelChange={(newRowSelectionModel) => {
             onSelectItems(newRowSelectionModel as string[]);

--- a/src/frontend/admin/src/components/templates/certificates-definitions/filters/CertificateDefinitionFilters.tsx
+++ b/src/frontend/admin/src/components/templates/certificates-definitions/filters/CertificateDefinitionFilters.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Grid from "@mui/material/Unstable_Grid2";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  MandatorySearchFilterProps,
+  SearchFilters,
+} from "@/components/presentational/filters/SearchFilters";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFValuesChange } from "@/components/presentational/hook-form/RFHValuesChange";
+import { RHFCertificateDefinitionTemplates } from "@/components/templates/certificates-definitions/inputs/RHFCertificateDefinitionTemplates";
+import { CertificateDefinitionResourceQuery } from "@/hooks/useCertificateDefinitions/useCertificateDefinitions";
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: "components.templates.certificatesDefinitions.filters.CertificateDefinitionFilters.searchPlaceholder",
+    description: "Text for the search input placeholder",
+    defaultMessage: "Search by title or name",
+  },
+});
+
+type Props = MandatorySearchFilterProps & {
+  onFilter: (values: CertificateDefinitionResourceQuery) => void;
+};
+
+export function CertificateDefinitionFilters({
+  onFilter,
+  ...searchFilterProps
+}: Props) {
+  const intl = useIntl();
+  const getDefaultValues = () => {
+    return {
+      template: "",
+    };
+  };
+  const RegisterSchema = Yup.object().shape({
+    template: Yup.string().nullable(),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(RegisterSchema),
+    defaultValues: getDefaultValues() as any, // To not trigger type validation for default value
+  });
+
+  return (
+    <SearchFilters
+      {...searchFilterProps}
+      searchInputPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
+      renderContent={() => (
+        <RHFProvider
+          id="certificate-definition-filter-form"
+          showSubmit={false}
+          methods={methods}
+        >
+          <RHFValuesChange
+            debounceTime={200}
+            useAnotherValueReference={true}
+            onSubmit={onFilter}
+          >
+            <Grid container mt={2} spacing={2}>
+              <Grid xs={12}>
+                <RHFCertificateDefinitionTemplates
+                  isFilterContext={true}
+                  name="template"
+                />
+              </Grid>
+            </Grid>
+          </RHFValuesChange>
+        </RHFProvider>
+      )}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/certificates-definitions/inputs/RHFCertificateDefinitionTemplates.tsx
+++ b/src/frontend/admin/src/components/templates/certificates-definitions/inputs/RHFCertificateDefinitionTemplates.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { defineMessages, useIntl } from "react-intl";
+import { useQuery } from "@tanstack/react-query";
+import {
+  RHFSelect,
+  RHFSelectProps,
+} from "@/components/presentational/hook-form/RHFSelect";
+import { SearchFilterComponentProps } from "@/components/presentational/filters/SearchFilters";
+import { CertificateDefinitionRepository } from "@/services/repositories/certificate-definition/CertificateDefinitionRepository";
+
+const messages = defineMessages({
+  templateLabel: {
+    id: "components.templates.certificateDefinition.form.RHFCertificateDefinitionTemplates.templateLabel",
+    defaultMessage: "Template",
+    description: "Label for the certificate definition template input",
+  },
+});
+
+type Props = SearchFilterComponentProps &
+  RHFSelectProps & {
+    name: string;
+  };
+
+export function RHFCertificateDefinitionTemplates({
+  name,
+  isFilterContext,
+}: Props) {
+  const intl = useIntl();
+
+  const languages = useQuery({
+    queryKey: ["certificateDefinitionTemplates"],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: async () => {
+      return CertificateDefinitionRepository.getAllTemplates();
+    },
+  });
+
+  return (
+    <RHFSelect
+      data-testid="certificate-template-select"
+      disabled={languages.isLoading}
+      name={name}
+      options={languages.data ?? []}
+      isFilterContext={isFilterContext}
+      label={intl.formatMessage(messages.templateLabel)}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/certificates-definitions/list/CertificatesDefinitionsList.tsx
+++ b/src/frontend/admin/src/components/templates/certificates-definitions/list/CertificatesDefinitionsList.tsx
@@ -2,14 +2,21 @@ import * as React from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { useRouter } from "next/router";
 import { GridColDef } from "@mui/x-data-grid";
-import { TableComponent } from "@/components/presentational/table/TableComponent";
+import {
+  DefaultTableProps,
+  TableComponent,
+} from "@/components/presentational/table/TableComponent";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { CertificateDefinition } from "@/services/api/models/CertificateDefinition";
-import { useCertificateDefinitions } from "@/hooks/useCertificateDefinitions/useCertificateDefinitions";
+import {
+  CertificateDefinitionResourceQuery,
+  useCertificateDefinitions,
+} from "@/hooks/useCertificateDefinitions/useCertificateDefinitions";
 import { CustomLink } from "@/components/presentational/link/CustomLink";
 import { commonTranslations } from "@/translations/common/commonTranslations";
 import { SimpleCard } from "@/components/presentational/card/SimpleCard";
 import { usePaginatedTableResource } from "@/components/presentational/table/usePaginatedTableResource";
+import { CertificateDefinitionFilters } from "@/components/templates/certificates-definitions/filters/CertificateDefinitionFilters";
 
 const messages = defineMessages({
   nameHeader: {
@@ -24,12 +31,19 @@ const messages = defineMessages({
   },
 });
 
-export function CertificatesDefinitionsList() {
+type Props = DefaultTableProps<CertificateDefinition>;
+
+export function CertificatesDefinitionsList(props: Props) {
   const intl = useIntl();
-  const paginatedResource = usePaginatedTableResource<CertificateDefinition>({
-    useResource: useCertificateDefinitions,
-  });
   const { push } = useRouter();
+
+  const paginatedResource = usePaginatedTableResource<
+    CertificateDefinition,
+    CertificateDefinitionResourceQuery
+  >({
+    useResource: useCertificateDefinitions,
+    changeUrlOnPageChange: props.changeUrlOnPageChange,
+  });
 
   const columns: GridColDef<CertificateDefinition>[] = [
     {
@@ -67,6 +81,11 @@ export function CertificatesDefinitionsList() {
   return (
     <SimpleCard>
       <TableComponent
+        {...paginatedResource.tableProps}
+        {...props}
+        filters={
+          <CertificateDefinitionFilters {...paginatedResource.filtersProps} />
+        }
         columns={columns}
         columnBuffer={3}
         onEditClick={(certificateDefinition: CertificateDefinition) => {
@@ -75,7 +94,6 @@ export function CertificatesDefinitionsList() {
           }
           push(PATH_ADMIN.certificates.edit(certificateDefinition.id));
         }}
-        {...paginatedResource.tableProps}
         onUseAsTemplateClick={(certificateDefinition) => {
           if (certificateDefinition.id === undefined) {
             return;

--- a/src/frontend/admin/src/components/templates/contract-definition/filters/ContractDefinitionFilters.tsx
+++ b/src/frontend/admin/src/components/templates/contract-definition/filters/ContractDefinitionFilters.tsx
@@ -1,0 +1,74 @@
+import * as React from "react";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Grid from "@mui/material/Unstable_Grid2";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  MandatorySearchFilterProps,
+  SearchFilters,
+} from "@/components/presentational/filters/SearchFilters";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFValuesChange } from "@/components/presentational/hook-form/RFHValuesChange";
+import { RHFContractDefinitionLanguage } from "@/components/templates/contract-definition/inputs/RHFContractDefinitionLanguage";
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: "components.templates.contractDefinition.filters.ContractDefinitionFilters.searchPlaceholder",
+    description: "Text for the search input placeholder",
+    defaultMessage: "Search by title",
+  },
+});
+
+type Props = MandatorySearchFilterProps & {
+  onFilter: (values: any) => void;
+};
+
+export function ContractDefinitionFilters({
+  onFilter,
+  ...searchFilterProps
+}: Props) {
+  const intl = useIntl();
+  const getDefaultValues = () => {
+    return {
+      language: "",
+    };
+  };
+  const RegisterSchema = Yup.object().shape({
+    language: Yup.string().nullable(),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(RegisterSchema),
+    defaultValues: getDefaultValues() as any, // To not trigger type validation for default value
+  });
+
+  return (
+    <SearchFilters
+      {...searchFilterProps}
+      searchInputPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
+      renderContent={() => (
+        <RHFProvider
+          id="cotract-definition-filter-form"
+          showSubmit={false}
+          methods={methods}
+        >
+          <RHFValuesChange
+            debounceTime={200}
+            useAnotherValueReference={true}
+            onSubmit={onFilter}
+          >
+            <Grid container mt={2} spacing={2}>
+              <Grid xs={12}>
+                <RHFContractDefinitionLanguage
+                  isFilterContext={true}
+                  name="language"
+                />
+              </Grid>
+            </Grid>
+          </RHFValuesChange>
+        </RHFProvider>
+      )}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/contract-definition/form/ContractDefinitionForm.tsx
+++ b/src/frontend/admin/src/components/templates/contract-definition/form/ContractDefinitionForm.tsx
@@ -12,7 +12,6 @@ import { ErrorMessage } from "@hookform/error-message";
 import FormHelperText from "@mui/material/FormHelperText";
 import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
 import { RHFTextField } from "@/components/presentational/hook-form/RHFTextField";
-import { RHFSelect } from "@/components/presentational/hook-form/RHFSelect";
 import { ServerSideErrorForm } from "@/types/utils";
 import { genericUpdateFormError } from "@/utils/forms";
 import { useContractDefinitions } from "@/hooks/useContractDefinitions/useContractDefinitions";
@@ -22,7 +21,7 @@ import {
 } from "@/services/api/models/ContractDefinition";
 import { MarkdownComponent } from "@/components/presentational/inputs/markdown/MardownComponent";
 import { removeEOL } from "@/utils/string";
-import { languageTranslations } from "@/translations/common/languageTranslations";
+import { RHFContractDefinitionLanguage } from "@/components/templates/contract-definition/inputs/RHFContractDefinitionLanguage";
 
 const messages = defineMessages({
   informationText: {
@@ -155,20 +154,7 @@ export function ContractDefinitionForm({
             />
           </Grid>
           <Grid xs={12}>
-            <RHFSelect
-              name="language"
-              options={[
-                {
-                  label: intl.formatMessage(languageTranslations.french),
-                  value: "fr-fr",
-                },
-                {
-                  label: intl.formatMessage(languageTranslations.english),
-                  value: "en-us",
-                },
-              ]}
-              label={intl.formatMessage(messages.languageLabel)}
-            />
+            <RHFContractDefinitionLanguage name="language" />
           </Grid>
           <Grid xs={12}>
             <RHFTextField

--- a/src/frontend/admin/src/components/templates/contract-definition/inputs/RHFContractDefinitionLanguage.tsx
+++ b/src/frontend/admin/src/components/templates/contract-definition/inputs/RHFContractDefinitionLanguage.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+import { defineMessages, useIntl } from "react-intl";
+import { useQuery } from "@tanstack/react-query";
+import { languageTranslations } from "@/translations/common/languageTranslations";
+import {
+  RHFSelect,
+  RHFSelectProps,
+} from "@/components/presentational/hook-form/RHFSelect";
+import { SearchFilterComponentProps } from "@/components/presentational/filters/SearchFilters";
+import { LocalesEnum } from "@/types/i18n/LocalesEnum";
+import { ContractDefinitionRepository } from "@/services/repositories/contract-definition/ContractDefinitionRepository";
+
+const messages = defineMessages({
+  languageLabel: {
+    id: "components.templates.contractDefinitions.form.RhfContractDefinitionLanguage.languageLabel",
+    defaultMessage: "Language",
+    description: "Label for the language input",
+  },
+});
+
+type Props = SearchFilterComponentProps &
+  RHFSelectProps & {
+    name: string;
+  };
+
+export function RHFContractDefinitionLanguage({
+  name,
+  isFilterContext,
+}: Props) {
+  const intl = useIntl();
+
+  const defaultLanguages = [
+    {
+      label: intl.formatMessage(languageTranslations[LocalesEnum.FRENCH]),
+      value: LocalesEnum.FRENCH,
+    },
+    {
+      label: intl.formatMessage(languageTranslations[LocalesEnum.ENGLISH]),
+      value: LocalesEnum.ENGLISH,
+    },
+  ];
+
+  const languages = useQuery({
+    queryKey: ["contractDefinitionLanguages"],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: async () => {
+      return ContractDefinitionRepository.getAllLanguages();
+    },
+  });
+
+  return (
+    <RHFSelect
+      data-testid="contract-definition-language-input"
+      disabled={languages.isLoading}
+      getOptionLabel={(value: LocalesEnum) =>
+        intl.formatMessage(languageTranslations[value])
+      }
+      name={name}
+      options={languages.data ?? defaultLanguages}
+      isFilterContext={isFilterContext}
+      label={intl.formatMessage(messages.languageLabel)}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/contract-definition/list/ContractsDefinitionsList.tsx
+++ b/src/frontend/admin/src/components/templates/contract-definition/list/ContractsDefinitionsList.tsx
@@ -2,14 +2,21 @@ import * as React from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { useRouter } from "next/router";
 import { GridColDef } from "@mui/x-data-grid";
-import { TableComponent } from "@/components/presentational/table/TableComponent";
+import {
+  DefaultTableProps,
+  TableComponent,
+} from "@/components/presentational/table/TableComponent";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { CustomLink } from "@/components/presentational/link/CustomLink";
 import { commonTranslations } from "@/translations/common/commonTranslations";
 import { SimpleCard } from "@/components/presentational/card/SimpleCard";
-import { useContractDefinitions } from "@/hooks/useContractDefinitions/useContractDefinitions";
+import {
+  ContractDefinitionResourceQuery,
+  useContractDefinitions,
+} from "@/hooks/useContractDefinitions/useContractDefinitions";
 import { ContractDefinition } from "@/services/api/models/ContractDefinition";
 import { usePaginatedTableResource } from "@/components/presentational/table/usePaginatedTableResource";
+import { ContractDefinitionFilters } from "@/components/templates/contract-definition/filters/ContractDefinitionFilters";
 
 const messages = defineMessages({
   languageHeader: {
@@ -24,10 +31,16 @@ const messages = defineMessages({
   },
 });
 
-export function ContractsDefinitionsList() {
+type Props = DefaultTableProps<ContractDefinition>;
+
+export function ContractsDefinitionsList(props: Props) {
   const intl = useIntl();
-  const paginatedResource = usePaginatedTableResource<ContractDefinition>({
+  const paginatedResource = usePaginatedTableResource<
+    ContractDefinition,
+    ContractDefinitionResourceQuery
+  >({
     useResource: useContractDefinitions,
+    changeUrlOnPageChange: props.changeUrlOnPageChange,
   });
 
   const { push } = useRouter();
@@ -60,7 +73,11 @@ export function ContractsDefinitionsList() {
     <SimpleCard>
       <TableComponent
         {...paginatedResource.tableProps}
+        {...props}
         columns={columns}
+        filters={
+          <ContractDefinitionFilters {...paginatedResource.filtersProps} />
+        }
         columnBuffer={3}
         onEditClick={(contractsDefinition: ContractDefinition) => {
           if (contractsDefinition.id === undefined) {

--- a/src/frontend/admin/src/components/templates/courses-runs/filters/CourseRunFilters.tsx
+++ b/src/frontend/admin/src/components/templates/courses-runs/filters/CourseRunFilters.tsx
@@ -1,0 +1,177 @@
+import * as React from "react";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Grid from "@mui/material/Unstable_Grid2";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  MandatorySearchFilterProps,
+  SearchFilters,
+} from "@/components/presentational/filters/SearchFilters";
+import { Course } from "@/services/api/models/Course";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFValuesChange } from "@/components/presentational/hook-form/RFHValuesChange";
+import { CourseSearch } from "@/components/templates/courses/inputs/search/CourseSearch";
+import { RHFSelectCourseRunState } from "@/components/templates/courses-runs/input/RHFSelectCourseRunState";
+import RHFRadioGroup from "@/components/presentational/hook-form/RHFRadioGroup";
+import { commonTranslations } from "@/translations/common/commonTranslations";
+import { entitiesInputLabel } from "@/translations/common/entitiesInputLabel";
+import { courseRunFormMessages } from "@/components/templates/courses-runs/form/translations";
+import { CourseRunResourcesQuery } from "@/hooks/useCourseRun/useCourseRun";
+import { Organization } from "@/services/api/models/Organization";
+import { courseFormMessages } from "@/components/templates/courses/form/translations";
+import { OrganizationSearch } from "@/components/templates/organizations/inputs/search/OrganizationSearch";
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: "components.templates.coursesRuns.filters.CourseRunFilters.searchPlaceholder",
+    description: "Text for the search input placeholder",
+    defaultMessage: "Search by title or resource link",
+  },
+});
+
+type FormValues = {
+  course: Course;
+  courses: Course[];
+  organizations: Organization[];
+  state: string;
+  is_gradable: boolean | "none";
+  is_listed: boolean | "none";
+};
+
+type Props = MandatorySearchFilterProps & {
+  onFilter: (values: CourseRunResourcesQuery) => void;
+};
+
+export function CourseRunFilters({ onFilter, ...searchFilterProps }: Props) {
+  const intl = useIntl();
+
+  const trueFalseOptions = [
+    { label: intl.formatMessage(commonTranslations.none), value: "none" },
+    { label: intl.formatMessage(commonTranslations.yes), value: true },
+    { label: intl.formatMessage(commonTranslations.no), value: false },
+  ];
+
+  const getTrueFalseLabel = (value: string): string => {
+    if (value === "") {
+      return "";
+    }
+
+    return intl.formatMessage(
+      value === "true" ? commonTranslations.yes : commonTranslations.no,
+    );
+  };
+
+  const getDefaultValues = () => {
+    return {
+      course: null,
+      courses: [],
+      organizations: [],
+      state: "",
+      is_gradable: "none",
+      is_listed: "none",
+    };
+  };
+
+  const RegisterSchema = Yup.object().shape({
+    course: Yup.mixed<Course>().nullable(),
+    courses: Yup.array<any, Course>().nullable(),
+    organizations: Yup.array<any, Organization>().nullable(),
+    state: Yup.string().nullable(),
+    is_gradable: Yup.mixed().nullable(),
+    is_listed: Yup.mixed().nullable(),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(RegisterSchema),
+    defaultValues: getDefaultValues() as any, // To not trigger type validation for default value
+  });
+
+  const onSubmit = (values: FormValues) => {
+    const filters: CourseRunResourcesQuery = {
+      // courseId: values.course?.id,
+      course_ids: values.courses.map((course) => course.id),
+      organization_ids: values.organizations.map(
+        (organization) => organization.id,
+      ),
+      state: values.state,
+      is_listed: values.is_listed !== "none" ? values.is_listed : undefined,
+      is_gradable:
+        values.is_gradable !== "none" ? values.is_gradable : undefined,
+    };
+    onFilter(filters);
+  };
+
+  return (
+    <SearchFilters
+      {...searchFilterProps}
+      searchInputPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
+      renderContent={() => (
+        <RHFProvider
+          id="course-run-filters-form"
+          showSubmit={false}
+          methods={methods}
+        >
+          <RHFValuesChange debounceTime={200} onSubmit={onSubmit}>
+            <Grid container mt={2} spacing={2}>
+              <Grid xs={12} sm={6}>
+                <CourseSearch
+                  isFilterContext={true}
+                  multiple={true}
+                  fullWidth={true}
+                  label={intl.formatMessage(entitiesInputLabel.course)}
+                  name="courses"
+                />
+              </Grid>
+              <Grid xs={12} sm={6}>
+                <OrganizationSearch
+                  enableAdd={false}
+                  multiple={true}
+                  isFilterContext={true}
+                  name="organizations"
+                  label={intl.formatMessage(
+                    courseFormMessages.organizationsLabel,
+                  )}
+                />
+              </Grid>
+              <Grid xs={12}>
+                <RHFSelectCourseRunState
+                  data-testid="select-course-run-state"
+                  isFilterContext={true}
+                  fullWidth={true}
+                  name="state"
+                />
+              </Grid>
+              <Grid xs={12} sm={6}>
+                <RHFRadioGroup
+                  row
+                  data-testid="course-run-isListed-filter"
+                  getValueLabel={getTrueFalseLabel}
+                  options={trueFalseOptions}
+                  isFilterContext={true}
+                  label={intl.formatMessage(
+                    courseRunFormMessages.isListedLabel,
+                  )}
+                  name="is_listed"
+                />
+              </Grid>
+              <Grid xs={12} sm={6}>
+                <RHFRadioGroup
+                  row
+                  data-testid="course-run-isGradable-filter"
+                  getValueLabel={getTrueFalseLabel}
+                  options={trueFalseOptions}
+                  isFilterContext={true}
+                  label={intl.formatMessage(
+                    courseRunFormMessages.isGradableLabel,
+                  )}
+                  name="is_gradable"
+                />
+              </Grid>
+            </Grid>
+          </RHFValuesChange>
+        </RHFProvider>
+      )}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/courses-runs/input/RHFSelectCourseRunState.tsx
+++ b/src/frontend/admin/src/components/templates/courses-runs/input/RHFSelectCourseRunState.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import { useMemo } from "react";
+import { defineMessages, useIntl } from "react-intl";
+import { useFormContext } from "react-hook-form";
+import { Priority } from "@/services/api/models/Course";
+import {
+  RHFSelect,
+  RHFSelectProps,
+  SelectOption,
+} from "@/components/presentational/hook-form/RHFSelect";
+import { courseRunStateMessages } from "@/translations/course-runs/priority-state";
+import { useSearchFilterContext } from "@/components/presentational/filters/SearchFilters";
+
+const messages = defineMessages({
+  state: {
+    id: "components.templates.coursesRuns.input.RHFSelectCourseRunState.state",
+    description: "Label text for the select state input",
+    defaultMessage: "State",
+  },
+});
+
+export function RHFSelectCourseRunState(props: RHFSelectProps) {
+  const searchFilterContext = useSearchFilterContext(props.isFilterContext);
+  const { setValue } = useFormContext();
+  const intl = useIntl();
+  const options: SelectOption[] = useMemo(() => {
+    const result: SelectOption[] = [];
+    Object.values(Priority).forEach((v) => {
+      if (v && typeof v === "number") {
+        result.push({
+          label: intl.formatMessage(courseRunStateMessages[v as Priority]),
+          value: v,
+        });
+      }
+    });
+    return result;
+  }, []);
+
+  const afterChange = (newValue: string) => {
+    if (!props.isFilterContext || !searchFilterContext) {
+      return;
+    }
+
+    if (newValue && !Number.isNaN(Number(newValue))) {
+      searchFilterContext.addChip({
+        name: props.name,
+        label: intl.formatMessage(messages.state),
+        value: intl.formatMessage(
+          courseRunStateMessages[newValue as unknown as Priority],
+        ),
+        onDelete: (name: string) => {
+          setValue(name, "", { shouldValidate: true, shouldDirty: true });
+        },
+      });
+    } else {
+      searchFilterContext.removeChip(props.name);
+    }
+  };
+
+  return (
+    <RHFSelect
+      options={options}
+      afterChange={afterChange}
+      noneOption={true}
+      {...props}
+      label={intl.formatMessage(messages.state)}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/courses-runs/list/CoursesRunsList.tsx
+++ b/src/frontend/admin/src/components/templates/courses-runs/list/CoursesRunsList.tsx
@@ -19,6 +19,7 @@ import {
 import { usePaginatedTableResource } from "@/components/presentational/table/usePaginatedTableResource";
 import { commonTranslations } from "@/translations/common/commonTranslations";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { CourseRunFilters } from "@/components/templates/courses-runs/filters/CourseRunFilters";
 
 type Props = DefaultTableProps<CourseRun> & {
   courseId?: string;
@@ -35,6 +36,7 @@ export function CoursesRunsList({ courseId, ...props }: Props) {
     CourseRunResourcesQuery
   >({
     useResource: useCoursesRuns,
+    changeUrlOnPageChange: props.changeUrlOnPageChange,
     filters: { courseId },
   });
 
@@ -54,6 +56,7 @@ export function CoursesRunsList({ courseId, ...props }: Props) {
     <TableComponent
       {...paginatedResource.tableProps}
       {...props}
+      filters={<CourseRunFilters {...paginatedResource.filtersProps} />}
       columns={columns}
       columnBuffer={6}
       getOptions={(courseRun) => {

--- a/src/frontend/admin/src/components/templates/courses/filters/CourseFilters.tsx
+++ b/src/frontend/admin/src/components/templates/courses/filters/CourseFilters.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Grid from "@mui/material/Unstable_Grid2";
+import { defineMessages, useIntl } from "react-intl";
+import { OrganizationSearch } from "../../organizations/inputs/search/OrganizationSearch";
+import { courseFormMessages } from "../form/translations";
+import {
+  MandatorySearchFilterProps,
+  SearchFilters,
+} from "@/components/presentational/filters/SearchFilters";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFValuesChange } from "@/components/presentational/hook-form/RFHValuesChange";
+
+import { Organization } from "@/services/api/models/Organization";
+import { CourseResourceQuery } from "@/hooks/useCourses/useCourses";
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: "components.templates.courses.filters.CourseFilters.searchPlaceholder",
+    description: "Text for the search input placeholder",
+    defaultMessage: "Search by title or code",
+  },
+});
+
+type FormValues = {
+  organizations?: Organization[];
+};
+
+type Props = MandatorySearchFilterProps & {
+  onFilter: (values: CourseResourceQuery) => void;
+};
+
+export function CourseFilters({ onFilter, ...searchFilterProps }: Props) {
+  const intl = useIntl();
+  const getDefaultValues = () => {
+    return {
+      organizations: [],
+    };
+  };
+  const RegisterSchema = Yup.object().shape({
+    organizations: Yup.array<any, Organization>().nullable(),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(RegisterSchema),
+    defaultValues: getDefaultValues() as any, // To not trigger type validation for default value
+  });
+
+  const onSubmit = (values: FormValues) => {
+    const filters: CourseResourceQuery = {
+      organization_ids: values.organizations?.map((org) => org.id),
+    };
+    onFilter(filters);
+  };
+
+  return (
+    <SearchFilters
+      {...searchFilterProps}
+      searchInputPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
+      renderContent={() => (
+        <RHFProvider
+          id="course-filter-form"
+          showSubmit={false}
+          methods={methods}
+        >
+          <RHFValuesChange
+            debounceTime={200}
+            useAnotherValueReference={true}
+            onSubmit={onSubmit}
+          >
+            <Grid container mt={2} spacing={2}>
+              <Grid xs={12}>
+                <OrganizationSearch
+                  enableAdd={false}
+                  multiple={true}
+                  isFilterContext={true}
+                  name="organizations"
+                  label={intl.formatMessage(
+                    courseFormMessages.organizationsLabel,
+                  )}
+                />
+              </Grid>
+            </Grid>
+          </RHFValuesChange>
+        </RHFProvider>
+      )}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/courses/form/sections/target-course-runs/CourseFormTargetCourseRunsSection.tsx
+++ b/src/frontend/admin/src/components/templates/courses/form/sections/target-course-runs/CourseFormTargetCourseRunsSection.tsx
@@ -47,6 +47,7 @@ export function CourseFormTargetCourseRunsSection({ course }: Props) {
         />
       </SimpleCard>
       <CustomModal
+        data-testid="target-course-runs-modal"
         fullWidth
         maxWidth="lg"
         title={intl.formatMessage(courseFormMessages.addCourseRunModalTitle)}

--- a/src/frontend/admin/src/components/templates/courses/list/CoursesList.tsx
+++ b/src/frontend/admin/src/components/templates/courses/list/CoursesList.tsx
@@ -2,14 +2,18 @@ import * as React from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { useRouter } from "next/router";
 import { GridColDef } from "@mui/x-data-grid";
-import { TableComponent } from "@/components/presentational/table/TableComponent";
+import {
+  DefaultTableProps,
+  TableComponent,
+} from "@/components/presentational/table/TableComponent";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { Course } from "@/services/api/models/Course";
-import { useCourses } from "@/hooks/useCourses/useCourses";
+import { CourseResourceQuery, useCourses } from "@/hooks/useCourses/useCourses";
 import { CustomLink } from "@/components/presentational/link/CustomLink";
 import { commonTranslations } from "@/translations/common/commonTranslations";
 import { SimpleCard } from "@/components/presentational/card/SimpleCard";
 import { usePaginatedTableResource } from "@/components/presentational/table/usePaginatedTableResource";
+import { CourseFilters } from "@/components/templates/courses/filters/CourseFilters";
 
 const messages = defineMessages({
   codeHeader: {
@@ -29,10 +33,16 @@ const messages = defineMessages({
   },
 });
 
-export function CoursesList() {
+type Props = DefaultTableProps<Course>;
+
+export function CoursesList(props: Props) {
   const intl = useIntl();
   const { push } = useRouter();
-  const paginatedResource = usePaginatedTableResource<Course>({
+
+  const paginatedResource = usePaginatedTableResource<
+    Course,
+    CourseResourceQuery
+  >({
     useResource: useCourses,
   });
 
@@ -69,6 +79,8 @@ export function CoursesList() {
     <SimpleCard>
       <TableComponent
         {...paginatedResource.tableProps}
+        {...props}
+        filters={<CourseFilters {...paginatedResource.filtersProps} />}
         columns={columns}
         columnBuffer={4}
         getEntityName={(course) => {

--- a/src/frontend/admin/src/components/templates/orders/filters/OrderFilters.tsx
+++ b/src/frontend/admin/src/components/templates/orders/filters/OrderFilters.tsx
@@ -1,0 +1,154 @@
+import * as React from "react";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Grid from "@mui/material/Unstable_Grid2";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  MandatorySearchFilterProps,
+  SearchFilters,
+} from "@/components/presentational/filters/SearchFilters";
+import { Course } from "@/services/api/models/Course";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFValuesChange } from "@/components/presentational/hook-form/RFHValuesChange";
+import { CourseSearch } from "@/components/templates/courses/inputs/search/CourseSearch";
+import { Product } from "@/services/api/models/Product";
+import { Organization } from "@/services/api/models/Organization";
+import { User } from "@/services/api/models/User";
+import { ProductSearch } from "@/components/templates/products/inputs/search/ProductSearch";
+import { OrganizationSearch } from "@/components/templates/organizations/inputs/search/OrganizationSearch";
+import { UserSearch } from "@/components/templates/users/inputs/search/UserSearch";
+import { RHFOrderState } from "@/components/templates/orders/inputs/RHFOrderState";
+import { entitiesInputLabel } from "@/translations/common/entitiesInputLabel";
+import { OrderListQuery } from "@/hooks/useOrders/useOrders";
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: "components.templates.orders.filters.OrderFilters.searchPlaceholder",
+    description: "Text for the search input placeholder",
+    defaultMessage:
+      "Search by product title, owner (full name or email), organization (code or title), course code",
+  },
+});
+
+type FormValues = {
+  product?: Product;
+  course?: Course;
+  organization?: Organization;
+  owner?: User;
+  products?: Product[];
+  courses?: Course[];
+  organizations?: Organization[];
+  owners?: User[];
+  state?: string;
+};
+
+type Props = MandatorySearchFilterProps & {
+  onFilter: (values: OrderListQuery) => void;
+};
+
+export function OrderFilters({ onFilter, ...searchFilterProps }: Props) {
+  const intl = useIntl();
+
+  const getDefaultValues = () => {
+    return {
+      product: null,
+      course: null,
+      organization: null,
+      owner: null,
+      products: [],
+      courses: [],
+      organizations: [],
+      owners: [],
+      state: "",
+    };
+  };
+  const RegisterSchema = Yup.object().shape({
+    state: Yup.string().nullable(),
+    products: Yup.array<any, Product>().nullable(),
+    courses: Yup.array<any, Course>().nullable(),
+    organizations: Yup.array<any, Organization>().nullable(),
+    owners: Yup.array<any, User>().nullable(),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(RegisterSchema),
+    defaultValues: getDefaultValues() as any, // To not trigger type validation for default value
+  });
+
+  const onSubmit = (values: FormValues) => {
+    const filters: OrderListQuery = {
+      product_ids: values.products?.map((product) => product.id),
+      course_ids: values.courses?.map((course) => course.id),
+      organization_ids: values.organizations?.map(
+        (organization) => organization.id,
+      ),
+      owner_ids: values.owners?.map((owner) => owner.id),
+      state: values.state,
+    };
+    onFilter(filters);
+  };
+
+  return (
+    <SearchFilters
+      {...searchFilterProps}
+      searchInputPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
+      renderContent={() => (
+        <RHFProvider
+          id="order-filters-main-form"
+          showSubmit={false}
+          methods={methods}
+        >
+          <RHFValuesChange debounceTime={200} onSubmit={onSubmit}>
+            <Grid container mt={2} spacing={2}>
+              <Grid xs={12}>
+                <RHFOrderState
+                  data-testid="select-order-state-filter"
+                  isFilterContext={true}
+                  fullWidth={true}
+                  name="state"
+                />
+              </Grid>
+              <Grid xs={12} sm={6}>
+                <ProductSearch
+                  isFilterContext={true}
+                  multiple={true}
+                  fullWidth={true}
+                  label={intl.formatMessage(entitiesInputLabel.product)}
+                  name="products"
+                />
+              </Grid>
+              <Grid xs={12} sm={6}>
+                <CourseSearch
+                  isFilterContext={true}
+                  fullWidth={true}
+                  multiple={true}
+                  label={intl.formatMessage(entitiesInputLabel.course)}
+                  name="courses"
+                />
+              </Grid>
+              <Grid xs={12} sm={6}>
+                <OrganizationSearch
+                  isFilterContext={true}
+                  fullWidth={true}
+                  multiple={true}
+                  label={intl.formatMessage(entitiesInputLabel.organization)}
+                  name="organizations"
+                />
+              </Grid>
+              <Grid xs={12} sm={6}>
+                <UserSearch
+                  isFilterContext={true}
+                  fullWidth={true}
+                  multiple={true}
+                  label={intl.formatMessage(entitiesInputLabel.owner)}
+                  name="owners"
+                />
+              </Grid>
+            </Grid>
+          </RHFValuesChange>
+        </RHFProvider>
+      )}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/orders/inputs/RHFOrderState.tsx
+++ b/src/frontend/admin/src/components/templates/orders/inputs/RHFOrderState.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { useMemo } from "react";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  RHFSelect,
+  RHFSelectProps,
+  SelectOption,
+} from "@/components/presentational/hook-form/RHFSelect";
+import { OrderStatesEnum } from "@/services/api/models/Order";
+import { orderStatesMessages } from "@/components/templates/orders/view/translations";
+
+const messages = defineMessages({
+  state: {
+    id: "components.templates.coursesRuns.input.RHFOrderState.state",
+    description: "Label text for the select state input",
+    defaultMessage: "State",
+  },
+});
+
+export function RHFOrderState(props: RHFSelectProps) {
+  const intl = useIntl();
+
+  const options: SelectOption[] = useMemo(() => {
+    const result: SelectOption[] = [];
+    Object.values(OrderStatesEnum).forEach((v) => {
+      result.push({
+        label: intl.formatMessage(orderStatesMessages[v]),
+        value: v,
+      });
+    });
+    return result;
+  }, []);
+
+  return (
+    <RHFSelect
+      options={options}
+      getOptionLabel={(value: OrderStatesEnum) =>
+        intl.formatMessage(orderStatesMessages[value])
+      }
+      noneOption={true}
+      {...props}
+      label={intl.formatMessage(messages.state)}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/orders/list/OrdersList.tsx
+++ b/src/frontend/admin/src/components/templates/orders/list/OrdersList.tsx
@@ -1,14 +1,18 @@
 import * as React from "react";
 import { GridColDef } from "@mui/x-data-grid";
 import { defineMessages, useIntl } from "react-intl";
-import { TableComponent } from "@/components/presentational/table/TableComponent";
+import {
+  DefaultTableProps,
+  TableComponent,
+} from "@/components/presentational/table/TableComponent";
 import { SimpleCard } from "@/components/presentational/card/SimpleCard";
 import { usePaginatedTableResource } from "@/components/presentational/table/usePaginatedTableResource";
 import { OrderListItem } from "@/services/api/models/Order";
-import { useOrders } from "@/hooks/useOrders/useOrders";
+import { OrderListQuery, useOrders } from "@/hooks/useOrders/useOrders";
 import { CustomLink } from "@/components/presentational/link/CustomLink";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { commonTranslations } from "@/translations/common/commonTranslations";
+import { OrderFilters } from "@/components/templates/orders/filters/OrderFilters";
 
 const messages = defineMessages({
   id: {
@@ -38,10 +42,17 @@ const messages = defineMessages({
   },
 });
 
-export function OrdersList() {
+type Props = DefaultTableProps<OrderListItem>;
+
+export function OrdersList(props: Props) {
   const intl = useIntl();
-  const paginatedResource = usePaginatedTableResource<OrderListItem>({
+
+  const paginatedResource = usePaginatedTableResource<
+    OrderListItem,
+    OrderListQuery
+  >({
     useResource: useOrders,
+    changeUrlOnPageChange: props.changeUrlOnPageChange,
   });
 
   const columns: GridColDef[] = [
@@ -81,11 +92,13 @@ export function OrdersList() {
     <SimpleCard>
       <TableComponent
         {...paginatedResource.tableProps}
+        {...props}
+        filters={<OrderFilters {...paginatedResource.filtersProps} />}
         enableEdit={false}
         columns={columns}
         columnBuffer={5}
-        getEntityName={(organization) => {
-          return organization.title;
+        getEntityName={(order) => {
+          return order.organization_title;
         }}
       />
     </SimpleCard>

--- a/src/frontend/admin/src/components/templates/organizations/filters/OrganizationFilters.tsx
+++ b/src/frontend/admin/src/components/templates/organizations/filters/OrganizationFilters.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  MandatorySearchFilterProps,
+  SearchFilters,
+} from "@/components/presentational/filters/SearchFilters";
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: "components.templates.certificatesDefinitions.filters.CertificateDefinitionFilters.searchPlaceholder",
+    description: "Text for the search input placeholder",
+    defaultMessage: "Search by title, code",
+  },
+});
+
+type Props = MandatorySearchFilterProps & {
+  onFilter?: (values: any) => void;
+};
+
+export function OrganizationFilters({ onFilter, ...searchFilterProps }: Props) {
+  const intl = useIntl();
+
+  return (
+    <SearchFilters
+      {...searchFilterProps}
+      searchInputPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/organizations/list/OrganizationsList.tsx
+++ b/src/frontend/admin/src/components/templates/organizations/list/OrganizationsList.tsx
@@ -3,13 +3,17 @@ import { GridColDef } from "@mui/x-data-grid";
 import { defineMessages, useIntl } from "react-intl";
 import { useRouter } from "next/router";
 import { Organization } from "@/services/api/models/Organization";
-import { TableComponent } from "@/components/presentational/table/TableComponent";
+import {
+  DefaultTableProps,
+  TableComponent,
+} from "@/components/presentational/table/TableComponent";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { useOrganizations } from "@/hooks/useOrganizations/useOrganizations";
 import { CustomLink } from "@/components/presentational/link/CustomLink";
 import { commonTranslations } from "@/translations/common/commonTranslations";
 import { SimpleCard } from "@/components/presentational/card/SimpleCard";
 import { usePaginatedTableResource } from "@/components/presentational/table/usePaginatedTableResource";
+import { OrganizationFilters } from "@/components/templates/organizations/filters/OrganizationFilters";
 
 const messages = defineMessages({
   codeHeader: {
@@ -24,11 +28,14 @@ const messages = defineMessages({
   },
 });
 
-export function OrganizationsList() {
+type Props = DefaultTableProps<Organization>;
+
+export function OrganizationsList(props: Props) {
   const intl = useIntl();
   const { push } = useRouter();
   const paginatedResource = usePaginatedTableResource<Organization>({
     useResource: useOrganizations,
+    changeUrlOnPageChange: props.changeUrlOnPageChange,
   });
 
   const columns: GridColDef[] = [
@@ -58,6 +65,13 @@ export function OrganizationsList() {
     <SimpleCard>
       <TableComponent
         {...paginatedResource.tableProps}
+        {...props}
+        filters={
+          <OrganizationFilters
+            onSearch={paginatedResource.tableProps.onSearch}
+            loading={paginatedResource.tableProps.loading}
+          />
+        }
         columns={columns}
         columnBuffer={3}
         onEditClick={(organization: Organization) =>

--- a/src/frontend/admin/src/components/templates/products/filters/ProductFilters.tsx
+++ b/src/frontend/admin/src/components/templates/products/filters/ProductFilters.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+import * as Yup from "yup";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import Grid from "@mui/material/Unstable_Grid2";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  MandatorySearchFilterProps,
+  SearchFilters,
+} from "@/components/presentational/filters/SearchFilters";
+import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
+import { RHFValuesChange } from "@/components/presentational/hook-form/RFHValuesChange";
+import { RHFProductType } from "@/components/templates/products/inputs/RHFProductType";
+import { ProductResourceQuery } from "@/hooks/useProducts/useProducts";
+
+const messages = defineMessages({
+  searchPlaceholder: {
+    id: "components.templates.products.filters.ProductFilers.searchPlaceholder",
+    description: "Text for the search input placeholder",
+    defaultMessage: "Search by title",
+  },
+});
+
+type Props = MandatorySearchFilterProps & {
+  onFilter: (values: ProductResourceQuery) => void;
+};
+
+export function ProductFilers({ onFilter, ...searchFilterProps }: Props) {
+  const intl = useIntl();
+  const getDefaultValues = () => {
+    return {
+      type: "",
+    };
+  };
+  const RegisterSchema = Yup.object().shape({
+    type: Yup.string().nullable(),
+  });
+
+  const methods = useForm({
+    resolver: yupResolver(RegisterSchema),
+    defaultValues: getDefaultValues() as any, // To not trigger type validation for default value
+  });
+
+  return (
+    <SearchFilters
+      {...searchFilterProps}
+      searchInputPlaceholder={intl.formatMessage(messages.searchPlaceholder)}
+      renderContent={() => (
+        <RHFProvider
+          id="certificate-definition-filter-form"
+          showSubmit={false}
+          methods={methods}
+        >
+          <RHFValuesChange
+            debounceTime={200}
+            useAnotherValueReference={true}
+            onSubmit={onFilter}
+          >
+            <Grid container mt={2} spacing={2}>
+              <Grid xs={12}>
+                <RHFProductType isFilterContext={true} name="type" />
+              </Grid>
+            </Grid>
+          </RHFValuesChange>
+        </RHFProvider>
+      )}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/products/form/translations.ts
+++ b/src/frontend/admin/src/components/templates/products/form/translations.ts
@@ -1,6 +1,11 @@
 import { defineMessages } from "react-intl";
 
 export const productFormMessages = defineMessages({
+  microCredentialTitle: {
+    id: "components.templates.products.form.sections.ProductFormTypeSection.microCredentialTitle",
+    defaultMessage: "Microcredential",
+    description: "Title for the credential product type",
+  },
   mainSectionWizardTitle: {
     id: "components.templates.products.form.translations.mainSectionWizardTitle",
     defaultMessage: "Main",

--- a/src/frontend/admin/src/components/templates/products/inputs/RHFProductType.tsx
+++ b/src/frontend/admin/src/components/templates/products/inputs/RHFProductType.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { useMemo } from "react";
+import { defineMessages, useIntl } from "react-intl";
+import {
+  RHFSelect,
+  RHFSelectProps,
+  SelectOption,
+} from "@/components/presentational/hook-form/RHFSelect";
+import { productTypesMessages } from "@/translations/products/types";
+import { ProductType } from "@/services/api/models/Product";
+
+const messages = defineMessages({
+  type: {
+    id: "components.templates.products.input.RHFProductType.type",
+    description: "Label text for the select types input",
+    defaultMessage: "Type",
+  },
+});
+
+export function RHFProductType(props: RHFSelectProps) {
+  const intl = useIntl();
+
+  const options: SelectOption[] = useMemo(() => {
+    const result: SelectOption[] = [];
+    Object.values(ProductType).forEach((v) => {
+      result.push({
+        label: intl.formatMessage(productTypesMessages[v]),
+        value: v,
+      });
+    });
+    return result;
+  }, []);
+
+  return (
+    <RHFSelect
+      options={options}
+      getOptionLabel={(value: ProductType) =>
+        intl.formatMessage(productTypesMessages[value])
+      }
+      noneOption={true}
+      {...props}
+      label={intl.formatMessage(messages.type)}
+    />
+  );
+}

--- a/src/frontend/admin/src/components/templates/products/list/ProductsList.tsx
+++ b/src/frontend/admin/src/components/templates/products/list/ProductsList.tsx
@@ -2,13 +2,20 @@ import * as React from "react";
 import { GridColDef } from "@mui/x-data-grid";
 import { defineMessages, useIntl } from "react-intl";
 import { useRouter } from "next/router";
-import { TableComponent } from "@/components/presentational/table/TableComponent";
+import {
+  DefaultTableProps,
+  TableComponent,
+} from "@/components/presentational/table/TableComponent";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { CustomLink } from "@/components/presentational/link/CustomLink";
 import { commonTranslations } from "@/translations/common/commonTranslations";
-import { useProducts } from "@/hooks/useProducts/useProducts";
+import {
+  ProductResourceQuery,
+  useProducts,
+} from "@/hooks/useProducts/useProducts";
 import { Product } from "@/services/api/models/Product";
 import { usePaginatedTableResource } from "@/components/presentational/table/usePaginatedTableResource";
+import { ProductFilers } from "@/components/templates/products/filters/ProductFilters";
 
 const messages = defineMessages({
   priceHeader: {
@@ -28,11 +35,17 @@ const messages = defineMessages({
   },
 });
 
-export function ProductList() {
+type Props = DefaultTableProps<Product>;
+
+export function ProductList(props: Props) {
   const intl = useIntl();
   const { push } = useRouter();
-  const paginatedResource = usePaginatedTableResource({
+  const paginatedResource = usePaginatedTableResource<
+    Product,
+    ProductResourceQuery
+  >({
     useResource: useProducts,
+    changeUrlOnPageChange: props.changeUrlOnPageChange,
   });
 
   const columns: GridColDef[] = [
@@ -65,6 +78,8 @@ export function ProductList() {
   return (
     <TableComponent
       {...paginatedResource.tableProps}
+      {...props}
+      filters={<ProductFilers {...paginatedResource.filtersProps} />}
       columns={columns}
       columnBuffer={3}
       onEditClick={(product: Product) => {

--- a/src/frontend/admin/src/hooks/useCertificateDefinitions/useCertificateDefinitions.ts
+++ b/src/frontend/admin/src/hooks/useCertificateDefinitions/useCertificateDefinitions.ts
@@ -45,8 +45,9 @@ const messages = defineMessages({
   },
 });
 
-type CertificateDefintionRessourceQuery = ResourcesQuery & {
+export type CertificateDefinitionResourceQuery = ResourcesQuery & {
   name?: string;
+  template?: string;
 };
 
 /**
@@ -55,7 +56,7 @@ type CertificateDefintionRessourceQuery = ResourcesQuery & {
  */
 const props: UseResourcesProps<
   CertificateDefinition,
-  CertificateDefintionRessourceQuery
+  CertificateDefinitionResourceQuery
 > = {
   queryKey: ["certificatesDefinitions"],
   apiInterface: () => ({

--- a/src/frontend/admin/src/hooks/useContractDefinitions/useContractDefinitions.ts
+++ b/src/frontend/admin/src/hooks/useContractDefinitions/useContractDefinitions.ts
@@ -45,8 +45,9 @@ const messages = defineMessages({
   },
 });
 
-type ContractDefinitionRessourceQuery = ResourcesQuery & {
+export type ContractDefinitionResourceQuery = ResourcesQuery & {
   name?: string;
+  language?: string;
 };
 
 /**
@@ -55,7 +56,7 @@ type ContractDefinitionRessourceQuery = ResourcesQuery & {
  */
 const props: UseResourcesProps<
   ContractDefinition,
-  ContractDefinitionRessourceQuery
+  ContractDefinitionResourceQuery
 > = {
   queryKey: ["contractDefinitions"],
   apiInterface: () => ({

--- a/src/frontend/admin/src/hooks/useCourseRun/useCourseRun.ts
+++ b/src/frontend/admin/src/hooks/useCourseRun/useCourseRun.ts
@@ -49,8 +49,12 @@ export const useCourseRunMessages = defineMessages({
 
 export type CourseRunResourcesQuery = ResourcesQuery & {
   courseId?: string;
+  course_ids?: string[];
+  organization_ids?: string[];
   state?: Nullable<string>;
   start?: Nullable<string>;
+  is_gradable?: Nullable<boolean>;
+  is_listed?: Nullable<boolean>;
 };
 
 /**

--- a/src/frontend/admin/src/hooks/useCourses/useCourses.tsx
+++ b/src/frontend/admin/src/hooks/useCourses/useCourses.tsx
@@ -48,6 +48,12 @@ export const useCoursesMessages = defineMessages({
   },
 });
 
+export type CourseResourceQuery = ResourcesQuery & {
+  state?: string;
+  organization_ids?: string[];
+  start?: string;
+};
+
 /** const course = useCourse();
  * Joanie Api hook to retrieve/create/update/delete courses
  * owned by the authenticated user.
@@ -78,7 +84,7 @@ const props: UseResourcesProps<Course> = {
 // eslint-disable-next-line react-hooks/rules-of-hooks
 
 export const useCourses = (
-  filters?: ResourcesQuery,
+  filters?: CourseResourceQuery,
   queryOptions?: QueryOptions<Course>,
 ) => {
   const custom = useResourcesCustom({ ...props, filters, queryOptions });

--- a/src/frontend/admin/src/hooks/useOrders/useOrders.tsx
+++ b/src/frontend/admin/src/hooks/useOrders/useOrders.tsx
@@ -1,15 +1,11 @@
 import { defineMessages } from "react-intl";
 import {
+  ResourcesQuery,
   useResource,
   useResources,
   UseResourcesProps,
 } from "@/hooks/useResources";
-import {
-  Order,
-  OrderListItem,
-  OrderListQuery,
-  OrderQuery,
-} from "@/services/api/models/Order";
+import { Order, OrderListItem, OrderQuery } from "@/services/api/models/Order";
 import { OrderRepository } from "@/services/repositories/orders/OrderRepository";
 
 export const useOrdersMessages = defineMessages({
@@ -47,6 +43,18 @@ export const useOrdersMessages = defineMessages({
     defaultMessage: "Cannot find the order",
   },
 });
+
+export type OrderListQuery = ResourcesQuery & {
+  product_ids?: string[];
+  course_ids?: string[];
+  organization_ids?: string[];
+  owner_ids?: string[];
+  productId?: string;
+  courseId?: string;
+  organizationId?: string;
+  ownerId?: string;
+  state?: string;
+};
 
 const listProps: UseResourcesProps<OrderListItem, OrderListQuery> = {
   queryKey: ["ordersList"],

--- a/src/frontend/admin/src/hooks/useProducts/useProducts.ts
+++ b/src/frontend/admin/src/hooks/useProducts/useProducts.ts
@@ -10,6 +10,7 @@ import {
 import { Product } from "@/services/api/models/Product";
 import { ProductRepository } from "@/services/repositories/products/ProductRepository";
 import { DTOProductTargetCourseRelation } from "@/services/api/models/ProductTargetCourseRelation";
+import { Nullable } from "@/types/utils";
 
 const messages = defineMessages({
   errorUpdate: {
@@ -68,6 +69,10 @@ const messages = defineMessages({
   },
 });
 
+export type ProductResourceQuery = ResourcesQuery & {
+  state?: Nullable<number>;
+};
+
 /** const certifs = useProducts();
  * Joanie Api hook to retrieve/create/update/delete products
  * owned by the authenticated user.
@@ -98,7 +103,7 @@ const props: UseResourcesProps<Product> = {
 // eslint-disable-next-line react-hooks/rules-of-hooks
 
 export const useProducts = (
-  filters?: ResourcesQuery,
+  filters?: ProductResourceQuery,
   queryOptions?: QueryOptions<Product>,
 ) => {
   const intl = useIntl();

--- a/src/frontend/admin/src/layouts/dashboard/nav/account/DashboardLayoutNavAccount.tsx
+++ b/src/frontend/admin/src/layouts/dashboard/nav/account/DashboardLayoutNavAccount.tsx
@@ -120,6 +120,7 @@ export function DashboardLayoutNavAccount() {
           >
             {menuItems.map((item) => (
               <MenuItem
+                key={item.label}
                 onClick={() => {
                   handleCloseMenu();
                 }}

--- a/src/frontend/admin/src/pages/admin/certificates-definitions/list.tsx
+++ b/src/frontend/admin/src/pages/admin/certificates-definitions/list.tsx
@@ -44,7 +44,7 @@ export default function CertificatesDefinitionsListPage() {
         </Button>
       }
     >
-      <CertificatesDefinitionsList />
+      <CertificatesDefinitionsList changeUrlOnPageChange={true} />
     </DashboardLayoutPage>
   );
 }

--- a/src/frontend/admin/src/pages/admin/contracts-definitions/list.tsx
+++ b/src/frontend/admin/src/pages/admin/contracts-definitions/list.tsx
@@ -44,7 +44,7 @@ export default function ContractsDefinitionsListPage() {
         </Button>
       }
     >
-      <ContractsDefinitionsList />
+      <ContractsDefinitionsList changeUrlOnPageChange={true} />
     </DashboardLayoutPage>
   );
 }

--- a/src/frontend/admin/src/pages/admin/courses-runs/list.tsx
+++ b/src/frontend/admin/src/pages/admin/courses-runs/list.tsx
@@ -41,7 +41,7 @@ export default function CoursesRunsListPage() {
       }
     >
       <SimpleCard>
-        <CoursesRunsList />
+        <CoursesRunsList changeUrlOnPageChange={true} />
       </SimpleCard>
     </DashboardLayoutPage>
   );

--- a/src/frontend/admin/src/pages/admin/courses/list.tsx
+++ b/src/frontend/admin/src/pages/admin/courses/list.tsx
@@ -41,7 +41,7 @@ export default function CoursesListPage() {
         </Button>
       }
     >
-      <CoursesList />
+      <CoursesList changeUrlOnPageChange={true} />
     </DashboardLayoutPage>
   );
 }

--- a/src/frontend/admin/src/pages/admin/orders/list.tsx
+++ b/src/frontend/admin/src/pages/admin/orders/list.tsx
@@ -28,7 +28,7 @@ export default function OrderListPage() {
       ]}
       stretch={false}
     >
-      <OrdersList />
+      <OrdersList changeUrlOnPageChange={true} />
     </DashboardLayoutPage>
   );
 }

--- a/src/frontend/admin/src/pages/admin/organizations/list.tsx
+++ b/src/frontend/admin/src/pages/admin/organizations/list.tsx
@@ -41,7 +41,7 @@ export default function OrganizationListPage() {
         </Button>
       }
     >
-      <OrganizationsList />
+      <OrganizationsList changeUrlOnPageChange={true} />
     </DashboardLayoutPage>
   );
 }

--- a/src/frontend/admin/src/pages/admin/products/list.tsx
+++ b/src/frontend/admin/src/pages/admin/products/list.tsx
@@ -43,7 +43,7 @@ export default function ProductListPage() {
       }
     >
       <SimpleCard>
-        <ProductList />
+        <ProductList changeUrlOnPageChange={true} />
       </SimpleCard>
     </DashboardLayoutPage>
   );

--- a/src/frontend/admin/src/services/api/models/Order.ts
+++ b/src/frontend/admin/src/services/api/models/Order.ts
@@ -66,8 +66,6 @@ export type OrderMainInvoiceChildren = {
   updated_on: string;
 };
 
-export type OrderListQuery = ResourcesQuery & {};
-
 export type OrderQuery = ResourcesQuery & {};
 
 export enum OrderInvoiceTypesEnum {

--- a/src/frontend/admin/src/services/repositories/contract-definition/ContractDefinitionRepository.ts
+++ b/src/frontend/admin/src/services/repositories/contract-definition/ContractDefinitionRepository.ts
@@ -10,6 +10,7 @@ import {
   DTOContractDefinition,
 } from "@/services/api/models/ContractDefinition";
 import { ResourcesQuery } from "@/hooks/useResources/types";
+import { SelectOption } from "@/components/presentational/hook-form/RHFSelect";
 
 export const contractDefinitionRoutes: BaseEntityRoutesPaths = {
   get: (id: string, params: string = "") =>
@@ -20,11 +21,16 @@ export const contractDefinitionRoutes: BaseEntityRoutesPaths = {
   delete: (id: string) => `/contract-definitions/${id}/`,
 };
 
-export const ContractDefinitionRepository: AbstractRepository<
-  ContractDefinition,
-  ResourcesQuery,
-  DTOContractDefinition
-> = class ContractDefinitionRepository {
+interface Repository
+  extends AbstractRepository<
+    ContractDefinition,
+    ResourcesQuery,
+    DTOContractDefinition
+  > {
+  getAllLanguages: () => Promise<SelectOption[]>;
+}
+
+export const ContractDefinitionRepository: Repository = class ContractDefinitionRepository {
   static get(
     id: string,
     filters?: Maybe<ResourcesQuery>,
@@ -64,5 +70,19 @@ export const ContractDefinitionRepository: AbstractRepository<
       method: "PATCH",
       body: exportToFormData(payload),
     }).then(checkStatus);
+  }
+
+  static getAllLanguages(): Promise<SelectOption[]> {
+    return fetchApi(contractDefinitionRoutes.getAll(), {
+      method: "OPTIONS",
+    }).then(async (response) => {
+      const checkedResponse = await checkStatus(response);
+      const result: { value: string; display_name: string }[] =
+        checkedResponse.actions.POST.language.choices;
+      return result.map(({ value, display_name: label }) => ({
+        value,
+        label,
+      }));
+    });
   }
 };

--- a/src/frontend/admin/src/services/repositories/courses/CoursesRepository.ts
+++ b/src/frontend/admin/src/services/repositories/courses/CoursesRepository.ts
@@ -1,7 +1,6 @@
 import queryString from "query-string";
 import { BaseEntityRoutesPaths } from "@/types/routes";
 import { AbstractRepository } from "@/services/repositories/AbstractRepository";
-import { ResourcesQuery } from "@/hooks/useResources";
 import { Maybe } from "@/types/utils";
 import { checkStatus, fetchApi } from "@/services/http/HttpService";
 import { Course, DTOCourse } from "@/services/api/models/Course";
@@ -10,11 +9,7 @@ import { DTOAccesses } from "@/services/api/models/Accesses";
 import { SelectOption } from "@/components/presentational/hook-form/RHFSelect";
 import { CourseRun } from "@/services/api/models/CourseRun";
 import { CourseRunResourcesQuery } from "@/hooks/useCourseRun/useCourseRun";
-
-export type CourseResourceQuery = ResourcesQuery & {
-  state?: string;
-  start?: string;
-};
+import { CourseResourceQuery } from "@/hooks/useCourses/useCourses";
 
 type CourseRoutes = BaseEntityRoutesPaths & {
   addUserAccess: (id: string) => string;

--- a/src/frontend/admin/src/tests/certificate-definitions/certificate-definition-filters.test.e2e.ts
+++ b/src/frontend/admin/src/tests/certificate-definitions/certificate-definition-filters.test.e2e.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+import { mockPlaywrightCrud } from "@/tests/useResourceHandler";
+import { PATH_ADMIN } from "@/utils/routes/path";
+import { getCertificateDefinitionScenarioStore } from "@/tests/certificate-definitions/CertificateDefinitionTestScenario";
+import {
+  CertificateDefinition,
+  DTOCertificateDefinition,
+} from "@/services/api/models/CertificateDefinition";
+import { CERTIFICATE_DEFINITION_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/certificate-definitions/certificate-definition-mocks";
+
+const certificateDefinitionApiUrl =
+  "http://localhost:8071/api/v1.0/admin/certificate-definitions/";
+test.describe("Certificate definition filters", () => {
+  let store = getCertificateDefinitionScenarioStore(5);
+
+  test.beforeEach(async ({ page }) => {
+    store = getCertificateDefinitionScenarioStore(5);
+    await mockPlaywrightCrud<CertificateDefinition, DTOCertificateDefinition>({
+      data: store.list,
+      routeUrl: certificateDefinitionApiUrl,
+      page,
+      searchResult: store.list[1],
+      optionsResult: CERTIFICATE_DEFINITION_OPTIONS_REQUEST_RESULT,
+    });
+  });
+
+  test("Test that filters apply", async ({ page }) => {
+    await page.goto(PATH_ADMIN.certificates.list);
+    await expect(
+      page.getByRole("heading", { name: "Certificates definitions" }),
+    ).toBeVisible();
+
+    // Check all certificate definition
+    await Promise.all(
+      store.list.map(async (certificate) => {
+        await expect(
+          page.getByRole("link", { name: certificate.title }),
+        ).toBeVisible();
+      }),
+    );
+
+    // Check if all filters are presents
+    await expect(
+      page.getByPlaceholder("Search by title or name"),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Filters" }).click();
+    await expect(page.getByRole("heading", { name: "filters" })).toBeVisible();
+    const selectTemplateLocator = page.getByLabel("Template");
+    const templateInputLocator = page.locator(`[name='template']`);
+    await expect(selectTemplateLocator).toBeVisible();
+    await expect(templateInputLocator).toHaveValue("");
+
+    // Select template
+    await selectTemplateLocator.click();
+    await expect(
+      page.getByRole("option", { name: "Certificate" }),
+    ).toBeVisible();
+    await expect(page.getByRole("option", { name: "Degree" })).toBeVisible();
+
+    // Check filters result
+    const filterResult = [store.list[1], store.list[2]];
+    await mockPlaywrightCrud<CertificateDefinition, DTOCertificateDefinition>({
+      data: store.list,
+      routeUrl: certificateDefinitionApiUrl,
+      page,
+      forceFiltersMode: true,
+      searchResult: filterResult,
+    });
+
+    await page.getByRole("option", { name: "Certificate" }).click();
+    await expect(templateInputLocator).toHaveValue("certificate");
+
+    await page.getByLabel("close").click();
+    await expect(
+      page.getByRole("button", { name: "Template: certificate" }),
+    ).toBeVisible();
+
+    await Promise.all(
+      filterResult.map(async (certificate) => {
+        await expect(
+          page.getByRole("link", { name: certificate.title }),
+        ).toBeVisible();
+      }),
+    );
+
+    // Remove all filters
+    await page.getByRole("button", { name: "Clear" }).click();
+
+    // Check that the list returns to the initial state
+    await mockPlaywrightCrud<CertificateDefinition, DTOCertificateDefinition>({
+      data: store.list,
+      routeUrl: certificateDefinitionApiUrl,
+      page,
+      forceFiltersMode: false,
+      searchResult: filterResult,
+    });
+
+    await Promise.all(
+      store.list.map(async (certificate) => {
+        await expect(
+          page.getByRole("link", { name: certificate.title }),
+        ).toBeVisible();
+      }),
+    );
+
+    await page.getByRole("button", { name: "Filters" }).click();
+    await expect(templateInputLocator).toHaveValue("");
+    await expect(page.getByLabel("Template")).toBeVisible();
+  });
+});

--- a/src/frontend/admin/src/tests/certificate-definitions/certificate-definition.test.e2e.ts
+++ b/src/frontend/admin/src/tests/certificate-definitions/certificate-definition.test.e2e.ts
@@ -14,6 +14,8 @@ import { expectHaveClasses } from "@/tests/utils";
 const certificateDefinitionApiUrl =
   "http://localhost:8071/api/v1.0/admin/certificate-definitions/";
 
+const searchPlaceholder = "Search by title or name";
+
 test.describe("Certificate definition form", () => {
   let store = getCertificateDefinitionScenarioStore();
 
@@ -253,12 +255,11 @@ test.describe("Certificate definition list", () => {
     page,
   }) => {
     await page.goto(PATH_ADMIN.certificates.list);
-    await expect(page.getByPlaceholder("Search...")).toBeVisible();
+    await expect(page.getByPlaceholder(searchPlaceholder)).toBeVisible();
 
     // await expect(page.getByText(certificateDefinition.name)).toBeVisible();
     await Promise.all(
       store.list.map(async (certificateDefinition, index) => {
-        // console.log(certificateDefinition.title);
         if (index > 19) {
           return;
         }
@@ -269,7 +270,6 @@ test.describe("Certificate definition list", () => {
     await page.getByLabel("Go to next page").click();
     await Promise.all(
       store.list.map(async (certificateDefinition, index) => {
-        // console.log(certificateDefinition.title);
         if (index <= 19) {
           return;
         }
@@ -313,7 +313,7 @@ test.describe("Certificate definition list", () => {
       searchResult: store.list[1],
     });
     await page.goto(PATH_ADMIN.certificates.list);
-    await expect(page.getByPlaceholder("Search...")).toBeVisible();
+    await expect(page.getByPlaceholder(searchPlaceholder)).toBeVisible();
 
     await Promise.all(
       store.list.map(async (certificateDefinition) => {
@@ -322,8 +322,8 @@ test.describe("Certificate definition list", () => {
       }),
     );
 
-    await page.getByPlaceholder("Search...").click();
-    await page.getByPlaceholder("Search...").fill("search");
+    await page.getByPlaceholder(searchPlaceholder).click();
+    await page.getByPlaceholder(searchPlaceholder).fill("search");
     await expect(page.getByTestId("circular-loader-container")).toBeVisible();
     await expect(page.getByTestId("circular-loader-container")).toBeHidden();
 
@@ -345,8 +345,8 @@ test.describe("Certificate definition list", () => {
       }),
     );
 
-    await page.getByPlaceholder("Search...").click();
-    await page.getByPlaceholder("Search...").fill("");
+    await page.getByPlaceholder(searchPlaceholder).click();
+    await page.getByPlaceholder(searchPlaceholder).fill("");
     await Promise.all(
       store.list.map(async (certificateDefinition) => {
         await expect(page.getByText(certificateDefinition.title)).toBeVisible();

--- a/src/frontend/admin/src/tests/contract-definitions/contract-definition-filters.test.e2e.ts
+++ b/src/frontend/admin/src/tests/contract-definitions/contract-definition-filters.test.e2e.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+import { mockPlaywrightCrud } from "@/tests/useResourceHandler";
+import { getContractDefinitionScenarioStore } from "@/tests/contract-definitions/ContractDefinitionTestScenario";
+import {
+  ContractDefinition,
+  DTOContractDefinition,
+} from "@/services/api/models/ContractDefinition";
+import { PATH_ADMIN } from "@/utils/routes/path";
+import { CONTRACT_DEFINITION_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/contract-definitions/contract-definition-mocks";
+
+const contractDefinitionApiUrl =
+  "http://localhost:8071/api/v1.0/admin/contract-definitions/";
+
+test.describe("Contract definition filters", () => {
+  let store = getContractDefinitionScenarioStore();
+
+  test.beforeEach(async ({ page }) => {
+    store = getContractDefinitionScenarioStore();
+    await mockPlaywrightCrud<ContractDefinition, DTOContractDefinition>({
+      data: store.list,
+      routeUrl: contractDefinitionApiUrl,
+      page,
+      searchResult: store.list[1],
+      optionsResult: CONTRACT_DEFINITION_OPTIONS_REQUEST_RESULT,
+    });
+  });
+
+  test("Test that filters apply", async ({ page }) => {
+    await page.goto(PATH_ADMIN.contract_definition.list);
+    await expect(
+      page.getByRole("heading", { name: "Contracts definitions" }),
+    ).toBeVisible();
+
+    await Promise.all(
+      store.list.map(async (contract) => {
+        await expect(page.getByText(contract.title)).toBeVisible();
+      }),
+    );
+
+    await page.getByRole("button", { name: "Filters" }).click();
+    await expect(page.getByRole("heading", { name: "filters" })).toBeVisible();
+    const selectLangLocator = page
+      .getByTestId("contract-definition-language-input")
+      .getByLabel("Language");
+    await expect(selectLangLocator).toBeVisible();
+    await expect(page.locator(`[name='language']`)).toHaveValue("");
+    await selectLangLocator.click();
+
+    await expect(page.getByRole("option", { name: "English" })).toBeVisible();
+    await expect(page.getByRole("option", { name: "French" })).toBeVisible();
+
+    const filterResult = [store.list[0], store.list[1]];
+    await mockPlaywrightCrud<ContractDefinition, DTOContractDefinition>({
+      data: store.list,
+      routeUrl: contractDefinitionApiUrl,
+      page,
+      searchResult: filterResult,
+      forceFiltersMode: true,
+      optionsResult: CONTRACT_DEFINITION_OPTIONS_REQUEST_RESULT,
+    });
+
+    await page.getByRole("option", { name: "French" }).click();
+    await expect(page.locator(`[name='language']`)).toHaveValue("fr-fr");
+    await page.getByLabel("close").click();
+
+    await Promise.all(
+      filterResult.map(async (contract) => {
+        await expect(page.getByText(contract.title)).toBeVisible();
+      }),
+    );
+
+    await expect(page.getByText(store.list[2].title)).toBeHidden();
+
+    await expect(
+      page.getByRole("button", { name: "Language: French" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Clear" })).toBeVisible();
+    await page.getByRole("button", { name: "Filters" }).click();
+    await expect(page.getByLabel("French")).toBeVisible();
+    await page.getByLabel("close").click();
+
+    await mockPlaywrightCrud<ContractDefinition, DTOContractDefinition>({
+      data: store.list,
+      routeUrl: contractDefinitionApiUrl,
+      page,
+      searchResult: filterResult,
+      forceFiltersMode: false,
+      optionsResult: CONTRACT_DEFINITION_OPTIONS_REQUEST_RESULT,
+    });
+    await page.getByRole("button", { name: "Language: French" }).click();
+    await page.getByRole("button", { name: "Clear" }).click();
+
+    await Promise.all(
+      store.list.map(async (contract) => {
+        await expect(page.getByText(contract.title)).toBeVisible();
+      }),
+    );
+    await page.getByRole("button", { name: "Filters" }).click();
+    await expect(selectLangLocator).toBeVisible();
+    await expect(page.locator(`[name='language']`)).toHaveValue("");
+  });
+});

--- a/src/frontend/admin/src/tests/contract-definitions/contract-definition.test.e2e.ts
+++ b/src/frontend/admin/src/tests/contract-definitions/contract-definition.test.e2e.ts
@@ -7,6 +7,7 @@ import {
 } from "@/services/api/models/ContractDefinition";
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { expectHaveClasses } from "@/tests/utils";
+import { CONTRACT_DEFINITION_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/contract-definitions/contract-definition-mocks";
 
 const contractDefinitionApiUrl =
   "http://localhost:8071/api/v1.0/admin/contract-definitions/";
@@ -19,6 +20,7 @@ test.describe("Contract definition form", () => {
     await mockPlaywrightCrud<ContractDefinition, DTOContractDefinition>({
       data: store.list,
       routeUrl: contractDefinitionApiUrl,
+      optionsResult: CONTRACT_DEFINITION_OPTIONS_REQUEST_RESULT,
       page,
       createCallback: store.postUpdate,
       updateCallback: store.postUpdate,
@@ -51,7 +53,7 @@ test.describe("Contract definition form", () => {
 
     await expect(page.getByTestId("InfoOutlinedIcon")).toHaveCount(1);
     await expect(page.getByLabel("Title", { exact: true })).toHaveCount(1);
-    await page.getByLabel("Language").click();
+    await page.getByTestId("contract-definition-language-input").click();
     await expect(page.getByRole("option", { name: "English" })).toHaveCount(1);
     await expect(page.getByRole("option", { name: "French" })).toHaveCount(1);
     await page.getByRole("option", { name: "French" }).click();

--- a/src/frontend/admin/src/tests/course-run/course-run-filters.test.e2e.ts
+++ b/src/frontend/admin/src/tests/course-run/course-run-filters.test.e2e.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "@playwright/test";
+import { mockPlaywrightCrud } from "@/tests/useResourceHandler";
+import { Course, DTOCourse } from "@/services/api/models/Course";
+import { PATH_ADMIN } from "@/utils/routes/path";
+import { getCourseRunTestScenario } from "@/tests/course-run/CourseRunTestScenario";
+import { CourseRun, DTOCourseRun } from "@/services/api/models/CourseRun";
+import { COURSE_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/courses/course-mocks";
+
+test.describe("Course run filters", () => {
+  let store = getCourseRunTestScenario();
+  //
+  test.beforeEach(async ({ page }) => {
+    store = getCourseRunTestScenario();
+
+    await mockPlaywrightCrud<CourseRun, DTOCourseRun>({
+      data: store.courseRuns,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/course-runs/",
+      page,
+    });
+  });
+
+  test("Check if all filters are presents", async ({ page }) => {
+    await page.goto(PATH_ADMIN.courses_run.list);
+    // Wait the page
+    await expect(
+      page.getByRole("heading", { name: "Course runs" }),
+    ).toBeVisible();
+
+    // Click on filters button
+    await page.getByRole("button", { name: "Filters" }).click();
+
+    // Check the course and state inputs
+    await expect(
+      page.getByTestId("course-runs-search").getByLabel("Course"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("select-course-run-state").getByLabel("State"),
+    ).toBeVisible();
+
+    // Check the is listed radio buttons
+    await expect(page.getByText("Is listed?")).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isListed-filter").getByLabel("None"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isListed-filter").getByLabel("Yes"),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("course-run-isListed-filter")
+        .getByLabel("No", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isListed-filter").getByText("None"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isListed-filter").getByText("Yes"),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("course-run-isListed-filter")
+        .getByText("No", { exact: true }),
+    ).toBeVisible();
+
+    // Check the is gradable radio buttons
+    await expect(page.getByText("Is gradable?")).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isGradable-filter").getByLabel("None"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isGradable-filter").getByText("None"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isGradable-filter").getByLabel("Yes"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("course-run-isGradable-filter").getByText("Yes"),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("course-run-isGradable-filter")
+        .getByLabel("No", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      page
+        .getByTestId("course-run-isGradable-filter")
+        .getByText("No", { exact: true }),
+    ).toBeVisible();
+  });
+
+  test("Check all chips by filters", async ({ page }) => {
+    await mockPlaywrightCrud<Course, DTOCourse>({
+      data: store.courses,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/courses/",
+      searchResult: store.courses[0],
+      page,
+      optionsResult: COURSE_OPTIONS_REQUEST_RESULT,
+    });
+    await page.goto(PATH_ADMIN.courses_run.list);
+    // Wait the page
+    await expect(
+      page.getByRole("heading", { name: "Course runs" }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Filters" }).click();
+    await page.getByTestId("course-runs-search").getByLabel("Course").click();
+    await page.getByTestId("course-runs-search").getByLabel("Course").fill("c");
+    await page.getByRole("option", { name: store.courses[0].title }).click();
+    await page
+      .getByTestId("select-course-run-state")
+      .getByLabel("State")
+      .click();
+    await page.getByRole("option", { name: "Future open" }).click();
+    await page
+      .getByTestId("course-run-isListed-filter")
+      .getByLabel("No", { exact: true })
+      .check();
+    await page
+      .getByTestId("course-run-isGradable-filter")
+      .getByLabel("Yes")
+      .check();
+    await page.getByLabel("close").click();
+    await expect(
+      page.getByRole("button", { name: `Course: ${store.courses[0].title}` }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "State: Future open" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Is listed?: No" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Is gradable?: Yes" }),
+    ).toBeVisible();
+  });
+});

--- a/src/frontend/admin/src/tests/course/course-courseRun-section.test.e2e.ts
+++ b/src/frontend/admin/src/tests/course/course-courseRun-section.test.e2e.ts
@@ -62,11 +62,17 @@ test.describe("Course product relation", () => {
     await page.getByRole("link", { name: course.title }).click();
 
     await page.getByRole("button", { name: "Add a course run" }).click();
-    await expect(page.getByRole("textbox", { name: "Title" })).toBeVisible();
-    await expect(page.getByLabel("Course", { exact: true })).toBeDisabled();
-    await expect(page.getByLabel("Course", { exact: true })).toHaveValue(
-      course.title,
-    );
+    const modalLocator = page.getByTestId("target-course-runs-modal");
+    await expect(modalLocator).toBeVisible();
+    await expect(
+      modalLocator.getByRole("textbox", { name: "Title" }),
+    ).toBeVisible();
+    await expect(
+      modalLocator.getByLabel("Course", { exact: true }),
+    ).toBeDisabled();
+    await expect(
+      modalLocator.getByLabel("Course", { exact: true }),
+    ).toHaveValue(course.title);
   });
   test("Copy url inside the clipboard", async ({ page, context }) => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);

--- a/src/frontend/admin/src/tests/course/course-filters.test.e2e.ts
+++ b/src/frontend/admin/src/tests/course/course-filters.test.e2e.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+import { mockPlaywrightCrud } from "@/tests/useResourceHandler";
+import { PATH_ADMIN } from "@/utils/routes/path";
+import { getCourseScenarioStore } from "@/tests/course/CourseTestScenario";
+import { Course, DTOCourse } from "@/services/api/models/Course";
+import { COURSE_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/courses/course-mocks";
+import {
+  DTOOrganization,
+  Organization,
+} from "@/services/api/models/Organization";
+
+const coursesApiUrl = "http://localhost:8071/api/v1.0/admin/courses/";
+test.describe("Course filters", () => {
+  let store = getCourseScenarioStore();
+
+  test.beforeEach(async ({ page }) => {
+    store = getCourseScenarioStore();
+    await mockPlaywrightCrud<Course, DTOCourse>({
+      data: store.list,
+      routeUrl: coursesApiUrl,
+      page,
+      optionsResult: COURSE_OPTIONS_REQUEST_RESULT,
+    });
+    await mockPlaywrightCrud<Organization, DTOOrganization>({
+      data: store.organizations,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/organizations/",
+      page,
+    });
+  });
+
+  test("Check the presence and proper functioning of the filters", async ({
+    page,
+  }) => {
+    await page.goto(PATH_ADMIN.courses.list);
+    await expect(page.getByRole("heading", { name: "Courses" })).toBeVisible();
+
+    // Check all certificate definition
+    await Promise.all(
+      store.list.map(async (course) => {
+        await expect(
+          page.getByRole("link", { name: course.title }),
+        ).toBeVisible();
+      }),
+    );
+
+    // Check if all filters are presents
+    await expect(
+      page.getByPlaceholder("Search by title or code"),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Filters" }).click();
+    await expect(page.getByRole("heading", { name: "filters" })).toBeVisible();
+
+    const selectOrgSelector = page.getByLabel("Organizations");
+    await expect(selectOrgSelector).toBeVisible();
+    await selectOrgSelector.click();
+
+    // Check filters result
+    const filterResult = [store.list[1], store.list[2]];
+    await mockPlaywrightCrud<Course, DTOCourse>({
+      data: store.list,
+      routeUrl: coursesApiUrl,
+      page,
+      forceFiltersMode: true,
+      searchResult: filterResult,
+      optionsResult: COURSE_OPTIONS_REQUEST_RESULT,
+    });
+
+    await page
+      .getByRole("option", { name: store.organizations[0].title })
+      .click();
+
+    await page.getByLabel("close").click();
+
+    await Promise.all(
+      filterResult.map(async (course) => {
+        await expect(
+          page.getByRole("link", { name: course.title }),
+        ).toBeVisible();
+      }),
+    );
+
+    // Check that the list returns to the initial state
+    await mockPlaywrightCrud<Course, DTOCourse>({
+      data: store.list,
+      routeUrl: coursesApiUrl,
+      page,
+      searchResult: filterResult,
+      forceFiltersMode: false,
+      optionsResult: COURSE_OPTIONS_REQUEST_RESULT,
+    });
+
+    // Remove all filters
+    await page.getByRole("button", { name: "Clear" }).click();
+    await Promise.all(
+      store.list.map(async (certificate) => {
+        await expect(
+          page.getByRole("link", { name: certificate.title }),
+        ).toBeVisible();
+      }),
+    );
+  });
+});

--- a/src/frontend/admin/src/tests/course/course.test.e2e.ts
+++ b/src/frontend/admin/src/tests/course/course.test.e2e.ts
@@ -181,8 +181,10 @@ test.describe("Course form", async () => {
       page.getByRole("heading", { name: `Edit course: ${oldCourseTitle}` }),
     ).toBeVisible();
 
-    await page.getByRole("textbox", { name: "Title" }).click();
-    await page.getByRole("textbox", { name: "Title" }).fill(newCourseTitle);
+    await page.getByRole("textbox", { name: "Title", exact: true }).click();
+    await page
+      .getByRole("textbox", { name: "Title", exact: true })
+      .fill(newCourseTitle);
     await page.getByRole("button", { name: "Submit" }).click();
     await page.getByText("Operation completed successfully.").click();
     await expect(
@@ -276,14 +278,15 @@ test.describe("Course list", async () => {
         await expect(page.getByText(course.code)).toBeVisible();
       }),
     );
-    await page.getByPlaceholder("Search...").click();
-    await page.getByPlaceholder("Search...").fill(store.list[1].title);
+    const searchPlaceholder = "Search by title or code";
+    await page.getByPlaceholder(searchPlaceholder).click();
+    await page.getByPlaceholder(searchPlaceholder).fill(store.list[1].title);
     await expect(page.getByTestId("circular-loader-container")).toBeVisible();
     await expect(page.getByTestId("circular-loader-container")).toBeHidden();
     await expect(page.getByText(store.list[1].title)).toBeVisible();
     await expect(page.getByText(store.list[0].title)).toBeHidden();
-    await page.getByPlaceholder("Search...").click();
-    await page.getByPlaceholder("Search...").fill("");
+    await page.getByPlaceholder(searchPlaceholder).click();
+    await page.getByPlaceholder(searchPlaceholder).fill("");
     await expect(page.getByTestId("circular-loader-container")).toBeVisible();
     await expect(page.getByTestId("circular-loader-container")).toBeHidden();
     await Promise.all(

--- a/src/frontend/admin/src/tests/mocks/certificate-definitions/certificate-definition-mocks.ts
+++ b/src/frontend/admin/src/tests/mocks/certificate-definitions/certificate-definition-mocks.ts
@@ -1,0 +1,22 @@
+export const CERTIFICATE_DEFINITION_OPTIONS_REQUEST_RESULT = {
+  actions: {
+    POST: {
+      template: {
+        type: "choice",
+        required: false,
+        read_only: false,
+        label: "Template to generate pdf",
+        choices: [
+          {
+            value: "certificate",
+            display_name: "Certificate",
+          },
+          {
+            value: "degree",
+            display_name: "Degree",
+          },
+        ],
+      },
+    },
+  },
+};

--- a/src/frontend/admin/src/tests/mocks/contract-definitions/contract-definition-mocks.ts
+++ b/src/frontend/admin/src/tests/mocks/contract-definitions/contract-definition-mocks.ts
@@ -1,0 +1,18 @@
+export const CONTRACT_DEFINITION_OPTIONS_REQUEST_RESULT = {
+  actions: {
+    POST: {
+      language: {
+        choices: [
+          {
+            value: "en-us",
+            display_name: "English",
+          },
+          {
+            value: "fr-fr",
+            display_name: "French",
+          },
+        ],
+      },
+    },
+  },
+};

--- a/src/frontend/admin/src/tests/orders/OrderTestScenario.ts
+++ b/src/frontend/admin/src/tests/orders/OrderTestScenario.ts
@@ -1,9 +1,30 @@
 import { OrderFactory } from "@/services/factories/orders";
+import { Product } from "@/services/api/models/Product";
+import { User } from "@/services/api/models/User";
+import { Organization } from "@/services/api/models/Organization";
+import { Course } from "@/services/api/models/Course";
 
 export const getOrdersScenarioStore = (itemsNumber: number = 30) => {
   const list = OrderFactory(itemsNumber);
+  const products: Product[] = [];
+  const users: User[] = [];
+  const organizations: Organization[] = [];
+  const courses: Course[] = [];
+
+  list.forEach((order) => {
+    products.push(order.product);
+    users.push(order.owner);
+    organizations.push(order.organization);
+    if (order.course) {
+      courses.push(order.course);
+    }
+  });
 
   return {
     list,
+    products,
+    users,
+    organizations,
+    courses,
   };
 };

--- a/src/frontend/admin/src/tests/orders/orders-filters.test.e2e.ts
+++ b/src/frontend/admin/src/tests/orders/orders-filters.test.e2e.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "@playwright/test";
+import { getOrdersScenarioStore } from "@/tests/orders/OrderTestScenario";
+import {
+  getUrlCatchSearchParamsRegex,
+  mockPlaywrightCrud,
+} from "@/tests/useResourceHandler";
+import { transformOrdersToOrderListItems } from "@/services/api/models/Order";
+import { PATH_ADMIN } from "@/utils/routes/path";
+import { Course, DTOCourse } from "@/services/api/models/Course";
+import { DTOProduct, Product } from "@/services/api/models/Product";
+import {
+  DTOOrganization,
+  Organization,
+} from "@/services/api/models/Organization";
+import { User } from "@/services/api/models/User";
+import { ORGANIZATION_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/organizations/organization-mock";
+import { COURSE_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/courses/course-mocks";
+
+test.describe("Order filters", () => {
+  let store = getOrdersScenarioStore();
+  test.beforeEach(async ({ page }) => {
+    const url = "http://localhost:8071/api/v1.0/admin/orders/";
+    store = getOrdersScenarioStore();
+    const list = transformOrdersToOrderListItems(store.list);
+    const queryParamsRegex = getUrlCatchSearchParamsRegex(url);
+    await page.unroute(queryParamsRegex);
+    await page.route(queryParamsRegex, async (route, request) => {
+      const methods = request.method();
+      if (methods === "GET") {
+        await route.fulfill({ json: list });
+      }
+    });
+
+    await mockPlaywrightCrud<Product, DTOProduct>({
+      data: store.products,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/products/",
+      page,
+      searchResult: store.products[0],
+    });
+
+    await mockPlaywrightCrud<Organization, DTOOrganization>({
+      data: store.organizations,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/organizations/",
+      page,
+      searchResult: store.organizations[0],
+      optionsResult: ORGANIZATION_OPTIONS_REQUEST_RESULT,
+    });
+
+    await mockPlaywrightCrud<User, any>({
+      data: store.users,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/users/",
+      page,
+      forceFiltersMode: true,
+      searchResult: store.users[0],
+    });
+
+    await mockPlaywrightCrud<Course, DTOCourse>({
+      data: store.courses,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/courses/",
+      page,
+      searchResult: store.courses[0],
+      optionsResult: COURSE_OPTIONS_REQUEST_RESULT,
+    });
+  });
+
+  test("Check all field are presents", async ({ page }) => {
+    await page.goto(PATH_ADMIN.orders.list);
+    await expect(page.getByRole("heading", { name: "Orders" })).toBeVisible();
+    await expect(
+      page.getByPlaceholder("Search by product title,"),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Filters" }).click();
+    await expect(
+      page.getByTestId("select-order-state-filter").getByLabel("State"),
+    ).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Product" })).toBeVisible();
+    await expect(page.getByLabel("Course")).toBeVisible();
+    await expect(page.getByRole("combobox", { name: "Owner" })).toBeVisible();
+    await expect(
+      page.getByRole("combobox", { name: "Organization" }),
+    ).toBeVisible();
+  });
+
+  test("Check all chips", async ({ page }) => {
+    await page.goto(PATH_ADMIN.orders.list);
+    await expect(page.getByRole("heading", { name: "Orders" })).toBeVisible();
+    await page.getByRole("button", { name: "Filters" }).click();
+    await page
+      .getByTestId("select-order-state-filter")
+      .getByLabel("State")
+      .click();
+    await page.getByRole("option", { name: "Submitted" }).click();
+    await page.getByRole("combobox", { name: "Product" }).click();
+    await page.getByRole("combobox", { name: "Product" }).fill("p");
+    await page.getByRole("option", { name: store.products[0].title }).click();
+    await page.getByLabel("Course").click();
+    await page.getByLabel("Course").fill("c");
+    await page.getByRole("option", { name: store.courses[0].title }).click();
+    await page.getByRole("combobox", { name: "Organization" }).click();
+    await page.getByRole("combobox", { name: "Organization" }).fill("o");
+    await page
+      .getByRole("option", { name: store.organizations[0].title })
+      .click();
+    await page.getByRole("combobox", { name: "Owner" }).click();
+    await page.getByRole("combobox", { name: "Owner" }).fill("u");
+    await page.getByRole("option", { name: store.users[0].username }).click();
+    await page.getByLabel("close").click();
+    await expect(
+      page.getByRole("button", { name: "State: Submitted" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: `Product: ${store.products[0].title}` }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: `Course: ${store.courses[0].title}` }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", {
+        name: `Organization: ${store.organizations[0].title}`,
+      }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: `Owner: ${store.users[0].username}` }),
+    ).toBeVisible();
+  });
+});

--- a/src/frontend/admin/src/tests/organization/organization.test.e2e.ts
+++ b/src/frontend/admin/src/tests/organization/organization.test.e2e.ts
@@ -9,6 +9,8 @@ import { PATH_ADMIN } from "@/utils/routes/path";
 import { ORGANIZATION_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/organizations/organization-mock";
 import { User } from "@/services/api/models/User";
 
+const searchPlaceholder = "Search by title, code";
+
 test.describe("Organization Form", () => {
   let store = getOrganizationScenarioStore();
   test.beforeEach(async ({ page }) => {
@@ -100,7 +102,7 @@ test.describe("Organization List", () => {
       page.getByRole("heading", { name: "Organizations" }),
     ).toHaveCount(1);
 
-    await expect(page.getByPlaceholder("Search...")).toBeVisible();
+    await expect(page.getByPlaceholder(searchPlaceholder)).toBeVisible();
     await Promise.all(
       store.list.map(async (org) => {
         await expect(page.getByText(org.title)).toBeVisible();
@@ -127,14 +129,14 @@ test.describe("Organization List", () => {
       page.getByRole("heading", { name: "Organizations" }),
     ).toHaveCount(1);
 
-    await expect(page.getByPlaceholder("Search...")).toBeVisible();
+    await expect(page.getByPlaceholder(searchPlaceholder)).toBeVisible();
     await expect(page.getByText(store.list[1].title)).toBeVisible();
-    await page.getByPlaceholder("Search...").fill(store.list[0].title);
+    await page.getByPlaceholder(searchPlaceholder).fill(store.list[0].title);
     await expect(page.getByTestId("circular-loader-container")).toBeVisible();
     await expect(page.getByTestId("circular-loader-container")).toBeHidden();
     await expect(page.getByText(store.list[1].title)).toBeHidden();
     await expect(page.getByText(store.list[0].title)).toBeVisible();
-    await page.getByPlaceholder("Search...").fill("");
+    await page.getByPlaceholder(searchPlaceholder).fill("");
     await expect(page.getByTestId("circular-loader-container")).toBeVisible();
     await expect(page.getByTestId("circular-loader-container")).toBeHidden();
     await expect(page.getByText(store.list[1].title)).toBeVisible();

--- a/src/frontend/admin/src/tests/product/product.test.e2e.ts
+++ b/src/frontend/admin/src/tests/product/product.test.e2e.ts
@@ -21,6 +21,8 @@ import {
   DTOContractDefinition,
 } from "@/services/api/models/ContractDefinition";
 
+const searchPlaceholder = "Search by title";
+
 test.describe("Product list", () => {
   const store = getProductScenarioStore();
   test.beforeEach(async ({ page }) => {
@@ -34,7 +36,7 @@ test.describe("Product list", () => {
   test("verify all products are inside the list", async ({ page }) => {
     // Go to the page
     await page.goto(PATH_ADMIN.products.list);
-    await expect(page.getByPlaceholder("Search...")).toBeVisible();
+    await expect(page.getByPlaceholder(searchPlaceholder)).toBeVisible();
     await Promise.all(
       store.products.map(async (product) => {
         await expect(page.getByText(product.title)).toBeVisible();
@@ -53,7 +55,7 @@ test.describe("Product list", () => {
     });
     // Go to the page
     await page.goto(PATH_ADMIN.products.list);
-    await expect(page.getByPlaceholder("Search...")).toBeVisible();
+    await expect(page.getByPlaceholder(searchPlaceholder)).toBeVisible();
 
     await Promise.all(
       store.products.map(async (product) => {
@@ -61,15 +63,15 @@ test.describe("Product list", () => {
       }),
     );
 
-    await page.getByPlaceholder("Search...").click();
-    await page.getByPlaceholder("Search...").fill(productToSearch.title);
+    await page.getByPlaceholder(searchPlaceholder).click();
+    await page.getByPlaceholder(searchPlaceholder).fill(productToSearch.title);
     await expect(page.getByTestId("circular-loader-container")).toBeVisible();
     await expect(page.getByTestId("circular-loader-container")).toBeHidden();
     await expect(page.getByText(productToSearch.title)).toBeVisible();
     await expect(page.getByText(store.products[1].title)).toBeHidden();
 
-    await page.getByPlaceholder("Search...").click();
-    await page.getByPlaceholder("Search...").fill("");
+    await page.getByPlaceholder(searchPlaceholder).click();
+    await page.getByPlaceholder(searchPlaceholder).fill("");
     await Promise.all(
       store.products.map(async (product) => {
         await expect(page.getByText(product.title)).toBeVisible();
@@ -244,6 +246,7 @@ test.describe("Product form", () => {
 
     const course = store.courses[0];
     const courseRuns = course.courses_runs as CourseRun[];
+
     await mockCourseRunsFromCourse(page, courseRuns);
     await mockTargetCourses(
       page,

--- a/src/frontend/admin/src/tests/useResourceHandler.ts
+++ b/src/frontend/admin/src/tests/useResourceHandler.ts
@@ -6,10 +6,11 @@ type Props<T extends WithId, Payload> = {
   routeUrl: string;
   page: Page;
   searchTimeout?: number;
+  forceFiltersMode?: boolean;
   updateCallback?: (payload: Payload, item?: T) => T;
   createCallback?: (payload: Payload) => T;
   optionsResult?: any;
-  searchResult?: T;
+  searchResult?: T | T[];
   getByIdResult?: T;
   data: T[];
 };
@@ -39,6 +40,7 @@ export const catchAllIdRegex = (
 export const mockPlaywrightCrud = async <T extends WithId, Payload>({
   routeUrl,
   searchTimeout = 0,
+  forceFiltersMode = false,
   page,
   ...props
 }: Props<T, Payload>) => {
@@ -64,8 +66,13 @@ export const mockPlaywrightCrud = async <T extends WithId, Payload>({
       const url = new URL(request.url());
       const query = url.searchParams.get("query");
 
-      let result = [props.searchResult ?? resources.data[0]];
-      if (query === null || query === "") {
+      let result = [resources.data[0]];
+      if (props.searchResult) {
+        result = Array.isArray(props.searchResult)
+          ? props.searchResult
+          : [props.searchResult];
+      }
+      if ((query === null || query === "") && !forceFiltersMode) {
         result = [...resources.data];
       }
 

--- a/src/frontend/admin/src/translations/common/commonTranslations.ts
+++ b/src/frontend/admin/src/translations/common/commonTranslations.ts
@@ -36,6 +36,11 @@ export const commonTranslations = defineMessages({
     defaultMessage: "Delete",
     description: "Common delete label",
   },
+  state: {
+    id: "translations.common.commonTranslations.state",
+    defaultMessage: "State",
+    description: "Common state label",
+  },
   language: {
     id: "translations.common.commonTranslations.language",
     defaultMessage: "Language",
@@ -60,6 +65,21 @@ export const commonTranslations = defineMessages({
     id: "translations.common.commonTranslations.successCopy",
     defaultMessage: "Link added to your clipboard",
     description: "Text for the success click to copy notification",
+  },
+  none: {
+    id: "translations.common.commonTranslations.none",
+    defaultMessage: "None",
+    description: "None label",
+  },
+  yes: {
+    id: "translations.common.commonTranslations.yes",
+    defaultMessage: "Yes",
+    description: "Text for the yes word",
+  },
+  no: {
+    id: "translations.common.commonTranslations.no",
+    defaultMessage: "No",
+    description: "Text for the no word",
   },
   clickToView: {
     id: "translations.common.commonTranslations.clickToView",

--- a/src/frontend/admin/src/translations/common/entitiesInputLabel.ts
+++ b/src/frontend/admin/src/translations/common/entitiesInputLabel.ts
@@ -1,0 +1,24 @@
+import { defineMessages } from "react-intl";
+
+export const entitiesInputLabel = defineMessages({
+  product: {
+    id: "translations.common.entitiesInputLabel.product",
+    defaultMessage: "Product",
+    description: "Common Product input label",
+  },
+  course: {
+    id: "translations.common.entitiesInputLabel.course",
+    defaultMessage: "Course",
+    description: "Common Course input label",
+  },
+  organization: {
+    id: "translations.common.entitiesInputLabel.organization",
+    defaultMessage: "Organization",
+    description: "Common Organization input label",
+  },
+  owner: {
+    id: "translations.common.entitiesInputLabel.owner",
+    defaultMessage: "Owner",
+    description: "Common Owner input label",
+  },
+});

--- a/src/frontend/admin/src/translations/common/languageTranslations.ts
+++ b/src/frontend/admin/src/translations/common/languageTranslations.ts
@@ -1,12 +1,13 @@
 import { defineMessages } from "react-intl";
+import { LocalesEnum } from "@/types/i18n/LocalesEnum";
 
-export const languageTranslations = defineMessages({
-  english: {
+export const languageTranslations = defineMessages<LocalesEnum>({
+  [LocalesEnum.ENGLISH]: {
     id: "translations.common.languageTranslations.english",
     defaultMessage: "English",
     description: "Common english label",
   },
-  french: {
+  [LocalesEnum.FRENCH]: {
     id: "translations.common.languageTranslations.french",
     defaultMessage: "French",
     description: "Common french label",

--- a/src/frontend/admin/src/translations/course-runs/priority-state.ts
+++ b/src/frontend/admin/src/translations/course-runs/priority-state.ts
@@ -1,0 +1,45 @@
+import { defineMessages } from "react-intl";
+import { Priority } from "@/services/api/models/Course";
+
+export const courseRunStateMessages = defineMessages<Priority>({
+  [Priority.ONGOING_OPEN]: {
+    id: "translations.courseRuns.priorityState.onGoingOpen",
+    defaultMessage: "Currently open",
+    description: "Label for the ON_GOING_OPEN priority",
+  },
+  [Priority.FUTURE_OPEN]: {
+    id: "translations.courseRuns.priorityState.futureOpen",
+    defaultMessage: "Future open",
+    description: "Label for the FUTURE_OPEN priority",
+  },
+  [Priority.ARCHIVED_OPEN]: {
+    id: "translations.courseRuns.priorityState.archivedOpen",
+    defaultMessage: "Archived open",
+    description: "Label for the ARCHIVED_OPEN priority",
+  },
+  [Priority.FUTURE_NOT_YET_OPEN]: {
+    id: "translations.courseRuns.priorityState.futureNotYetOpen",
+    defaultMessage: "Future not yet open",
+    description: "Label for the FUTURE_NOT_YET_OPEN priority",
+  },
+  [Priority.FUTURE_CLOSED]: {
+    id: "translations.courseRuns.priorityState.futureClosed",
+    defaultMessage: "Future closed",
+    description: "Label for the FUTURE_CLOSED priority",
+  },
+  [Priority.ONGOING_CLOSED]: {
+    id: "translations.courseRuns.priorityState.ongoigClosed",
+    defaultMessage: "Ongoing closed",
+    description: "Label for the ONGOING_CLOSED priority",
+  },
+  [Priority.ARCHIVED_CLOSED]: {
+    id: "translations.courseRuns.priorityState.archivedClosed",
+    defaultMessage: "Archived closed",
+    description: "Label for the ARCHIVED_CLOSED priority",
+  },
+  [Priority.TO_BE_SCHEDULED]: {
+    id: "translations.courseRuns.priorityState.toBeScheduled",
+    defaultMessage: "To be scheduled",
+    description: "Label for the TO_BE_SCHEDULED priority",
+  },
+});

--- a/src/frontend/admin/src/translations/products/types.ts
+++ b/src/frontend/admin/src/translations/products/types.ts
@@ -1,0 +1,20 @@
+import { defineMessages } from "react-intl";
+import { ProductType } from "@/services/api/models/Product";
+
+export const productTypesMessages = defineMessages<ProductType>({
+  [ProductType.CERTIFICATE]: {
+    id: "translations.products.productTypesMessages.certificate",
+    defaultMessage: "Certificate",
+    description: "Label for the CERTIFICATE product type",
+  },
+  [ProductType.CREDENTIAL]: {
+    id: "translations.products.productTypesMessages.credential",
+    defaultMessage: "Credential",
+    description: "Label for the CREDENTIAL product type",
+  },
+  [ProductType.ENROLLMENT]: {
+    id: "translations.products.productTypesMessages.enrollment",
+    defaultMessage: "Enrollment",
+    description: "Label for the ENROLLMENT product type",
+  },
+});


### PR DESCRIPTION
## Purpose

Currently, the Back office only allow to filter list views by full text search that is really limited. Indeed we should add several filters specific to each views.


https://github.com/openfun/joanie/assets/19410531/64177033-6af9-4fcf-99e8-479a4b9421f0




#564 
