### PR TITLE
👔(backend) bind course organizations to certificate context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ## Added
 
-- Add `join_and` template tags
+- Add `join_and` and `list_key` template tags
 - Add address and new properties on client OrganizationSerializer
 - Add admin endpoints to create/update/delete organization addresses
 - Add several admin api endpoint filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to
 
 ### Changed
 
+- Bind organization course author into certificate context
+  instead of organization order
 - Prevent to create an order with course run that has ended
 - Debug view for Certificate, Degree, Contract Definition and Invoice
 - Internalize invoice template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add `join_and` template tags
 - Add address and new properties on client OrganizationSerializer
 - Add admin endpoints to create/update/delete organization addresses
 - Add several admin api endpoint filters

--- a/src/backend/joanie/core/templates/issuers/certificate.css
+++ b/src/backend/joanie/core/templates/issuers/certificate.css
@@ -60,8 +60,24 @@ sup {
 }
 
 .header__logos img {
-  height: 28mm;
+  height: 24mm;
   width: auto;
+}
+
+.header__logos-organizations {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  flex: 1;
+  margin: -2mm -2mm -2mm 5mm;
+}
+
+.header__logos-organizations img {
+  height: 28mm;
+  object-position: center;
+  object-fit: contain;
+  width: 28mm;
+  padding: 2mm;
 }
 
 .header__title {

--- a/src/backend/joanie/core/templates/issuers/certificate.html
+++ b/src/backend/joanie/core/templates/issuers/certificate.html
@@ -15,7 +15,11 @@
         <header class="header">
             <div class="header__logos">
                 <img src="{% base64_static "joanie/images/logo_fun.png" %}" />
-                <img src="{{ organization.logo }}" />
+                <div class="header__logos-organizations">
+                    {% for organization in organizations %}
+                        <img src="{{ organization.logo }}" />
+                    {% endfor %}
+                </div>
             </div>
             <h1 class="header__title">{% translate "Attestation of achievement" %}</h1>
         </header>
@@ -23,11 +27,11 @@
             <div class="content">
                 <section class="details">
                     <p>
-                    {% blocktranslate trimmed with student=student.name course=course.name organization=organization.name site=site.name %}
+                    {% blocktranslate trimmed with student=student.name course=course.name organizations=organizations|list_key:'name'|join_and site=site.name %}
                     <strong class="details__student-name">{{ student }}</strong>
                     <br/>has successfully completed the MOOC<sup>*</sup>
                     <br/><strong class="details__course-name">{{ course }}</strong>
-                    <br/>proposed by <strong>{{ organization }}</strong>
+                    <br/>proposed by <strong>{{ organizations }}</strong>
                     <br />and published on the platform <strong>{{ site }}</strong>
                     {% endblocktranslate %}
                     </p>

--- a/src/backend/joanie/core/templates/issuers/degree.html
+++ b/src/backend/joanie/core/templates/issuers/degree.html
@@ -2,6 +2,11 @@
 {% load static %}
 {% load extra_tags %}
 
+{% comment %}
+This template is used for FUN use case. It assumes that there is only one organization
+which is the course provider. So the organization is accessed with organizations.0.
+{% endcomment %}
+
 <html>
 {% if debug %}
 <head>
@@ -18,7 +23,7 @@
                 <img src="{% base64_static "joanie/images/logo_fun.png" %}" />
             </div>
             <div class="organization">
-                <img src="{{ organization.logo }}" />
+                <img src="{{ organizations.0.logo }}" />
             </div>
         </div>
         <div class="title">
@@ -28,7 +33,7 @@
     <article class="main">
         <section id="representative">
             <p>
-                {% blocktranslate trimmed with representative=organization.representative organization=organization.name %}
+                {% blocktranslate trimmed with representative=organizations.0.representative organization=organizations.0.name %}
                 I, {{ representative }},<br/>
                 legal representative of the course provider {{ organization }}<br/>
                 certifies that:
@@ -55,7 +60,7 @@
                     {% translate "Stamp and signature of the course provider manager" %}
                 </p>
                 <div class="manager">
-                    <img src="{{ organization.signature }}" />
+                    <img src="{{ organizations.0.signature }}" />
                 </div>
             </div>
         </section>

--- a/src/backend/joanie/core/templatetags/extra_tags.py
+++ b/src/backend/joanie/core/templatetags/extra_tags.py
@@ -2,6 +2,7 @@
 
 from django import template
 from django.contrib.staticfiles import finders
+from django.utils.translation import gettext as _
 
 from joanie.core.utils import image_to_base64
 
@@ -15,3 +16,15 @@ def base64_static(path):
     if full_path:
         return image_to_base64(full_path, True)
     return ""
+
+
+@register.filter
+def join_and(items: list):
+    """A template tag filter to join a list of items in human-readable way."""
+    comma_join_threshold = 2
+    if len(items) > comma_join_threshold:
+        return _("{:s} and {:s}").format(
+            ", ".join(map(str, items[:-1])), str(items[-1])
+        )
+
+    return _(" and ").join(map(str, items))

--- a/src/backend/joanie/core/templatetags/extra_tags.py
+++ b/src/backend/joanie/core/templatetags/extra_tags.py
@@ -28,3 +28,11 @@ def join_and(items: list):
         )
 
     return _(" and ").join(map(str, items))
+
+
+@register.filter
+def list_key(items: list[dict], key: str):
+    """
+    A template tag filter to get a list of values from a list of dictionaries.
+    """
+    return [item[key] for item in items]

--- a/src/backend/joanie/core/views.py
+++ b/src/backend/joanie/core/views.py
@@ -158,12 +158,14 @@ class DebugCertificateTemplateView(DebugPdfTemplateView):
                 2024, 1, 5, 13, 57, 53, 275708, tzinfo=datetime.timezone.utc
             ),
             "student": {"name": "John Doe"},
-            "organization": {
-                "representative": "Joanie Cunningham",
-                "signature": SIGNATURE_FALLBACK,
-                "logo": LOGO_FALLBACK,
-                "name": "Organization 0",
-            },
+            "organizations": [
+                {
+                    "representative": "Joanie Cunningham",
+                    "signature": SIGNATURE_FALLBACK,
+                    "logo": LOGO_FALLBACK,
+                    "name": "Organization 0",
+                }
+            ],
             "site": {"name": "example.com", "hostname": "https://example.com"},
             "course": {"name": "Full Stack Pancake, Full Stack Developer"},
         }
@@ -205,12 +207,14 @@ class DebugDegreeTemplateView(DebugPdfTemplateView):
                 2024, 1, 5, 10, 40, 54, 50357, tzinfo=datetime.timezone.utc
             ),
             "student": {"name": "Joanie Cunningham"},
-            "organization": {
-                "representative": "Joanie Cunningham",
-                "signature": SIGNATURE_FALLBACK,
-                "logo": LOGO_FALLBACK,
-                "name": "Organization Test",
-            },
+            "organizations": [
+                {
+                    "representative": "Joanie Cunningham",
+                    "signature": SIGNATURE_FALLBACK,
+                    "logo": LOGO_FALLBACK,
+                    "name": "Organization Test",
+                }
+            ],
             "site": {"name": "example.com", "hostname": "https://example.com"},
             "course": {"name": "Full Stack Pancake, Full Stack Developer"},
         }

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -465,28 +465,16 @@ class CertificateApiTest(BaseAPITestCase):
         document_text = pdf_extract_text(BytesIO(response.content)).replace("\n", "")
         self.assertRegex(document_text, r"ATTESTATION OF ACHIEVEMENT")
 
-    def test_api_certificate_download_unprocessable_entity(self):
+    @mock.patch(
+        "joanie.core.models.Certificate.get_document_context", side_effect=ValueError
+    )
+    def test_api_certificate_download_unprocessable_entity(self, _):
         """
         If the server is not able to create the certificate document, it should return
         a 422 error.
         """
         user = factories.UserFactory()
-        organization = factories.OrganizationFactory(
-            title="University X", representative="Joanie Cunningham", logo=None
-        )
-
-        product = factories.ProductFactory(
-            courses=[],
-            title="Graded product",
-        )
-        factories.CourseProductRelationFactory(
-            product=product, organizations=[organization]
-        )
-
-        order = factories.OrderFactory(
-            product=product, organization=organization, owner=user
-        )
-        certificate = factories.OrderCertificateFactory(order=order)
+        certificate = factories.OrderCertificateFactory(order__owner=user)
 
         token = self.generate_token_from_user(user)
 

--- a/src/backend/joanie/tests/core/test_commands_generate_certificates.py
+++ b/src/backend/joanie/tests/core/test_commands_generate_certificates.py
@@ -192,13 +192,13 @@ class CreateCertificatesTestCase(TestCase):
         self.assertEqual(certificate_qs.count(), 0)
 
         # A certificate should be generated for the 1st product
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(19):
             call_command("generate_certificates", product=product_1.id)
         self.assertEqual(certificate_qs.filter(order=orders[0]).count(), 1)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 0)
 
         # Then a certificate should be generated for the 2nd product
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(19):
             call_command("generate_certificates", product=product_2.id)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 1)
 
@@ -295,12 +295,12 @@ class CreateCertificatesTestCase(TestCase):
         self.assertEqual(certificate_qs.count(), 0)
 
         # A certificate should be generated for the 1st product
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(19):
             call_command("generate_certificates", product=product_1.id)
         self.assertEqual(certificate_qs.filter(order=orders[0]).count(), 1)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 0)
 
         # Then a certificate should be generated for the 2nd product
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(19):
             call_command("generate_certificates", product=product_2.id)
         self.assertEqual(certificate_qs.filter(order=orders[1]).count(), 1)

--- a/src/backend/joanie/tests/core/test_helpers.py
+++ b/src/backend/joanie/tests/core/test_helpers.py
@@ -136,7 +136,7 @@ class HelpersTestCase(TestCase):
         self.assertEqual(certificate_qs.count(), 0)
 
         # DB queries should be minimized
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             _certificate, created = order.get_or_generate_certificate()
         self.assertTrue(created)
         self.assertEqual(certificate_qs.count(), 1)

--- a/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_certificate_product.py
+++ b/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_certificate_product.py
@@ -21,21 +21,23 @@ class CertificateProductGetOrGenerateCertificateOrderModelsTestCase(TestCase):
         self,
     ):
         """Generate a certificate for a product order"""
+        course = factories.CourseFactory(
+            organizations=factories.OrganizationFactory.create_batch(2)
+        )
         enrollment = factories.EnrollmentFactory(
             course_run__is_gradable=True,
             course_run__is_listed=True,
             course_run__state=models.CourseState.ONGOING_OPEN,
+            course_run__course=course,
             is_active=True,
         )
         product = factories.ProductFactory(
             price="0.00",
             type="certificate",
             certificate_definition=factories.CertificateDefinitionFactory(),
-            courses=[enrollment.course_run.course],
+            courses=[course],
         )
-        organization = product.course_relations.first().organizations.first()
         order = factories.OrderFactory(
-            organization=organization,
             product=product,
             course=None,
             enrollment=enrollment,
@@ -59,12 +61,21 @@ class CertificateProductGetOrGenerateCertificateOrderModelsTestCase(TestCase):
             "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGNgY"
             "PgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
         )
+        # Should contain all course organizations
+        organizations = course.organizations.all()
+        self.assertEqual(len(document_context["organizations"]), 2)
         self.assertEqual(
-            document_context["organization"]["logo"],
+            document_context["organizations"][0]["name"], organizations[0].title
+        )
+        self.assertEqual(
+            document_context["organizations"][1]["name"], organizations[1].title
+        )
+        self.assertEqual(
+            document_context["organizations"][0]["logo"],
             blue_square_base64,
         )
         self.assertEqual(
-            document_context["organization"]["signature"],
+            document_context["organizations"][0]["signature"],
             blue_square_base64,
         )
 

--- a/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_credential_product.py
+++ b/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_credential_product.py
@@ -32,6 +32,11 @@ class CredentialProductGetOrGenerateCertificateOrderModelsTestCase(TestCase):
             type="credential",
             certificate_definition=factories.CertificateDefinitionFactory(),
             target_courses=[course_run.course],
+            courses=[
+                factories.CourseFactory(
+                    organizations=factories.OrganizationFactory.create_batch(2)
+                )
+            ],
         )
         order = factories.OrderFactory(product=product)
         order.submit()
@@ -55,11 +60,11 @@ class CredentialProductGetOrGenerateCertificateOrderModelsTestCase(TestCase):
             "PgPAAEDAQAIicLsAAAAAElFTkSuQmCC"
         )
         self.assertEqual(
-            document_context["organization"]["logo"],
+            document_context["organizations"][0]["logo"],
             blue_square_base64,
         )
         self.assertEqual(
-            document_context["organization"]["signature"],
+            document_context["organizations"][0]["signature"],
             blue_square_base64,
         )
 

--- a/src/backend/joanie/tests/core/test_templatetags_extra_tags.py
+++ b/src/backend/joanie/tests/core/test_templatetags_extra_tags.py
@@ -3,7 +3,7 @@ Test suite for extra template tags of the joanie core app
 """
 from django.test import TestCase
 
-from joanie.core.templatetags.extra_tags import base64_static, join_and
+from joanie.core.templatetags.extra_tags import base64_static, join_and, list_key
 
 
 class TemplateTagsExtraTagsTestCase(TestCase):
@@ -48,3 +48,19 @@ class TemplateTagsExtraTagsTestCase(TestCase):
         # - Test with four items
         items += ["Marsha"]
         self.assertEqual(join_and(items), "Joanie, Richie, Fonzie and Marsha")
+
+    def test_templatetags_extra_tags_list_key(self):
+        """
+        The template tags `list_key` should return a list of values from a list of
+        dictionaries.
+        """
+        data = [
+            {"username": "joanie"},
+            {"username": "richie"},
+            {"username": "fonzie"},
+            {"username": "marsha"},
+        ]
+
+        self.assertEqual(
+            list_key(data, "username"), ["joanie", "richie", "fonzie", "marsha"]
+        )

--- a/src/backend/joanie/tests/core/test_templatetags_extra_tags.py
+++ b/src/backend/joanie/tests/core/test_templatetags_extra_tags.py
@@ -3,7 +3,7 @@ Test suite for extra template tags of the joanie core app
 """
 from django.test import TestCase
 
-from joanie.core.templatetags.extra_tags import base64_static
+from joanie.core.templatetags.extra_tags import base64_static, join_and
 
 
 class TemplateTagsExtraTagsTestCase(TestCase):
@@ -28,3 +28,23 @@ class TemplateTagsExtraTagsTestCase(TestCase):
         """
         static_filepath = "unknown-static-file.txt"
         self.assertEqual(base64_static(static_filepath), "")
+
+    def test_templatetags_extra_tags_join_and(self):
+        """
+        The template tags `join_and` should join a list of items in a human-readable way
+        """
+        # - Test with a single item
+        items = ["Joanie"]
+        self.assertEqual(join_and(items), "Joanie")
+
+        # - Test with two items
+        items += ["Richie"]
+        self.assertEqual(join_and(items), "Joanie and Richie")
+
+        # - Test with three items
+        items += ["Fonzie"]
+        self.assertEqual(join_and(items), "Joanie, Richie and Fonzie")
+
+        # - Test with four items
+        items += ["Marsha"]
+        self.assertEqual(join_and(items), "Joanie, Richie, Fonzie and Marsha")

--- a/src/backend/joanie/tests/core/test_utils_issuers_certificate_and_degree_generate_document.py
+++ b/src/backend/joanie/tests/core/test_utils_issuers_certificate_and_degree_generate_document.py
@@ -24,17 +24,14 @@ class UtilsIssuersCertificateAndDegreeGenerateDocumentTestCase(TestCase):
         organization = factories.OrganizationFactory(
             title="University X", representative="Joanie Cunningham"
         )
-        course = factories.CourseFactory()
+        course = factories.CourseFactory(organizations=[organization])
         certificate_definition = factories.CertificateDefinitionFactory(
             template=enums.DEGREE
         )
         product = factories.ProductFactory(
-            courses=[],
+            courses=[course],
             title="Graded product",
             certificate_definition=certificate_definition,
-        )
-        factories.CourseProductRelationFactory(
-            course=course, product=product, organizations=[organization]
         )
 
         # - Add French translations
@@ -82,7 +79,9 @@ class UtilsIssuersCertificateAndDegreeGenerateDocumentTestCase(TestCase):
         """
         organization = factories.OrganizationFactory(title="University X")
         user = factories.UserFactory(first_name="Joanie Cunningham")
-        course = factories.CourseFactory(title="Course with attestation")
+        course = factories.CourseFactory(
+            title="Course with attestation", organizations=[organization]
+        )
         enrollment = factories.EnrollmentFactory(user=user, course_run__course=course)
         certificate_definition = factories.CertificateDefinitionFactory(
             template=enums.CERTIFICATE
@@ -97,7 +96,6 @@ class UtilsIssuersCertificateAndDegreeGenerateDocumentTestCase(TestCase):
         certificate = factories.EnrollmentCertificateFactory(
             certificate_definition=certificate_definition,
             enrollment=enrollment,
-            organization=organization,
         )
 
         document = issuers.generate_document(


### PR DESCRIPTION
Description...

Currently, the organization bound into certificate context was the order one (picked from course organization seller).
After some review, it appears that the organization which that should be bound into context is the course author not the course selling.

As our business logic allows to define several organization as course author, we have to update our template to now support a list of organization. About the degree template, we can assume that there is always only one organization author for now.

## Proposal

- [x] Bind course organization author instead selling organization into certificate context
- [x] Update certificate templates and business logic accordingly  
