### PR TITLE
:sparkles: (backend) CRUD addresses for Organization for backoffice and admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add admin endpoints to create/update/delete organization addresses
 - Add several admin api endpoint filters
 - Filter course product relation client api endpoint by product type
 - Link Organization to Address Model

--- a/src/backend/joanie/admin_urls.py
+++ b/src/backend/joanie/admin_urls.py
@@ -67,6 +67,11 @@ admin_organization_related_router.register(
     api_admin.OrganizationAccessViewSet,
     basename="admin_organization_accesses",
 )
+admin_organization_related_router.register(
+    "addresses",
+    api_admin.OrganizationAddressViewSet,
+    basename="admin_organization_addresses",
+)
 
 # Admin API routes nested under products
 admin_product_related_router = DefaultRouter()

--- a/src/backend/joanie/tests/core/test_api_admin_organization_addresses.py
+++ b/src/backend/joanie/tests/core/test_api_admin_organization_addresses.py
@@ -1,0 +1,405 @@
+"""
+Test suite for Organization Address Admin API endpoints.
+"""
+import uuid
+from http import HTTPStatus
+
+from django.test import TestCase
+
+from joanie.core import factories
+
+
+class OrganizationAddressAdminAPITest(TestCase):
+    """
+    Test suite for Organization Address Admin API endpoints.
+    """
+
+    def test_admin_api_organization_addresses_request_anonymous(self):
+        """
+        Anonymous users should not be able to request organization addresses endpoint.
+        """
+        organization = factories.OrganizationFactory()
+
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/addresses/"
+        )
+
+        self.assertContains(
+            response,
+            "Authentication credentials were not provided.",
+            status_code=HTTPStatus.UNAUTHORIZED,
+        )
+
+    def test_admin_api_organization_addresses_request_authenticated(self):
+        """
+        Authenticated users should not be able to request organization addresses endpoint.
+        """
+        user = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        organization = factories.OrganizationFactory()
+
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/addresses/"
+        )
+
+        self.assertContains(
+            response,
+            "You do not have permission to perform this action.",
+            status_code=HTTPStatus.FORBIDDEN,
+        )
+
+    def test_admin_api_organization_addresses_request_list(self):
+        """
+        Super admin user should not be able to list organization addresses.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/addresses/"
+        )
+
+        self.assertContains(
+            response,
+            'Method \\"GET\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
+
+    def test_admin_api_organization_addresses_request_get(self):
+        """
+        Super admin user should not be able to retrieve an organization address.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        address = factories.OrganizationAddressFactory(organization=organization)
+
+        response = self.client.get(
+            f"/api/v1.0/admin/organizations/{organization.id}/addresses/{address.id}/"
+        )
+
+        self.assertContains(
+            response,
+            'Method \\"GET\\" not allowed.',
+            status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        )
+
+    def test_admin_api_organization_addresses_request_create(self):
+        """
+        Super admin user should be able to create an address for an organization.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        organization = factories.OrganizationFactory()
+        self.client.login(username=admin.username, password="password")
+
+        response = self.client.post(
+            f"/api/v1.0/admin/organizations/{organization.id}/addresses/",
+            data={
+                "address": "1 rue de l'exemple",
+                "city": "Paris",
+                "country": "FR",
+                "first_name": "John",
+                "last_name": "Doe",
+                "is_main": True,
+                "is_reusable": True,
+                "postcode": "75000",
+                "title": "Home",
+            },
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertEqual(organization.addresses.count(), 1)
+
+        organization_address = organization.addresses.first()
+
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(organization_address.id),
+                "address": str(organization_address.address),
+                "city": str(organization_address.city),
+                "country": str(organization_address.country),
+                "first_name": (organization_address.first_name),
+                "last_name": (organization_address.last_name),
+                "is_main": (organization_address.is_main),
+                "is_reusable": (organization_address.is_reusable),
+                "postcode": (organization_address.postcode),
+                "title": (organization_address.title),
+            },
+        )
+
+    def test_admin_api_organization_addresses_request_create_with_unknown_organization_id(
+        self,
+    ):
+        """
+        An 400 Bad Request should be raised if the organization id is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        not_exiting_organization_id = uuid.uuid4()
+
+        response = self.client.post(
+            f"/api/v1.0/admin/organizations/{not_exiting_organization_id}/addresses/",
+            data={
+                "address": "1 rue de l'exemple",
+                "city": "Paris",
+                "country": "FR",
+                "first_name": "John",
+                "last_name": "Doe",
+                "is_main": True,
+                "is_reusable": True,
+                "postcode": "75000",
+                "title": "Home",
+            },
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(
+            response.json(), {"organization_id": "Resource does not exist."}
+        )
+
+    def test_admin_api_organization_addresses_request_update(self):
+        """
+        Super admin user should be able to update an organization address.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        address = factories.OrganizationAddressFactory(
+            address="1 rue de l'exemple", organization=organization
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/organizations/{organization.id}/addresses/{address.id}/",
+            content_type="application/json",
+            data={
+                "address": "61 bis rue de l'exemple",
+                "city": "Paris",
+                "country": "FR",
+                "first_name": "John",
+                "last_name": "Doe",
+                "is_main": True,
+                "is_reusable": True,
+                "postcode": "75000",
+                "title": "Home",
+            },
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(
+            content,
+            {
+                "id": str(address.id),
+                "address": "61 bis rue de l'exemple",
+                "city": "Paris",
+                "country": "FR",
+                "first_name": "John",
+                "last_name": "Doe",
+                "is_main": True,
+                "is_reusable": True,
+                "postcode": "75000",
+                "title": "Home",
+            },
+        )
+
+    def test_admin_api_organization_addresses_request_update_with_unknown_address_id(
+        self,
+    ):
+        """
+        An 404 Not found error should be raised if the address id to update is unknown.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+
+        self.assertEqual(organization.addresses.count(), 0)
+
+        response = self.client.put(
+            f"/api/v1.0/admin/organizations/{organization.id}/addresses/{uuid.uuid4()}/",
+            data={
+                "address": "61 bis rue de l'exemple",
+                "city": "Paris",
+                "country": "FR",
+                "first_name": "John",
+                "last_name": "Doe",
+                "is_main": True,
+                "is_reusable": True,
+                "postcode": "75000",
+                "title": "Home",
+            },
+        )
+
+        self.assertContains(response, "Not found.", status_code=HTTPStatus.NOT_FOUND)
+
+    def test_admin_api_organization_addresses_request_update_with_partial_payload(self):
+        """
+        An 400 Bad request error should be raised if a partial payload is provided.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        address = factories.OrganizationAddressFactory(
+            organization=organization, title="Office"
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/organizations/{organization.id}/accesses/{address.id}/",
+            content_type="application/json",
+            data={
+                "title": "Home",
+            },
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        self.assertEqual(response.json(), {"detail": "Not found."})
+
+    def test_admin_api_organization_addresses_request_update_with_fake_organization_id(
+        self,
+    ):
+        """
+        An 400 Bad request error should be raised if trying to update an address with a
+        non existing `organization_id`.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organization = factories.OrganizationFactory()
+        address = factories.OrganizationAddressFactory(
+            organization=organization, title="Office"
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/organizations/{uuid.uuid4()}/addresses/{address.id}/",
+            content_type="application/json",
+            data={
+                "address": "61 bis rue de l'exemple",
+                "city": "Paris",
+                "country": "FR",
+                "first_name": "John",
+                "last_name": "Doe",
+                "is_main": True,
+                "is_reusable": True,
+                "postcode": "75000",
+                "title": "Home",
+            },
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": "The relation does not exist between the address and the organization."
+            },
+        )
+
+    def test_admin_api_organization_addresses_request_partial_update(self):
+        """
+        Super admin user should be able to partially update an organization's address because it
+        accepts that needs to be applied.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        address = factories.OrganizationAddressFactory(
+            title="Headquarters",
+            address="61 bis rue de l'exemple",
+            city="Paris",
+            country="FR",
+            first_name="John",
+            last_name="Doe",
+            is_main=True,
+            is_reusable=True,
+            postcode="75000",
+        )
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/organizations/{address.organization.id}/addresses/{address.id}/",
+            content_type="application/json",
+            data={
+                "title": "Home sweet home",
+            },
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(address.id),
+                "title": "Home sweet home",
+                "address": "61 bis rue de l'exemple",
+                "city": "Paris",
+                "country": "FR",
+                "first_name": "John",
+                "last_name": "Doe",
+                "is_main": True,
+                "is_reusable": True,
+                "postcode": "75000",
+            },
+        )
+
+    def test_admin_api_organization_addresses_request_delete(self):
+        """
+        Super admin user should be able to delete an organization's address when the relation
+        exists.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        address = factories.OrganizationAddressFactory()
+
+        self.assertEqual(address.organization.addresses.count(), 1)
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/organizations/{address.organization.id}/addresses/{address.id}/"
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+        self.assertEqual(address.organization.accesses.count(), 0)
+
+    def test_admin_api_organization_addresses_request_delete_with_wrong_address_id(
+        self,
+    ):
+        """
+        Super admin user should not be able to delete an address if there is no relation
+        between the organization and the address.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        [organization_1, organization_2] = factories.OrganizationFactory.create_batch(2)
+        address = factories.OrganizationAddressFactory(organization=organization_1)
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/organizations/{organization_2.id}/addresses/{address.id}/"
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            ["The relation does not exist between the address and the organization."],
+        )
+
+    def test_admin_api_organization_addresses_request_update_with_wrong_address_id(
+        self,
+    ):
+        """
+        Super admin user should not be able to update partially an address if there is no relation
+        between the organization and the address.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        [organization_1, organization_2] = factories.OrganizationFactory.create_batch(2)
+        address = factories.OrganizationAddressFactory(organization=organization_1)
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/organizations/{organization_2.id}/addresses/{address.id}/",
+            content_type="application/json",
+            data={"title": "Office"},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "detail": "The relation does not exist between the address and the organization."
+            },
+        )

--- a/src/backend/joanie/tests/core/test_api_admin_organizations.py
+++ b/src/backend/joanie/tests/core/test_api_admin_organizations.py
@@ -197,7 +197,8 @@ class OrganizationAdminApiTest(TestCase):
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=admin.username, password="password")
         organization = factories.OrganizationFactory()
-
+        # Add addresses to organization
+        address = factories.OrganizationAddressFactory(organization=organization)
         # Add accesses to organization
         accesses_count = random.randint(0, 5)
         factories.UserOrganizationAccessFactory.create_batch(
@@ -240,6 +241,30 @@ class OrganizationAdminApiTest(TestCase):
                     ),
                     "filename": organization.logo.name,
                 },
+                "enterprise_code": organization.enterprise_code,
+                "activity_category_code": organization.activity_category_code,
+                "representative_profession": organization.representative_profession,
+                "signatory_representative": organization.signatory_representative,
+                "signatory_representative_profession": (
+                    organization.signatory_representative_profession
+                ),
+                "contact_phone": organization.contact_phone,
+                "contact_email": organization.contact_email,
+                "dpo_email": organization.dpo_email,
+                "addresses": [
+                    {
+                        "id": str(address.id),
+                        "title": address.title,
+                        "address": address.address,
+                        "city": address.city,
+                        "country": address.country,
+                        "first_name": address.first_name,
+                        "last_name": address.last_name,
+                        "is_main": address.is_main,
+                        "is_reusable": address.is_reusable,
+                        "postcode": address.postcode,
+                    }
+                ],
                 "accesses": [
                     {
                         "id": str(access.id),

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -2789,6 +2789,217 @@
                 }
             }
         },
+        "/api/v1.0/admin/organizations/{organization_id}/addresses/": {
+            "post": {
+                "operationId": "organizations_addresses_create",
+                "description": "Write only Address for Organizations ViewSet.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminOrganizationAddressRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminOrganizationAddressRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AdminOrganizationAddress"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1.0/admin/organizations/{organization_id}/addresses/{id}/": {
+            "put": {
+                "operationId": "organizations_addresses_update",
+                "description": "Write only Address for Organizations ViewSet.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminOrganizationAddressRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminOrganizationAddressRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AdminOrganizationAddress"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "organizations_addresses_partial_update",
+                "description": "Write only Address for Organizations ViewSet.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAdminOrganizationAddressRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAdminOrganizationAddressRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AdminOrganizationAddress"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "organizations_addresses_destroy",
+                "description": "Delete the address of an organization when the relation exists only.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "organization_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
         "/api/v1.0/admin/organizations/{id}/": {
             "get": {
                 "operationId": "organizations_retrieve",
@@ -4836,10 +5047,61 @@
                     },
                     "title": {
                         "type": "string"
+                    },
+                    "enterprise_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 50
+                    },
+                    "activity_category_code": {
+                        "type": "string",
+                        "maxLength": 50
+                    },
+                    "representative_profession": {
+                        "type": "string",
+                        "nullable": true,
+                        "title": "Profession of the organization's representative",
+                        "description": "representative profession",
+                        "maxLength": 100
+                    },
+                    "signatory_representative": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "This field is optional. If it is set, you must set the field'signatory_representative_profession' as well",
+                        "maxLength": 100
+                    },
+                    "signatory_representative_profession": {
+                        "type": "string",
+                        "nullable": true,
+                        "title": "Profession of the signatory representative",
+                        "description": "signatory representative profession",
+                        "maxLength": 100
+                    },
+                    "contact_phone": {
+                        "type": "string",
+                        "title": "Contact phone number",
+                        "maxLength": 40
+                    },
+                    "contact_email": {
+                        "type": "string",
+                        "maxLength": 100
+                    },
+                    "dpo_email": {
+                        "type": "string",
+                        "title": "Data protection officer email",
+                        "maxLength": 100
+                    },
+                    "addresses": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AdminOrganizationAddress"
+                        },
+                        "readOnly": true
                     }
                 },
                 "required": [
                     "accesses",
+                    "addresses",
                     "code",
                     "id",
                     "title"
@@ -4880,6 +5142,119 @@
                         "$ref": "#/components/schemas/OrganizationAccessRoleChoiceEnum"
                     }
                 }
+            },
+            "AdminOrganizationAddress": {
+                "type": "object",
+                "description": "Serializer for the Address model for an organization",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "primary key for the record as UUID"
+                    },
+                    "title": {
+                        "type": "string",
+                        "maxLength": 100
+                    },
+                    "address": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "postcode": {
+                        "type": "string",
+                        "maxLength": 50
+                    },
+                    "city": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "country": {
+                        "$ref": "#/components/schemas/CountryEnum"
+                    },
+                    "first_name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "last_name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "is_main": {
+                        "type": "boolean",
+                        "title": "Main"
+                    },
+                    "is_reusable": {
+                        "type": "boolean",
+                        "title": "Reusable"
+                    }
+                },
+                "required": [
+                    "address",
+                    "city",
+                    "country",
+                    "first_name",
+                    "id",
+                    "last_name",
+                    "postcode",
+                    "title"
+                ]
+            },
+            "AdminOrganizationAddressRequest": {
+                "type": "object",
+                "description": "Serializer for the Address model for an organization",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 100
+                    },
+                    "address": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "postcode": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 50
+                    },
+                    "city": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "country": {
+                        "$ref": "#/components/schemas/CountryEnum"
+                    },
+                    "first_name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "last_name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "is_main": {
+                        "type": "boolean",
+                        "title": "Main"
+                    },
+                    "is_reusable": {
+                        "type": "boolean",
+                        "title": "Reusable"
+                    }
+                },
+                "required": [
+                    "address",
+                    "city",
+                    "country",
+                    "first_name",
+                    "last_name",
+                    "postcode",
+                    "title"
+                ]
             },
             "AdminOrganizationLight": {
                 "type": "object",
@@ -4939,6 +5314,49 @@
                     "title": {
                         "type": "string",
                         "minLength": 1
+                    },
+                    "enterprise_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 50
+                    },
+                    "activity_category_code": {
+                        "type": "string",
+                        "maxLength": 50
+                    },
+                    "representative_profession": {
+                        "type": "string",
+                        "nullable": true,
+                        "title": "Profession of the organization's representative",
+                        "description": "representative profession",
+                        "maxLength": 100
+                    },
+                    "signatory_representative": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "This field is optional. If it is set, you must set the field'signatory_representative_profession' as well",
+                        "maxLength": 100
+                    },
+                    "signatory_representative_profession": {
+                        "type": "string",
+                        "nullable": true,
+                        "title": "Profession of the signatory representative",
+                        "description": "signatory representative profession",
+                        "maxLength": 100
+                    },
+                    "contact_phone": {
+                        "type": "string",
+                        "title": "Contact phone number",
+                        "maxLength": 40
+                    },
+                    "contact_email": {
+                        "type": "string",
+                        "maxLength": 100
+                    },
+                    "dpo_email": {
+                        "type": "string",
+                        "title": "Data protection officer email",
+                        "maxLength": 100
                     }
                 },
                 "required": [
@@ -6185,6 +6603,53 @@
                     }
                 }
             },
+            "PatchedAdminOrganizationAddressRequest": {
+                "type": "object",
+                "description": "Serializer for the Address model for an organization",
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 100
+                    },
+                    "address": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "postcode": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 50
+                    },
+                    "city": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "country": {
+                        "$ref": "#/components/schemas/CountryEnum"
+                    },
+                    "first_name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "last_name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 255
+                    },
+                    "is_main": {
+                        "type": "boolean",
+                        "title": "Main"
+                    },
+                    "is_reusable": {
+                        "type": "boolean",
+                        "title": "Reusable"
+                    }
+                }
+            },
             "PatchedAdminOrganizationRequest": {
                 "type": "object",
                 "description": "Serializer for Organization model.",
@@ -6218,6 +6683,49 @@
                     "title": {
                         "type": "string",
                         "minLength": 1
+                    },
+                    "enterprise_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 50
+                    },
+                    "activity_category_code": {
+                        "type": "string",
+                        "maxLength": 50
+                    },
+                    "representative_profession": {
+                        "type": "string",
+                        "nullable": true,
+                        "title": "Profession of the organization's representative",
+                        "description": "representative profession",
+                        "maxLength": 100
+                    },
+                    "signatory_representative": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "This field is optional. If it is set, you must set the field'signatory_representative_profession' as well",
+                        "maxLength": 100
+                    },
+                    "signatory_representative_profession": {
+                        "type": "string",
+                        "nullable": true,
+                        "title": "Profession of the signatory representative",
+                        "description": "signatory representative profession",
+                        "maxLength": 100
+                    },
+                    "contact_phone": {
+                        "type": "string",
+                        "title": "Contact phone number",
+                        "maxLength": 40
+                    },
+                    "contact_email": {
+                        "type": "string",
+                        "maxLength": 100
+                    },
+                    "dpo_email": {
+                        "type": "string",
+                        "title": "Data protection officer email",
+                        "maxLength": 100
                     }
                 }
             },


### PR DESCRIPTION
## Purpose

We've linked `Organization` to `Address` Model with a foreign key, and we've added  the following properties on `Organization` model :
- `siret`
- `activity_number`
- `representative_profession`
- `signatory_representative` (optional)
- `signatory_representative_profession` (required when signatory_representative filled)
- `contact_phone`
- `contact_mail`
- `dpo_mail`

**All these new properties must be managed in the admin application.**

## Proposal
- [x] Add a viewset to manage addresses of an organization
- [x] Add admin serializer to manage serializing data about addresses for an organization
- [x] declare new viewset into admin_urls
- [x] add tests on the viewset+serializer OrganizationAddressViewset and AdminOrganizationAddressSerializer
- [x] Add new fields (new properties) to existing AdminOrganizationSerializer.
- [x] update tests for organization admin api.
- [x] update the standard django admin interface for the application 'Addresses'

