### PR TITLE
✨(backend) allow to filter course product relation by product type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Filter course product relation client api endpoint by product type
 - Link Organization to Address Model
 - New properties on Organization model to complete contract definition context
 - Allow to bulk sign contracts by training

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -83,6 +83,7 @@ class CourseProductRelationViewSet(
     lookup_url_kwarg = "pk_or_product_id"
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = serializers.CourseProductRelationSerializer
+    filterset_class = filters.CourseProductRelationViewSetFilter
     ordering = ["-created_on"]
     queryset = (
         models.CourseProductRelation.objects.filter(

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -193,3 +193,23 @@ class NestedOrderCourseViewSetFilter(filters.FilterSet):
                 "pk", flat=True
             ),
         )
+
+
+class CourseProductRelationViewSetFilter(filters.FilterSet):
+    """
+    Filter course product relations by product type.
+    """
+
+    product_type = filters.MultipleChoiceFilter(
+        field_name="product__type",
+        choices=enums.PRODUCT_TYPE_CHOICES,
+    )
+    product_type_exclude = filters.MultipleChoiceFilter(
+        field_name="product__type",
+        choices=enums.PRODUCT_TYPE_CHOICES,
+        exclude=True,
+    )
+
+    class Meta:
+        model = models.CourseProductRelation
+        fields: List[str] = []

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -748,6 +748,42 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_type",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "certificate",
+                                    "credential",
+                                    "enrollment"
+                                ]
+                            }
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_type_exclude",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "certificate",
+                                    "credential",
+                                    "enrollment"
+                                ]
+                            }
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
+                        "explode": true,
+                        "style": "form"
                     }
                 ],
                 "tags": [
@@ -1666,6 +1702,42 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_type",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "certificate",
+                                    "credential",
+                                    "enrollment"
+                                ]
+                            }
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_type_exclude",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "certificate",
+                                    "credential",
+                                    "enrollment"
+                                ]
+                            }
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
+                        "explode": true,
+                        "style": "form"
                     }
                 ],
                 "tags": [
@@ -3397,6 +3469,42 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_type",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "certificate",
+                                    "credential",
+                                    "enrollment"
+                                ]
+                            }
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "product_type_exclude",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "certificate",
+                                    "credential",
+                                    "enrollment"
+                                ]
+                            }
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
+                        "explode": true,
+                        "style": "form"
                     }
                 ],
                 "tags": [


### PR DESCRIPTION
## Purpose

API consumer needs to filter course product relation by product type. So we add two filter to filter out either by product type or by excluded product type.

https://github.com/openfun/richie/pull/2272

## Proposal

- [x] Filter `CourseProductRelationViewset` by `product__type`
