### PR TITLE
♻️(back) change default rest framework pagination class

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -15,7 +15,7 @@ from django.urls import reverse
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework import mixins, pagination, viewsets
+from rest_framework import mixins, viewsets
 from rest_framework import permissions as drf_permissions
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
@@ -39,21 +39,12 @@ UUID_REGEX = (
 )
 
 
-class Pagination(pagination.PageNumberPagination):
-    """Pagination to display no more than 100 objects per page sorted by creation date."""
-
-    ordering = "-created_on"
-    max_page_size = 100
-    page_size_query_param = "page_size"
-
-
 class CourseRunViewSet(
     mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
 ):
     """API ViewSet for all interactions with course runs."""
 
     lookup_field = "id"
-    pagination_class = Pagination
     permissions_classes = [drf_permissions.AllowAny]
     queryset = models.CourseRun.objects.filter(is_listed=True).select_related("course")
     serializer_class = serializers.CourseRunSerializer
@@ -201,7 +192,6 @@ class EnrollmentViewSet(
     """API ViewSet for all interactions with enrollments."""
 
     lookup_field = "id"
-    pagination_class = Pagination
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = serializers.EnrollmentSerializer
     filterset_class = filters.EnrollmentViewSetFilter
@@ -275,7 +265,6 @@ class OrderViewSet(
     """
 
     lookup_field = "pk"
-    pagination_class = Pagination
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = serializers.OrderSerializer
     filterset_class = filters.OrderViewSetFilter
@@ -604,7 +593,6 @@ class CertificateViewSet(
     """
 
     lookup_field = "pk"
-    pagination_class = Pagination
     serializer_class = serializers.CertificateSerializer
     permission_classes = [permissions.IsAuthenticated]
     queryset = models.Certificate.objects.all().select_related(
@@ -688,7 +676,6 @@ class OrganizationViewSet(
     """
 
     lookup_field = "pk"
-    pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
     serializer_class = serializers.OrganizationSerializer
 
@@ -783,7 +770,6 @@ class OrganizationAccessViewSet(
     """
 
     lookup_field = "pk"
-    pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
     queryset = models.OrganizationAccess.objects.all().select_related("user")
     serializer_class = serializers.OrganizationAccessSerializer
@@ -858,7 +844,6 @@ class CourseAccessViewSet(
     """
 
     lookup_field = "pk"
-    pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
     queryset = models.CourseAccess.objects.all().select_related("user")
     serializer_class = serializers.CourseAccessSerializer
@@ -925,7 +910,6 @@ class CourseViewSet(
     lookup_field = "pk"
     lookup_value_regex = "[0-9a-z-]*"
     filterset_class = filters.CourseViewSetFilter
-    pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
     serializer_class = serializers.CourseSerializer
     ordering = ["-created_on"]
@@ -1050,7 +1034,6 @@ class GenericContractViewSet(
     """
 
     lookup_field = "pk"
-    pagination_class = Pagination
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = serializers.ContractSerializer
     filterset_class = filters.ContractViewSetFilter
@@ -1407,7 +1390,6 @@ class NestedOrderCourseViewSet(NestedGenericViewSet, mixins.ListModelMixin):
 
     lookup_fields = ["course_id", "pk"]
     lookup_url_kwargs = ["course_id", "pk"]
-    pagination_class = Pagination
     permission_classes = [permissions.AccessPermission]
     serializer_class = serializers.NestedOrderCourseSerializer
     filterset_class = filters.NestedOrderCourseViewSetFilter

--- a/src/backend/joanie/core/pagination.py
+++ b/src/backend/joanie/core/pagination.py
@@ -1,0 +1,10 @@
+"""Pagination used by django rest framework."""
+from rest_framework.pagination import PageNumberPagination
+
+
+class Pagination(PageNumberPagination):
+    """Pagination to display no more than 100 objects per page sorted by creation date."""
+
+    ordering = "-created_on"
+    max_page_size = 100
+    page_size_query_param = "page_size"

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -297,7 +297,7 @@ class Base(Configuration):
             "nested_multipart_parser.drf.DrfNestedParser",
         ],
         "EXCEPTION_HANDLER": "joanie.core.api.exception_handler",
-        "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+        "DEFAULT_PAGINATION_CLASS": "joanie.core.pagination.Pagination",
         "PAGE_SIZE": 20,
         "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
         "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -21,6 +21,15 @@
                         }
                     },
                     {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
                         "in": "query",
                         "name": "query",
                         "schema": {
@@ -267,6 +276,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -521,6 +539,15 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -619,6 +646,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -1106,6 +1142,15 @@
                         }
                     },
                     {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
                         "in": "query",
                         "name": "query",
                         "schema": {
@@ -1374,6 +1419,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -1675,6 +1729,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -2166,6 +2229,15 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -2238,6 +2310,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -2698,6 +2779,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -3212,6 +3302,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -19,6 +19,15 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -727,6 +736,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -1639,6 +1657,15 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "tags": [
@@ -1872,6 +1899,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }
@@ -3349,6 +3385,15 @@
                         "required": false,
                         "in": "query",
                         "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
                         "schema": {
                             "type": "integer"
                         }


### PR DESCRIPTION
## Purpose

The setting DEFAULT_PAGINATION_CLASS was using a pagination class defined in rest_framework but we are using an other one in our viewsets. To be coherent and to avoid to define it every time, we choose to change the default class and remove the pagination property in evey viewset.

## Proposal

- [x] change default rest framework pagination class
