### PR TITLE
✨(backend) filter contract through a course product relation id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to
 - Allow to override settings in tray
 - Add API endpoints for other services to fetch  data on course run
 - Allow to filter contracts by signature state,
-  product, course and organization and id
+  product, course and organization, id and course product relation id
 - Add bulk download of signed contracts to generate ZIP archive with command
 - Add read-only api admin endpoint to list/retrieve orders
 - Add a management command to synchronize course run or product

--- a/src/backend/joanie/tests/core/test_api_courses_contract.py
+++ b/src/backend/joanie/tests/core/test_api_courses_contract.py
@@ -280,6 +280,124 @@ class CourseContractApiTest(BaseAPITestCase):
         self.assertEqual(count, 1)
         self.assertEqual(result_ids, [str(signed_contract.id)])
 
+    def test_api_courses_contracts_list_filter_by_course_product_relation_id(self):
+        """
+        Authenticated user with any access to the organization can query organization's
+        course contracts and filter them by course product relation.
+        """
+        organization = factories.OrganizationFactory.create()
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        factories.UserOrganizationAccessFactory(user=user, organization=organization)
+        course = factories.CourseFactory()
+        other_organization = factories.OrganizationFactory.create()
+
+        relation_1 = factories.CourseProductRelationFactory(
+            organizations=[organization, other_organization],
+            course=course,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
+
+        relation_2 = factories.CourseProductRelationFactory(
+            course=course,
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
+
+        contracts_1 = factories.ContractFactory.create_batch(
+            5,
+            order__product=relation_1.product,
+            order__course=relation_1.course,
+            order__organization=organization,
+        )
+
+        contracts_2 = factories.ContractFactory.create_batch(
+            3,
+            order__product=relation_2.product,
+            order__course=relation_2.course,
+            order__organization=organization,
+        )
+
+        # Create random contracts that should not be returned
+        other_relation = factories.CourseProductRelationFactory(
+            organizations=[organization],
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
+
+        factories.ContractFactory.create(
+            order__product=relation_1.product,
+            order__course=relation_1.course,
+            order__organization=other_organization,
+        )
+
+        factories.ContractFactory.create_batch(
+            3,
+            order__product=other_relation.product,
+            order__course=other_relation.course,
+            order__organization=organization,
+        )
+
+        factories.ContractFactory.create_batch(8)
+        factories.ContractFactory(order__owner=user)
+
+        # - List without filter should return 8 contracts
+        with self.assertNumQueries(56):
+            response = self.client.get(
+                f"/api/v1.0/courses/{course.id}/contracts/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 8)
+
+        # - Filter by the first relation should return 5 contracts
+        with self.assertNumQueries(10):
+            response = self.client.get(
+                f"/api/v1.0/courses/{course.id}/contracts/"
+                f"?course_product_relation_id={relation_1.id}",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        count = content["count"]
+        result_ids = [result["id"] for result in content["results"]]
+        self.assertEqual(count, 5)
+        self.assertCountEqual(
+            result_ids, [str(contract.id) for contract in contracts_1]
+        )
+
+        # - Filter by the second relation should return 3 contracts
+        with self.assertNumQueries(8):
+            response = self.client.get(
+                f"/api/v1.0/courses/{course.id}/contracts/"
+                f"?course_product_relation_id={relation_2.id}",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        count = content["count"]
+        result_ids = [result["id"] for result in content["results"]]
+        self.assertEqual(count, 3)
+        self.assertCountEqual(
+            result_ids, [str(contract.id) for contract in contracts_2]
+        )
+
+        # - Filter by the other relation should return no contracts
+        with self.assertNumQueries(2):
+            response = self.client.get(
+                f"/api/v1.0/courses/{course.id}/contracts/"
+                f"?course_product_relation_id={other_relation.id}",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        count = content["count"]
+        self.assertEqual(count, 0)
+
     def test_api_courses_contracts_retrieve_anonymous(self):
         """
         Anonymous user cannot query an organization's course contract.

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -467,6 +467,14 @@
                     },
                     {
                         "in": "query",
+                        "name": "course_product_relation_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
                         "name": "id",
                         "schema": {
                             "type": "array",
@@ -1282,6 +1290,14 @@
                     {
                         "in": "query",
                         "name": "course_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "course_product_relation_id",
                         "schema": {
                             "type": "string",
                             "format": "uuid"
@@ -3082,6 +3098,14 @@
                     {
                         "in": "query",
                         "name": "course_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "course_product_relation_id",
                         "schema": {
                             "type": "string",
                             "format": "uuid"


### PR DESCRIPTION
## Purpose

Our frontend consumer needs to be able to filter contracts through a course product relation id instead of a couple product / course id.

Close #575


## Proposal
- [x] Add `course_product_relation_id` filter to contracts endpoints
