### PR TITLE
🔧(tray) set imagePullPolicy in admin deployment

### DIFF
--- a/src/tray/templates/services/admin/deploy.yml.j2
+++ b/src/tray/templates/services/admin/deploy.yml.j2
@@ -46,6 +46,7 @@ spec:
 {% endif %}
       containers:
         - image: "{{ joanie_admin_nginx_image_name }}:{{ joanie_admin_nginx_image_tag }}"
+          imagePullPolicy: Always
           name: admin
           ports:
             - containerPort: 80


### PR DESCRIPTION
## Purpose

In the admin deployment, the imagePullPolicy is not set. We must use the Always policy to pull the last image with the same tag.


## Proposal

- [x] set imagePullPolicy in admin deployment