### PR TITLE
🚑(backend) fix get_zip_archive api endpoint

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -1169,7 +1169,7 @@ class ContractViewSet(GenericContractViewSet):
 
         if request.method == "GET":
             return FileResponse(
-                storage.open(f"{storage.location}/{zip_archive_name}", mode="rb"),
+                storage.open(zip_archive_name, mode="rb"),
                 as_attachment=True,
                 filename=zip_archive_name,
                 content_type="application/zip",


### PR DESCRIPTION
## Purpose

Currently the get_zip_archive returns 500 error as the path to open the contract is wrong. Indeed the storage location should not be used to build the archive path to open.

https://gip-fun-mooc.sentry.io/issues/4947129619/?environment=preproduction&project=6599941&query=is:unresolved&statsPeriod=30d&stream_index=3

## Proposal

- [x] Fix `get_zip_archive` endpoint
