### PR TITLE
✨(backend) add admin api filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add several admin api endpoint filters
 - Filter course product relation client api endpoint by product type
 - Link Organization to Address Model
 - New properties on Organization model to complete contract definition context

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -428,6 +428,7 @@ class OrderViewSet(
         "list": serializers.AdminOrderLightSerializer,
     }
     default_serializer_class = serializers.AdminOrderSerializer
+    filterset_class = filters.OrderAdminFilterSet
     queryset = models.Order.objects.all().select_related(
         "product",
         "owner",

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -5,7 +5,6 @@ from http import HTTPStatus
 
 from django.core.exceptions import ValidationError
 
-import django_filters.rest_framework
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import mixins, permissions, viewsets
@@ -27,7 +26,6 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
     serializer_class = serializers.AdminOrganizationSerializer
     queryset = models.Organization.objects.all()
-    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.OrganizationAdminFilterSet
 
     def get_serializer_class(self):
@@ -66,7 +64,6 @@ class CourseViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
     serializer_class = serializers.AdminCourseSerializer
     queryset = models.Course.objects.all().prefetch_related("organizations", "products")
-    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.CourseAdminFilterSet
 
     def get_serializer_class(self):
@@ -87,7 +84,6 @@ class CourseRunViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
     serializer_class = serializers.AdminCourseRunSerializer
     queryset = models.CourseRun.objects.all().select_related("course")
-    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.CourseRunAdminFilterSet
 
     def get_queryset(self):
@@ -113,7 +109,6 @@ class CertificateDefinitionViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
     serializer_class = serializers.AdminCertificateDefinitionSerializer
     queryset = models.CertificateDefinition.objects.all()
-    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.CertificateDefinitionAdminFilterSet
 
 
@@ -127,7 +122,6 @@ class UserViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     serializer_class = serializers.AdminUserSerializer
     me_serializer_class = serializers.AdminUserCompleteSerializer
     queryset = models.User.objects.all().order_by("username")
-    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.UserAdminFilterSet
 
     def get_queryset(self):
@@ -313,7 +307,6 @@ class ContractDefinitionViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAdminUser & permissions.DjangoModelPermissions]
     serializer_class = serializers.AdminContractDefinitionSerializer
     queryset = models.ContractDefinition.objects.all()
-    filter_backends = [django_filters.rest_framework.DjangoFilterBackend]
     filterset_class = filters.ContractDefinitionAdminFilterSet
 
 

--- a/src/backend/joanie/core/filters/admin.py
+++ b/src/backend/joanie/core/filters/admin.py
@@ -135,6 +135,11 @@ class CourseAdminFilterSet(filters.FilterSet):
         fields: List[str] = ["query"]
 
     query = filters.CharFilter(method="filter_by_query")
+    organization_ids = filters.ModelMultipleChoiceFilter(
+        queryset=models.Organization.objects.all().only("pk"),
+        field_name="organizations",
+        distinct=True,
+    )
 
     def filter_by_query(self, queryset, _name, value):
         """

--- a/src/backend/joanie/core/filters/admin.py
+++ b/src/backend/joanie/core/filters/admin.py
@@ -227,4 +227,55 @@ class UserAdminFilterSet(filters.FilterSet):
             | Q(first_name__icontains=value)
             | Q(last_name__icontains=value)
             | Q(email__icontains=value)
-        )
+        ).distinct()
+
+
+class OrderAdminFilterSet(filters.FilterSet):
+    """
+    FilterSet to filter orders by several criteria.
+    """
+
+    class Meta:
+        model = models.Order
+        fields: List[str] = ["query"]
+
+    query = filters.CharFilter(method="filter_by_query")
+    course_ids = filters.ModelMultipleChoiceFilter(
+        queryset=models.Course.objects.all().only("pk"),
+        field_name="course",
+        distinct=True,
+    )
+    organization_ids = filters.ModelMultipleChoiceFilter(
+        queryset=models.Organization.objects.all().only("pk"),
+        field_name="organization",
+        distinct=True,
+    )
+    owner_ids = filters.ModelMultipleChoiceFilter(
+        queryset=models.User.objects.all().only("pk"),
+        field_name="owner",
+        distinct=True,
+    )
+    product_ids = filters.ModelMultipleChoiceFilter(
+        queryset=models.Product.objects.all().only("pk"),
+        field_name="product",
+        distinct=True,
+    )
+    state = filters.ChoiceFilter(choices=enums.ORDER_STATE_CHOICES)
+
+    def filter_by_query(self, queryset, _name, value):
+        """
+        Filter resource by looking for product title, course title | code, organization
+        title | code, owner username, email, full_name
+        """
+
+        return queryset.filter(
+            Q(course__translations__title__icontains=value)
+            | Q(course__code__icontains=value)
+            | Q(organization__translations__title__icontains=value)
+            | Q(organization__code__icontains=value)
+            | Q(product__translations__title__icontains=value)
+            | Q(owner__email__icontains=value)
+            | Q(owner__username__icontains=value)
+            | Q(owner__first_name__icontains=value)
+            | Q(owner__last_name__icontains=value)
+        ).distinct()

--- a/src/backend/joanie/core/filters/admin.py
+++ b/src/backend/joanie/core/filters/admin.py
@@ -3,6 +3,7 @@ Admin API Resource Filters
 """
 from typing import List
 
+from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone as django_timezone
 
@@ -177,9 +178,10 @@ class ContractDefinitionAdminFilterSet(filters.FilterSet):
 
     class Meta:
         model = models.ContractDefinition
-        fields: List[str] = ["query"]
+        fields: List[str] = ["query", "language"]
 
     query = filters.CharFilter(method="filter_by_query")
+    language = filters.ChoiceFilter(choices=settings.LANGUAGES)
 
     def filter_by_query(self, queryset, _name, value):
         """

--- a/src/backend/joanie/core/filters/admin.py
+++ b/src/backend/joanie/core/filters/admin.py
@@ -42,6 +42,7 @@ class ProductAdminFilterSet(filters.FilterSet):
         fields: List[str] = ["query"]
 
     query = filters.CharFilter(method="filter_by_query")
+    type = filters.ChoiceFilter(choices=enums.PRODUCT_TYPE_CHOICES)
 
     def filter_by_query(self, queryset, _name, value):
         """

--- a/src/backend/joanie/core/filters/admin.py
+++ b/src/backend/joanie/core/filters/admin.py
@@ -8,7 +8,7 @@ from django.utils import timezone as django_timezone
 
 from django_filters import rest_framework as filters
 
-from joanie.core import models
+from joanie.core import enums, models
 
 
 class OrganizationAdminFilterSet(filters.FilterSet):
@@ -153,9 +153,10 @@ class CertificateDefinitionAdminFilterSet(filters.FilterSet):
 
     class Meta:
         model = models.CertificateDefinition
-        fields: List[str] = ["query"]
+        fields: List[str] = ["query", "template"]
 
     query = filters.CharFilter(method="filter_by_query")
+    template = filters.ChoiceFilter(choices=enums.CERTIFICATE_NAME_CHOICES)
 
     def filter_by_query(self, queryset, _name, value):
         """

--- a/src/backend/joanie/tests/core/test_api_admin_course_runs.py
+++ b/src/backend/joanie/tests/core/test_api_admin_course_runs.py
@@ -2,12 +2,14 @@
 Test suite for Course run Admin API.
 """
 import random
+import uuid
 from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 
 from django.test import TestCase
 
 from joanie.core import factories, models
+from joanie.core.models import CourseRun
 from joanie.tests import format_date
 
 
@@ -113,6 +115,204 @@ class CourseRunAdminApiTest(TestCase):
         content = response.json()
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["title"], "Session 1")
+
+        # The query parameter should also search into resource_link field
+        resource_link = "https://moodle.test/session1"
+        item = factories.CourseRunFactory(resource_link=resource_link)
+        response = self.client.get("/api/v1.0/admin/course-runs/?query=moodle.test")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(content["results"][0]["resource_link"], resource_link)
+
+    def test_admin_api_course_runs_list_filter_by_course_ids(self):
+        """
+        Staff user should be able to get a paginated list of course runs filtered
+        through one or several course id
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        course_runs = factories.CourseRunFactory.create_batch(2)
+        # - Create other random course runs
+        factories.CourseRunFactory.create_batch(2)
+
+        for course_run in course_runs:
+            course = course_run.course
+            response = self.client.get(
+                f"/api/v1.0/admin/course-runs/?course_ids={course.id}"
+            )
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            content = response.json()
+            self.assertEqual(content["count"], 1)
+            self.assertEqual(content["results"][0]["id"], str(course_run.id))
+
+        # - Several course id can be passed
+        response = self.client.get(
+            f"/api/v1.0/admin/course-runs/"
+            f"?course_ids={course_runs[0].course.id}"
+            f"&course_ids={course_runs[1].course.id}"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 2)
+
+        unknown_id = uuid.uuid4()
+        response = self.client.get(
+            f"/api/v1.0/admin/course-runs/?course_ids={unknown_id}"
+        )
+        self.assertContains(
+            response,
+            f'{{"course_ids":["'
+            f"Select a valid choice. {unknown_id} is not one of the available choices."
+            f'"]}}',
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    def test_admin_api_course_runs_list_filter_by_invalid_course_ids(self):
+        """
+        Staff user should be able to get a paginated list of course runs filtered
+        through a course id and get a bad request if the course id is not a valid uuid
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        response = self.client.get("/api/v1.0/admin/course-runs/?course_ids=invalid")
+
+        self.assertContains(
+            response,
+            '{"course_ids":["“invalid” is not a valid UUID."]}',
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    def test_admin_api_course_runs_list_filter_by_organization_ids(self):
+        """
+        Staff user should be able to get a paginated list of course runs filtered
+        through one or several organization id
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        organizations = factories.OrganizationFactory.create_batch(2)
+
+        for organization in organizations:
+            factories.CourseRunFactory.create(course__organizations=[organization])
+
+        # - Create random course runs
+        factories.CourseRunFactory.create_batch(2)
+
+        for organization in organizations:
+            response = self.client.get(
+                f"/api/v1.0/admin/course-runs/?organization_ids={organization.id}"
+            )
+            course_run = CourseRun.objects.get(course__organizations__in=[organization])
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            content = response.json()
+            self.assertEqual(content["count"], 1)
+            self.assertEqual(content["results"][0]["id"], str(course_run.id))
+
+        response = self.client.get(
+            f"/api/v1.0/admin/course-runs/"
+            f"?organization_ids={organizations[0].id}"
+            f"&organization_ids={organizations[1].id}"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 2)
+
+        # Test with an organization that does not have any course
+        other_organization = factories.OrganizationFactory()
+        response = self.client.get(
+            f"/api/v1.0/admin/course-runs/?organization_ids={other_organization.id}"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+        # Test with non existing organization
+        unknown_id = uuid.uuid4()
+        response = self.client.get(
+            f"/api/v1.0/admin/course-runs/?organization_ids={unknown_id}"
+        )
+        self.assertContains(
+            response,
+            '{"organization_ids":['
+            f'"Select a valid choice. {unknown_id} is not one of the available choices."'
+            "]}",
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    def test_admin_api_course_runs_list_filter_by_invalid_organization_ids(self):
+        """
+        Staff user should be able to get a paginated list of course runs filtered
+        through an organization id and get a bad request if the organization id is not
+        a valid uuid.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        response = self.client.get(
+            "/api/v1.0/admin/course-runs/?organization_ids=invalid"
+        )
+
+        self.assertContains(
+            response,
+            '{"organization_ids":["“invalid” is not a valid UUID."]}',
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    def test_admin_api_course_runs_list_filter_by_is_gradable(self):
+        """
+        Staff user should be able to get a paginated list of course runs filtered
+        through the `is_gradable` field
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        gradable_run = factories.CourseRunFactory(is_gradable=True)
+        non_gradable_run = factories.CourseRunFactory(is_gradable=False)
+
+        response = self.client.get("/api/v1.0/admin/course-runs/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 2)
+
+        response = self.client.get("/api/v1.0/admin/course-runs/?is_gradable=true")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(content["results"][0]["id"], str(gradable_run.id))
+
+        response = self.client.get("/api/v1.0/admin/course-runs/?is_gradable=false")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(content["results"][0]["id"], str(non_gradable_run.id))
+
+    def test_admin_api_course_runs_list_filter_by_is_listed(self):
+        """
+        Staff user should be able to get a paginated list of course runs filtered
+        through the `is_listed` field
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+        listed_run = factories.CourseRunFactory(is_listed=True)
+        non_listed_run = factories.CourseRunFactory(is_listed=False)
+
+        response = self.client.get("/api/v1.0/admin/course-runs/")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 2)
+
+        response = self.client.get("/api/v1.0/admin/course-runs/?is_listed=true")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(content["results"][0]["id"], str(listed_run.id))
+
+        response = self.client.get("/api/v1.0/admin/course-runs/?is_listed=false")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(content["results"][0]["id"], str(non_listed_run.id))
 
     def test_admin_api_course_runs_get(self):
         """
@@ -255,7 +455,7 @@ class CourseRunAdminApiTest(TestCase):
         self,
     ):
         """
-        When filtering by name the query returns only relevant CourseRuns
+        When filtering by title the query returns only relevant CourseRuns
         """
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
         self.client.login(username=admin.username, password="password")
@@ -276,7 +476,7 @@ class CourseRunAdminApiTest(TestCase):
         self.assertEqual(content["count"], 1)
         self.assertEqual(content["results"][0]["id"], str(course_run.id))
         response = self.client.get(
-            f"/api/v1.0/admin/courses/{course.id}/course-runs/?query=Cour",
+            f"/api/v1.0/admin/courses/{course.id}/course-runs/?query=CourseRu",
         )
 
         self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -286,6 +286,18 @@
                 "description": "Admin Contract Definition ViewSet",
                 "parameters": [
                     {
+                        "in": "query",
+                        "name": "language",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "en-us",
+                                "fr-fr"
+                            ]
+                        },
+                        "description": "Language of the contract definition\n\n* `en-us` - English\n* `fr-fr` - French"
+                    },
+                    {
                         "name": "page",
                         "required": false,
                         "in": "query",

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -1159,6 +1159,48 @@
                 "description": "Admin CourseRun ViewSet",
                 "parameters": [
                     {
+                        "in": "query",
+                        "name": "course_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "is_gradable",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "is_listed",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
                         "name": "page",
                         "required": false,
                         "in": "query",
@@ -1179,13 +1221,6 @@
                     {
                         "in": "query",
                         "name": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "resource_link",
                         "schema": {
                             "type": "string"
                         }
@@ -1765,6 +1800,48 @@
                         "required": true
                     },
                     {
+                        "in": "query",
+                        "name": "course_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "is_gradable",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "is_listed",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
                         "name": "page",
                         "required": false,
                         "in": "query",
@@ -1785,13 +1862,6 @@
                     {
                         "in": "query",
                         "name": "query",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "in": "query",
-                        "name": "resource_link",
                         "schema": {
                             "type": "string"
                         }

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -2332,6 +2332,48 @@
                 "description": "Admin Order ViewSet",
                 "parameters": [
                     {
+                        "in": "query",
+                        "name": "course_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "organization_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "owner_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
                         "name": "page",
                         "required": false,
                         "in": "query",
@@ -2348,6 +2390,42 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "state",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "canceled",
+                                "draft",
+                                "pending",
+                                "submitted",
+                                "validated"
+                            ]
+                        },
+                        "description": "* `draft` - Draft\n* `submitted` - Submitted\n* `pending` - Pending\n* `canceled` - Canceled\n* `validated` - Validated"
                     }
                 ],
                 "tags": [

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -2908,6 +2908,19 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "certificate",
+                                "credential",
+                                "enrollment"
+                            ]
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate"
                     }
                 ],
                 "tags": [

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -1441,6 +1441,20 @@
                 "description": "Admin Course ViewSet",
                 "parameters": [
                     {
+                        "in": "query",
+                        "name": "organization_ids",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uuid"
+                            }
+                        },
+                        "description": "primary key for the record as UUID",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
                         "name": "page",
                         "required": false,
                         "in": "query",

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -35,6 +35,20 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "template",
+                        "schema": {
+                            "type": "string",
+                            "nullable": true,
+                            "title": "Template to generate pdf",
+                            "enum": [
+                                "certificate",
+                                "degree"
+                            ]
+                        },
+                        "description": "* `certificate` - Certificate\n* `degree` - Degree"
                     }
                 ],
                 "tags": [


### PR DESCRIPTION
## Purpose

We need several admin api filters.


## Proposal

- [x] CertificateDefinition.template
- [x] ContractDefinition.language
- [x] Course.organization
- [ ] ~Course.state~
- [x] CourseRun.query
- [x] CourseRun.course
- [x] CourseRun.organization
- [x] CourseRun.is_gradable
- [x] CourseRun.is_listed
- [x] Product.type
- [ ] ~Product.state~
- [x] Order.query
- [x] Order.state
- [x] Order.product
- [x] Order.course
- [x] Order.organization
- [x] Order.owner

`Product.state` and `Course.state` filters are not included in this PR. Indeed, we cannot filter those fields through a simple queryset.filter and without heavy db accesses.
