### PR TITLE
🐛(backend) fix backend moodle create_user

### DIFF
--- a/src/backend/joanie/lms_handler/backends/moodle.py
+++ b/src/backend/joanie/lms_handler/backends/moodle.py
@@ -123,7 +123,7 @@ class MoodleLMSBackend(BaseLMSBackend):
             "auth": settings.MOODLE_AUTH_METHOD,
         }
         try:
-            return self.moodle("core_user_create_users", users=[user_data])
+            return self.moodle("core_user_create_users", users=[user_data])[0]
         except EmptyResponseException as e:
             logger.error("Moodle error while creating user %s: %s", user.username, e)
             raise MoodleUserCreateException() from e
@@ -141,8 +141,8 @@ class MoodleLMSBackend(BaseLMSBackend):
         except MoodleUserException as e:
             if not enrollment.is_active:
                 raise EnrollmentError() from e
-            user_created_response = self.create_user(enrollment.user)
-            user_id = user_created_response.get("id")
+            user_created = self.create_user(enrollment.user)
+            user_id = user_created.get("id")
 
         course_id = self.extract_course_id(enrollment.course_run.resource_link)
         moodle_enrollment = {

--- a/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
+++ b/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
@@ -381,7 +381,7 @@ class MoodleLMSBackendTestCase(TestCase):
                 )
             ],
             status=HTTPStatus.OK,
-            json={"id": 5, "username": user.username},
+            json=[{"id": 5, "username": user.username}],
         )
 
         result = self.backend.create_user(user)
@@ -644,7 +644,7 @@ class MoodleLMSBackendTestCase(TestCase):
                 )
             ],
             status=HTTPStatus.OK,
-            json={"id": 5, "username": user.username},
+            json=[{"id": 5, "username": user.username}],
         )
 
         responses.add(


### PR DESCRIPTION
## Purpose

The moodle webservice to create users return a list of new users as response. Our current implementation access the response as a dict so an AttributeError is raised when the backend tries to create a user on the fly during an enrollment.


## Proposal

- [x] Fix moodle `create_user` method
