### PR TITLE
:sparkles: (backend) Add new properties of Organization for serializer client API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add address and new properties on client OrganizationSerializer
 - Add admin endpoints to create/update/delete organization addresses
 - Add several admin api endpoint filters
 - Filter course product relation client api endpoint by product type

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_contract.py
@@ -77,6 +77,9 @@ class OrganizationContractApiTest(BaseAPITestCase):
         can query organization's contracts.
         """
         organizations = factories.OrganizationFactory.create_batch(2)
+        address_organization = factories.OrganizationAddressFactory(
+            organization=organizations[0], is_main=True, is_reusable=True
+        )
         user = factories.UserFactory()
         token = self.generate_token_from_user(user)
 
@@ -109,7 +112,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
         factories.ContractFactory(order__owner=user)
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(14):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organizations[0].id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -165,6 +168,34 @@ class OrganizationContractApiTest(BaseAPITestCase):
                             "code": contract.order.organization.code,
                             "logo": "_this_field_is_mocked",
                             "title": contract.order.organization.title,
+                            "address": {
+                                "id": str(address_organization.id),
+                                "address": address_organization.address,
+                                "city": address_organization.city,
+                                "country": address_organization.country,
+                                "first_name": address_organization.first_name,
+                                "is_main": address_organization.is_main,
+                                "last_name": address_organization.last_name,
+                                "postcode": address_organization.postcode,
+                                "title": address_organization.title,
+                            },
+                            "enterprise_code": contract.order.organization.enterprise_code,
+                            "activity_category_code": (
+                                contract.order.organization.activity_category_code
+                            ),
+                            "representative": contract.order.organization.representative,
+                            "representative_profession": (
+                                contract.order.organization.representative_profession
+                            ),
+                            "signatory_representative": (
+                                contract.order.organization.signatory_representative
+                            ),
+                            "signatory_representative_profession": (
+                                contract.order.organization.signatory_representative_profession
+                            ),
+                            "contact_email": contract.order.organization.contact_email,
+                            "contact_phone": contract.order.organization.contact_phone,
+                            "dpo_email": contract.order.organization.dpo_email,
                         },
                         "owner_name": contract.order.owner.username,
                         "product_title": contract.order.product.title,
@@ -224,7 +255,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 6 contracts
-        with self.assertNumQueries(57):
+        with self.assertNumQueries(66):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -235,7 +266,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 9)
 
         # - Filter by state=unsigned should return 5 contracts
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(14):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{str(organization.id)}"
@@ -254,7 +285,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=half_signed should return 3 contracts
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(10):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{str(organization.id)}"
@@ -273,7 +304,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=signed should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/organizations/{str(organization.id)}/contracts/?signature_state=signed",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -350,7 +381,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 8 contracts
-        with self.assertNumQueries(78):
+        with self.assertNumQueries(86):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -361,7 +392,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 8)
 
         # - Filter by the first relation should return 5 contracts
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(15):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/contracts/"
                 f"?course_product_relation_id={relation_1.id}",
@@ -378,7 +409,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by the second relation should return 3 contracts
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(11):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/contracts/"
                 f"?course_product_relation_id={relation_2.id}",
@@ -458,6 +489,9 @@ class OrganizationContractApiTest(BaseAPITestCase):
         can query an organization's contract.
         """
         organizations = factories.OrganizationFactory.create_batch(2)
+        address = factories.OrganizationAddressFactory(
+            organization=organizations[0], is_main=True, is_reusable=True
+        )
         user = factories.UserFactory()
         token = self.generate_token_from_user(user)
 
@@ -482,7 +516,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organizations[0]
         ).first()
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{str(organizations[0].id)}"
@@ -530,6 +564,34 @@ class OrganizationContractApiTest(BaseAPITestCase):
                     "code": contract.order.organization.code,
                     "logo": "_this_field_is_mocked",
                     "title": contract.order.organization.title,
+                    "address": {
+                        "id": str(address.id),
+                        "address": address.address,
+                        "city": address.city,
+                        "postcode": address.postcode,
+                        "country": address.country,
+                        "first_name": address.first_name,
+                        "last_name": address.last_name,
+                        "title": address.title,
+                        "is_main": True,
+                    },
+                    "enterprise_code": contract.order.organization.enterprise_code,
+                    "activity_category_code": (
+                        contract.order.organization.activity_category_code
+                    ),
+                    "representative": contract.order.organization.representative,
+                    "representative_profession": (
+                        contract.order.organization.representative_profession
+                    ),
+                    "signatory_representative": (
+                        contract.order.organization.signatory_representative
+                    ),
+                    "signatory_representative_profession": (
+                        contract.order.organization.signatory_representative_profession
+                    ),
+                    "contact_email": contract.order.organization.contact_email,
+                    "contact_phone": contract.order.organization.contact_phone,
+                    "dpo_email": contract.order.organization.dpo_email,
                 },
                 "owner_name": contract.order.owner.username,
                 "product_title": contract.order.product.title,
@@ -608,7 +670,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(48):
+        with self.assertNumQueries(49):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organization.code}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_course_product_relations.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_course_product_relations.py
@@ -55,7 +55,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                     course=course, product=product, organizations=[organizations[0]]
                 )
             )
-        with self.assertNumQueries(150):
+        with self.assertNumQueries(155):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -151,7 +151,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                     course=course, product=product, organizations=[organizations[0]]
                 )
             )
-        with self.assertNumQueries(49):
+        with self.assertNumQueries(50):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/"

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_courses.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_courses.py
@@ -61,7 +61,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         )
 
         # Retrieve all courses from org with access
-        with self.assertNumQueries(98):
+        with self.assertNumQueries(101):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/courses/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -153,7 +153,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         factories.UserOrganizationAccessFactory(
             organization=organizations[0], user=user
         )
-        with self.assertNumQueries(51):
+        with self.assertNumQueries(52):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/courses/{courses[0].id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -237,7 +237,7 @@ class OrganizationCourseApiTest(BaseAPITestCase):
         )
 
         # Retrieve all courses from org with listed course runs
-        with self.assertNumQueries(52):
+        with self.assertNumQueries(53):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{organizations[0].id}"

--- a/src/backend/joanie/tests/core/api/organizations/test_list.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_list.py
@@ -41,7 +41,7 @@ class OrganizationApiListTest(BaseAPITestCase):
             user=user, organization=organizations[1]
         )
 
-        with self.assertNumQueries(47):
+        with self.assertNumQueries(49):
             response = self.client.get(
                 "/api/v1.0/organizations/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -65,6 +65,9 @@ class OrganizationApiListTest(BaseAPITestCase):
 
         factories.OrganizationFactory()
         organization = factories.OrganizationFactory()
+        address_organization = factories.OrganizationAddressFactory(
+            organization=organization, is_main=True, is_reusable=True
+        )
         factories.UserOrganizationAccessFactory(user=user, organization=organization)
 
         with mock.patch.object(
@@ -105,6 +108,32 @@ class OrganizationApiListTest(BaseAPITestCase):
                             "size": organization.logo.size,
                         },
                         "title": organization.title,
+                        "address": {
+                            "id": str(address_organization.id),
+                            "address": address_organization.address,
+                            "city": address_organization.city,
+                            "postcode": address_organization.postcode,
+                            "country": address_organization.country,
+                            "first_name": address_organization.first_name,
+                            "last_name": address_organization.last_name,
+                            "title": address_organization.title,
+                            "is_main": True,
+                        },
+                        "enterprise_code": organization.enterprise_code,
+                        "activity_category_code": (organization.activity_category_code),
+                        "representative": organization.representative,
+                        "representative_profession": (
+                            organization.representative_profession
+                        ),
+                        "signatory_representative": (
+                            organization.signatory_representative
+                        ),
+                        "signatory_representative_profession": (
+                            organization.signatory_representative_profession
+                        ),
+                        "contact_email": organization.contact_email,
+                        "contact_phone": organization.contact_phone,
+                        "dpo_email": organization.dpo_email,
                     }
                 ],
             },

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -59,7 +59,7 @@ class CertificateApiTest(BaseAPITestCase):
 
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(4):
             response = self.client.get(
                 "/api/v1.0/certificates/", HTTP_AUTHORIZATION=f"Bearer {token}"
             )
@@ -128,6 +128,24 @@ class CertificateApiTest(BaseAPITestCase):
                                 "code": other_order.organization.code,
                                 "logo": "_this_field_is_mocked",
                                 "title": other_order.organization.title,
+                                "address": None,
+                                "enterprise_code": other_order.organization.enterprise_code,
+                                "activity_category_code": (
+                                    other_order.organization.activity_category_code
+                                ),
+                                "representative": other_order.organization.representative,
+                                "representative_profession": (
+                                    other_order.organization.representative_profession
+                                ),
+                                "signatory_representative": (
+                                    other_order.organization.signatory_representative
+                                ),
+                                "signatory_representative_profession": (
+                                    other_order.organization.signatory_representative_profession
+                                ),
+                                "contact_email": other_order.organization.contact_email,
+                                "contact_phone": other_order.organization.contact_phone,
+                                "dpo_email": other_order.organization.dpo_email,
                             },
                             "owner_name": other_certificate.order.owner.username,
                             "product_title": other_certificate.order.product.title,
@@ -155,6 +173,24 @@ class CertificateApiTest(BaseAPITestCase):
                                 "code": order.organization.code,
                                 "logo": "_this_field_is_mocked",
                                 "title": order.organization.title,
+                                "address": None,
+                                "enterprise_code": order.organization.enterprise_code,
+                                "activity_category_code": (
+                                    order.organization.activity_category_code
+                                ),
+                                "representative": order.organization.representative,
+                                "representative_profession": (
+                                    order.organization.representative_profession
+                                ),
+                                "signatory_representative": (
+                                    order.organization.signatory_representative
+                                ),
+                                "signatory_representative_profession": (
+                                    order.organization.signatory_representative_profession
+                                ),
+                                "contact_email": order.organization.contact_email,
+                                "contact_phone": order.organization.contact_phone,
+                                "dpo_email": order.organization.dpo_email,
                             },
                             "owner_name": certificate.order.owner.username,
                             "product_title": certificate.order.product.title,
@@ -241,7 +277,9 @@ class CertificateApiTest(BaseAPITestCase):
         user = factories.UserFactory()
         order = factories.OrderFactory(owner=user, product=factories.ProductFactory())
         certificate = factories.OrderCertificateFactory(order=order)
-
+        address_organization = factories.OrganizationAddressFactory(
+            organization=certificate.order.organization, is_main=True, is_reusable=True
+        )
         token = self.generate_token_from_user(user)
 
         # - Try to retrieve a not owned certificate should return a 404
@@ -285,6 +323,34 @@ class CertificateApiTest(BaseAPITestCase):
                         "code": certificate.order.organization.code,
                         "logo": "_this_field_is_mocked",
                         "title": certificate.order.organization.title,
+                        "address": {
+                            "id": str(address_organization.id),
+                            "address": address_organization.address,
+                            "city": address_organization.city,
+                            "postcode": address_organization.postcode,
+                            "country": address_organization.country,
+                            "first_name": address_organization.first_name,
+                            "last_name": address_organization.last_name,
+                            "title": address_organization.title,
+                            "is_main": address_organization.is_main,
+                        },
+                        "enterprise_code": certificate.order.organization.enterprise_code,
+                        "activity_category_code": (
+                            certificate.order.organization.activity_category_code
+                        ),
+                        "representative": certificate.order.organization.representative,
+                        "representative_profession": (
+                            certificate.order.organization.representative_profession
+                        ),
+                        "signatory_representative": (
+                            certificate.order.organization.signatory_representative
+                        ),
+                        "signatory_representative_profession": (
+                            certificate.order.organization.signatory_representative_profession
+                        ),
+                        "contact_email": certificate.order.organization.contact_email,
+                        "contact_phone": certificate.order.organization.contact_phone,
+                        "dpo_email": certificate.order.organization.dpo_email,
                     },
                     "owner_name": certificate.order.owner.username,
                     "product_title": certificate.order.product.title,

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -102,7 +102,7 @@ class ContractApiTest(BaseAPITestCase):
         # - Create random contracts that should not be returned
         factories.ContractFactory.create_batch(5)
 
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(14):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -154,6 +154,24 @@ class ContractApiTest(BaseAPITestCase):
                             "code": contract.order.organization.code,
                             "logo": "_this_field_is_mocked",
                             "title": contract.order.organization.title,
+                            "address": None,
+                            "enterprise_code": contract.order.organization.enterprise_code,
+                            "activity_category_code": (
+                                contract.order.organization.activity_category_code
+                            ),
+                            "representative": contract.order.organization.representative,
+                            "representative_profession": (
+                                contract.order.organization.representative_profession
+                            ),
+                            "signatory_representative": (
+                                contract.order.organization.signatory_representative
+                            ),
+                            "signatory_representative_profession": (
+                                contract.order.organization.signatory_representative_profession
+                            ),
+                            "contact_email": contract.order.organization.contact_email,
+                            "contact_phone": contract.order.organization.contact_phone,
+                            "dpo_email": contract.order.organization.dpo_email,
                         },
                         "owner_name": contract.order.owner.username,
                         "product_title": contract.order.product.title,
@@ -196,7 +214,7 @@ class ContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
 
         # - List without filter should return 9 contracts
-        with self.assertNumQueries(409):
+        with self.assertNumQueries(418):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -207,7 +225,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 9)
 
         # - Filter by state=unsigned should return 5 contracts
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(14):
             response = self.client.get(
                 "/api/v1.0/contracts/?signature_state=unsigned",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -223,7 +241,7 @@ class ContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=half_signed should return 3 contracts
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(10):
             response = self.client.get(
                 "/api/v1.0/contracts/?signature_state=half_signed",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -239,7 +257,7 @@ class ContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=signed should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 "/api/v1.0/contracts/?signature_state=signed",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -307,7 +325,7 @@ class ContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
 
         # - List without filter should return 2 contracts
-        with self.assertNumQueries(94):
+        with self.assertNumQueries(96):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -318,7 +336,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 2)
 
         # - Filter by org1 should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/contracts/?organization_id={str(org1.id)}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -332,7 +350,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertCountEqual(result_ids, [str(org1_contract.id)])
 
         # - Filter by org2 should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/contracts/?organization_id={str(org2.id)}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -378,7 +396,7 @@ class ContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
 
         # - List without filter should return 2 contracts
-        with self.assertNumQueries(94):
+        with self.assertNumQueries(96):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -389,7 +407,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 2)
 
         # - Filter by c1 should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/contracts/?course_id={str(c1.id)}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -403,7 +421,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertCountEqual(result_ids, [str(c1_contract.id)])
 
         # - Filter by c2 should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/contracts/?course_id={str(c2.id)}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -445,7 +463,7 @@ class ContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
 
         # - List without filter should return 2 contracts
-        with self.assertNumQueries(94):
+        with self.assertNumQueries(96):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -456,7 +474,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 2)
 
         # - Filter by c1 should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/contracts/?product_id={str(p1.id)}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -470,7 +488,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertCountEqual(result_ids, [str(p1_contract.id)])
 
         # - Filter by c2 should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/contracts/?product_id={str(p2.id)}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -527,7 +545,7 @@ class ContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(8)
 
         # - List without filter should return 8 contracts
-        with self.assertNumQueries(94):
+        with self.assertNumQueries(96):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -539,7 +557,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 2)
 
         # - Filter by the first relation should return 5 contracts
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(
                 f"/api/v1.0/contracts/?course_product_relation_id={relation_1.id}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -553,7 +571,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertCountEqual(result_ids, [str(contract_1.id)])
 
         # - Filter by the second relation should return 3 contracts
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(
                 f"/api/v1.0/contracts/?course_product_relation_id={relation_2.id}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -606,7 +624,7 @@ class ContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
 
         # - List without filter should return 5 contracts
-        with self.assertNumQueries(229):
+        with self.assertNumQueries(234):
             response = self.client.get(
                 "/api/v1.0/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -617,7 +635,7 @@ class ContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 5)
 
         # - List by filter id should return only contracts with those ids
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(10):
             response = self.client.get(
                 f"/api/v1.0/contracts/?id={contracts[0].id}&id={contracts[3].id}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -712,7 +730,7 @@ class ContractApiTest(BaseAPITestCase):
             order__owner=user, organization_signatory=organization_signatory
         )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             response = self.client.get(
                 f"/api/v1.0/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -771,6 +789,24 @@ class ContractApiTest(BaseAPITestCase):
                     "code": contract.order.organization.code,
                     "logo": "_this_field_is_mocked",
                     "title": contract.order.organization.title,
+                    "address": None,
+                    "enterprise_code": contract.order.organization.enterprise_code,
+                    "activity_category_code": (
+                        contract.order.organization.activity_category_code
+                    ),
+                    "representative": contract.order.organization.representative,
+                    "representative_profession": (
+                        contract.order.organization.representative_profession
+                    ),
+                    "signatory_representative": (
+                        contract.order.organization.signatory_representative
+                    ),
+                    "signatory_representative_profession": (
+                        contract.order.organization.signatory_representative_profession
+                    ),
+                    "contact_email": contract.order.organization.contact_email,
+                    "contact_phone": contract.order.organization.contact_phone,
+                    "dpo_email": contract.order.organization.dpo_email,
                 },
                 "owner_name": contract.order.owner.username,
                 "product_title": contract.order.product.title,

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -217,6 +217,22 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                         "id": str(organization.id),
                         "logo": "_this_field_is_mocked",
                         "title": organization.title,
+                        "address": None,
+                        "enterprise_code": organization.enterprise_code,
+                        "activity_category_code": (organization.activity_category_code),
+                        "representative": organization.representative,
+                        "representative_profession": (
+                            organization.representative_profession
+                        ),
+                        "signatory_representative": (
+                            organization.signatory_representative
+                        ),
+                        "signatory_representative_profession": (
+                            organization.signatory_representative_profession
+                        ),
+                        "contact_email": organization.contact_email,
+                        "contact_phone": organization.contact_phone,
+                        "dpo_email": organization.dpo_email,
                     }
                     for organization in relation.organizations.all()
                 ],
@@ -486,7 +502,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             organizations=factories.OrganizationFactory.create_batch(2),
         )
 
-        with self.assertNumQueries(75):
+        with self.assertNumQueries(77):
             self.client.get(f"/api/v1.0/courses/{course.code}/products/{product.id}/")
 
         # A second call to the url should benefit from caching on the product serializer
@@ -511,7 +527,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
         # Then cache should be language sensitive
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(18):
             self.client.get(
                 f"/api/v1.0/courses/{course.code}/products/{product.id}/",
                 HTTP_ACCEPT_LANGUAGE="fr-fr",
@@ -613,7 +629,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         )
         factories.UserCourseAccessFactory(user=user, course=course)
 
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             self.client.get(
                 f"/api/v1.0/course-product-relations/{relation.id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -726,6 +742,22 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                         "id": str(organization.id),
                         "logo": "_this_field_is_mocked",
                         "title": organization.title,
+                        "address": None,
+                        "enterprise_code": organization.enterprise_code,
+                        "activity_category_code": (organization.activity_category_code),
+                        "representative": organization.representative,
+                        "representative_profession": (
+                            organization.representative_profession
+                        ),
+                        "signatory_representative": (
+                            organization.signatory_representative
+                        ),
+                        "signatory_representative_profession": (
+                            organization.signatory_representative_profession
+                        ),
+                        "contact_email": organization.contact_email,
+                        "contact_phone": organization.contact_phone,
+                        "dpo_email": organization.dpo_email,
                     }
                     for organization in relation.organizations.all()
                 ],
@@ -759,7 +791,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 course=course, product=product, order_group=order_group1, state=state
             )
 
-        with self.assertNumQueries(51):
+        with self.assertNumQueries(52):
             self.client.get(
                 f"/api/v1.0/course-product-relations/{relation.id}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_courses_contract.py
+++ b/src/backend/joanie/tests/core/test_api_courses_contract.py
@@ -109,7 +109,7 @@ class CourseContractApiTest(BaseAPITestCase):
         factories.ContractFactory.create_batch(5)
         factories.ContractFactory(order__owner=user)
 
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(24):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(courses[0].id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -165,6 +165,24 @@ class CourseContractApiTest(BaseAPITestCase):
                             "code": contract.order.organization.code,
                             "logo": "_this_field_is_mocked",
                             "title": contract.order.organization.title,
+                            "address": None,
+                            "enterprise_code": contract.order.organization.enterprise_code,
+                            "activity_category_code": (
+                                contract.order.organization.activity_category_code
+                            ),
+                            "representative": contract.order.organization.representative,
+                            "representative_profession": (
+                                contract.order.organization.representative_profession
+                            ),
+                            "signatory_representative": (
+                                contract.order.organization.signatory_representative
+                            ),
+                            "signatory_representative_profession": (
+                                contract.order.organization.signatory_representative_profession
+                            ),
+                            "contact_email": contract.order.organization.contact_email,
+                            "contact_phone": contract.order.organization.contact_phone,
+                            "dpo_email": contract.order.organization.dpo_email,
                         },
                         "owner_name": contract.order.owner.username,
                         "product_title": contract.order.product.title,
@@ -221,7 +239,7 @@ class CourseContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 9 contracts
-        with self.assertNumQueries(57):
+        with self.assertNumQueries(66):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -232,7 +250,7 @@ class CourseContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 9)
 
         # - Filter by state=unsigned should return 5 contracts
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(14):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/?signature_state=unsigned",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -248,7 +266,7 @@ class CourseContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=half_signed should return 3 contracts
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(10):
             response = self.client.get(
                 (
                     f"/api/v1.0/courses/{str(relation.course.id)}"
@@ -267,7 +285,7 @@ class CourseContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by state=signed should return 1 contract
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(relation.course.id)}/contracts/?signature_state=signed",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -341,7 +359,7 @@ class CourseContractApiTest(BaseAPITestCase):
         factories.ContractFactory(order__owner=user)
 
         # - List without filter should return 8 contracts
-        with self.assertNumQueries(56):
+        with self.assertNumQueries(64):
             response = self.client.get(
                 f"/api/v1.0/courses/{course.id}/contracts/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -352,7 +370,7 @@ class CourseContractApiTest(BaseAPITestCase):
         self.assertEqual(content["count"], 8)
 
         # - Filter by the first relation should return 5 contracts
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(15):
             response = self.client.get(
                 f"/api/v1.0/courses/{course.id}/contracts/"
                 f"?course_product_relation_id={relation_1.id}",
@@ -369,7 +387,7 @@ class CourseContractApiTest(BaseAPITestCase):
         )
 
         # - Filter by the second relation should return 3 contracts
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(11):
             response = self.client.get(
                 f"/api/v1.0/courses/{course.id}/contracts/"
                 f"?course_product_relation_id={relation_2.id}",
@@ -480,7 +498,7 @@ class CourseContractApiTest(BaseAPITestCase):
 
         contract = models.Contract.objects.filter(order__course=courses[0]).first()
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             response = self.client.get(
                 f"/api/v1.0/courses/{str(courses[0].id)}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -525,6 +543,24 @@ class CourseContractApiTest(BaseAPITestCase):
                     "code": contract.order.organization.code,
                     "logo": "_this_field_is_mocked",
                     "title": contract.order.organization.title,
+                    "address": None,
+                    "enterprise_code": contract.order.organization.enterprise_code,
+                    "activity_category_code": (
+                        contract.order.organization.activity_category_code
+                    ),
+                    "representative": contract.order.organization.representative,
+                    "representative_profession": (
+                        contract.order.organization.representative_profession
+                    ),
+                    "signatory_representative": (
+                        contract.order.organization.signatory_representative
+                    ),
+                    "signatory_representative_profession": (
+                        contract.order.organization.signatory_representative_profession
+                    ),
+                    "contact_email": contract.order.organization.contact_email,
+                    "contact_phone": contract.order.organization.contact_phone,
+                    "dpo_email": contract.order.organization.dpo_email,
                 },
                 "owner_name": contract.order.owner.username,
                 "product_title": contract.order.product.title,
@@ -591,7 +627,7 @@ class CourseContractApiTest(BaseAPITestCase):
             order__organization=organization,
         )
 
-        with self.assertNumQueries(48):
+        with self.assertNumQueries(49):
             response = self.client.get(
                 f"/api/v1.0/courses/{relation.course.code}/contracts/{str(contract.id)}/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",

--- a/src/backend/joanie/tests/core/test_api_courses_order.py
+++ b/src/backend/joanie/tests/core/test_api_courses_order.py
@@ -293,7 +293,7 @@ class NestedOrderCourseViewSetAPITest(BaseAPITestCase):
         )
         token = self.get_user_token(user.username)
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(25):
             response = self.client.get(
                 f"/api/v1.0/courses/{relation_1.course.id}/orders/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -340,7 +340,7 @@ class NestedOrderCourseViewSetAPITest(BaseAPITestCase):
         ]
         token = self.get_user_token(user.username)
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(25):
             response = self.client.get(
                 f"/api/v1.0/courses/{relation.course.id}/orders/"
                 f"?organization_id={organizations[1].id}",
@@ -448,7 +448,7 @@ class NestedOrderCourseViewSetAPITest(BaseAPITestCase):
         )
         token = self.get_user_token(user.username)
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(26):
             response = self.client.get(
                 f"/api/v1.0/courses/{courses[0].id}/orders/"
                 f"?product_id={product.id}",
@@ -468,7 +468,7 @@ class NestedOrderCourseViewSetAPITest(BaseAPITestCase):
             response.json()["results"][1]["owner"]["id"], str(user_learners[0].id)
         )
 
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             response = self.client.get(
                 f"/api/v1.0/courses/{courses[1].id}/orders/"
                 f"?product_id={product.id}",
@@ -535,7 +535,7 @@ class NestedOrderCourseViewSetAPITest(BaseAPITestCase):
         )
         token = self.get_user_token(user.username)
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(26):
             response = self.client.get(
                 f"/api/v1.0/courses/{courses[0].id}/orders/"
                 f"?organization_id={organizations[0].id}&product_id={product.id}",
@@ -557,7 +557,7 @@ class NestedOrderCourseViewSetAPITest(BaseAPITestCase):
             str(organizations[0].id),
         )
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(25):
             response = self.client.get(
                 f"/api/v1.0/courses/{courses[1].id}/orders/"
                 f"?organization_id={organizations[1].id}&product_id={product.id}",

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -5596,16 +5596,85 @@
                     },
                     "logo": {
                         "type": "string",
-                        "format": "uri"
+                        "format": "uri",
+                        "nullable": true
                     },
                     "title": {
                         "type": "string",
                         "readOnly": true
+                    },
+                    "address": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Address"
+                            }
+                        ],
+                        "readOnly": true,
+                        "nullable": true
+                    },
+                    "enterprise_code": {
+                        "type": "string",
+                        "readOnly": true,
+                        "nullable": true
+                    },
+                    "activity_category_code": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "representative": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "representative fullname (to sign certificate for example)"
+                    },
+                    "representative_profession": {
+                        "type": "string",
+                        "readOnly": true,
+                        "nullable": true,
+                        "title": "Profession of the organization's representative",
+                        "description": "representative profession"
+                    },
+                    "signatory_representative": {
+                        "type": "string",
+                        "readOnly": true,
+                        "nullable": true,
+                        "description": "This field is optional. If it is set, you must set the field'signatory_representative_profession' as well"
+                    },
+                    "signatory_representative_profession": {
+                        "type": "string",
+                        "readOnly": true,
+                        "nullable": true,
+                        "title": "Profession of the signatory representative",
+                        "description": "signatory representative profession"
+                    },
+                    "contact_phone": {
+                        "type": "string",
+                        "readOnly": true,
+                        "title": "Contact phone number"
+                    },
+                    "contact_email": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "dpo_email": {
+                        "type": "string",
+                        "readOnly": true,
+                        "title": "Data protection officer email"
                     }
                 },
                 "required": [
+                    "activity_category_code",
+                    "address",
                     "code",
+                    "contact_email",
+                    "contact_phone",
+                    "dpo_email",
+                    "enterprise_code",
                     "id",
+                    "logo",
+                    "representative",
+                    "representative_profession",
+                    "signatory_representative",
+                    "signatory_representative_profession",
                     "title"
                 ]
             },
@@ -5665,9 +5734,13 @@
                 "properties": {
                     "logo": {
                         "type": "string",
-                        "format": "binary"
+                        "format": "binary",
+                        "nullable": true
                     }
-                }
+                },
+                "required": [
+                    "logo"
+                ]
             },
             "PaginatedAddressList": {
                 "type": "object",


### PR DESCRIPTION
## Purpose

Since we've added more properties on the Organization Model, we need to add them for the client API as well.
So far, we have added for the admin and the backoffice the management of these new properties.

## Proposal

Add the address field into the serializer of the OrganizationSerializer (client).
Add the other properties that are the direct attributes of the Organization model into the serializer's fields.

- [x] Update `OrganizationSerializer` serializer with address field 
- [x] make the address attribute a serializer method field in order to only show the main address of an Organization
- [x] add the other properties of the organization model into the fields of the OrganizationSerializer (client.py) that are required for the generation of the contract definition context.
- [x] update every failing tests, and add some tests showing the new fields available through the serializer, and update existing tests by adding an address to the organization that figures into the response asserts.
