### PR TITLE
Configure celery default queue and use ping command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   celery-dev:
     user: ${DOCKER_USER:-1000}
     image: joanie:development
-    command: ["celery", "-A", "joanie.celery_app", "worker", "-l", "DEBUG"]
+    command: ["celery", "-A", "joanie.celery_app", "worker", "-l", "DEBUG", "-n", "joanie@%h"]
     environment:
       - DJANGO_CONFIGURATION=Development
     env_file:

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -473,6 +473,7 @@ class Base(Configuration):
     # Celery
     CELERY_BROKER_URL = values.Value("redis://redis:6379/0")
     CELERY_BROKER_TRANSPORT_OPTIONS = values.DictValue({})
+    CELERY_DEFAULT_QUEUE = values.Value("celery")
 
     # pylint: disable=invalid-name
     @property

--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -78,6 +78,8 @@ spec:
               value: joanie.configs.settings
             - name: JOANIE_BACKOFFICE_BASE_URL
               value: "https://{{ joanie_admin_host }}"
+            - name: DJANGO_CELERY_DEFAULT_QUEUE
+              value: "default-queue-{{ deployment_stamp }}"
           envFrom:
             - secretRef:
                 name: "{{ joanie_secret_name }}"

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -61,18 +61,30 @@ joanie_celery_command:
   - worker
   - -l
   - INFO
+  - -n
+  - joanie@%h
 joanie_celery_livenessprobe:
   exec:
-    command: ["python", "manage.py", "check"]
+    command:
+      - celery
+      - -A
+      - joanie.celery_app
+      - inspect
+      - ping
+      - -d
+      - joanie@$HOSTNAME
   initialDelaySeconds: 60
-  periodSeconds: 30
-  timeoutSeconds: 5
 joanie_celery_readynessprobe:
   exec:
-    command: ["python", "manage.py", "check"]
+    command:
+      - celery
+      - -A
+      - joanie.celery_app
+      - inspect
+      - ping
+      - -d
+      - joanie@$HOSTNAME
   initialDelaySeconds: 15
-  periodSeconds: 10
-  timeoutSeconds: 5
 
 # -- resources
 {% set app_resources = {


### PR DESCRIPTION
## Purpose

The inspect ping command is a better solution for the liveness and
readyness than using the django check command. But to do that we have to
name every worker. To this, we weill use the hostname as uniqueness as
no other worker can run on the same host in our infrastructure.

We are using a blue green infrastructure. And we have an issue with
celery in this blue green strategy. When a new stack is deploy, celery
will discover thew newly created worker and if a message is posted we
will share the same default queue name so the task can be execute
randomly on the current or next stack. By defining the default queue
name with the deployment stamp no queue can be shared anymore.

## Proposal

- [x] configure worker name to use ping command
- [x] allow to configure default queue name