### PR TITLE
✅(backend) fix flaky test with course run languages order

### DIFF
--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -245,10 +245,7 @@ class CourseRunFactory(factory.django.DjangoModelFactory):
         """
         Compute a random set of languages from the complete list of Django supported languages.
         """
-        return {
-            language[0]
-            for language in random.sample(enums.ALL_LANGUAGES, random.randint(1, 5))
-        }
+        return {random.choice(enums.ALL_LANGUAGES)[0]}
 
     @factory.lazy_attribute_sequence
     def resource_link(self, sequence):


### PR DESCRIPTION
## Purpose

Some tests can fail randomly due to a difference in the order of languages dict of a course run resource. In those tests, we are using `assertCountEqual` method
 to compare resource with expected one regardless list order.

## Proposal

- [x] Try to fix identified flaky test
