### PR TITLE
🚑(backend) fix multiple get results in api client

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -104,6 +104,7 @@ class CourseProductRelationViewSet(
             "product__certificate_definition",
         )
         .prefetch_related("organizations")
+        .distinct()
     )
 
     @property


### PR DESCRIPTION
## Purpose

On the course product relation, a distinct call was missing so when the relation
 was linked to several organizations, a 500 error was raised due to the fact
 that the get request matched multiple relations.

https://gip-fun-mooc.sentry.io/issues/4889287908/?environment=preproduction&project=6599941&query=is:unresolved&statsPeriod=30d&stream_index=9