### PR TITLE
✨(backend) improve NestedOrderCourseSerializer

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -1411,6 +1411,7 @@ class NestedOrderCourseViewSet(NestedGenericViewSet, mixins.ListModelMixin):
         models.Order.objects.filter(state=enums.ORDER_STATE_VALIDATED)
         .select_related(
             "contract",
+            "certificate",
             "course",
             "enrollment",
             "organization",

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -417,6 +417,15 @@ class ContractDefinitionSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class ContractLightSerializer(serializers.ModelSerializer):
+    """Light serializer for Contract model."""
+
+    class Meta:
+        model = models.Contract
+        fields = ["id", "organization_signed_on", "student_signed_on"]
+        read_only_fields = fields
+
+
 class ContractSerializer(AbilitiesModelSerializer):
     """Serializer for Contract model serializer"""
 
@@ -775,6 +784,25 @@ class OrderGroupSerializer(serializers.ModelSerializer):
         return order_group.nb_seats - order_group.get_nb_binding_orders()
 
 
+class DefinitionResourcesProductSerializer(serializers.ModelSerializer):
+    """
+    A serializer for product model which only bind the related
+    definition resources.
+    """
+
+    certificate_definition_id = serializers.SlugRelatedField(
+        read_only=True, source="certificate_definition", slug_field="id"
+    )
+    contract_definition_id = serializers.SlugRelatedField(
+        read_only=True, source="contract_definition", slug_field="id"
+    )
+
+    class Meta:
+        model = models.Product
+        fields = ["id", "contract_definition_id", "certificate_definition_id"]
+        read_only_fields = fields
+
+
 class ProductSerializer(serializers.ModelSerializer):
     """
     Product serializer including
@@ -800,9 +828,7 @@ class ProductSerializer(serializers.ModelSerializer):
     target_courses = ProductTargetCourseRelationSerializer(
         read_only=True, many=True, source="target_course_relations"
     )
-    contract_definition = contract_definition = ContractDefinitionSerializer(
-        read_only=True
-    )
+    contract_definition = ContractDefinitionSerializer(read_only=True)
 
     class Meta:
         model = models.Product
@@ -995,26 +1021,30 @@ class NestedOrderCourseSerializer(serializers.ModelSerializer):
     id = serializers.CharField(read_only=True)
     organization = OrganizationSerializer(read_only=True, exclude_abilities=True)
     owner = UserLightSerializer(read_only=True)
+    product = DefinitionResourcesProductSerializer(read_only=True)
+    contract = ContractLightSerializer(read_only=True)
     course_id = serializers.SlugRelatedField(
         read_only=True, slug_field="id", source="course"
     )
     enrollment_id = serializers.SlugRelatedField(
         read_only=True, slug_field="id", source="enrollment"
     )
-    product_id = serializers.SlugRelatedField(
-        read_only=True, slug_field="id", source="product"
+    certificate_id = serializers.SlugRelatedField(
+        read_only=True, slug_field="id", source="certificate"
     )
 
     class Meta:
         model = models.Order
         fields = [
-            "id",
+            "certificate_id",
+            "contract",
+            "course_id",
             "created_on",
+            "enrollment_id",
+            "id",
             "organization",
             "owner",
-            "course_id",
-            "enrollment_id",
-            "product_id",
+            "product",
             "state",
         ]
         read_only_fields = fields

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -4296,6 +4296,37 @@
                     "title"
                 ]
             },
+            "ContractLight": {
+                "type": "object",
+                "description": "Light serializer for Contract model.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "primary key for the record as UUID"
+                    },
+                    "organization_signed_on": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "nullable": true,
+                        "title": "Date and time the organization signed the contract"
+                    },
+                    "student_signed_on": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "nullable": true,
+                        "title": "Date and time of issuance"
+                    }
+                },
+                "required": [
+                    "id",
+                    "organization_signed_on",
+                    "student_signed_on"
+                ]
+            },
             "CountryEnum": {
                 "enum": [
                     "AF",
@@ -4948,6 +4979,35 @@
                     }
                 }
             },
+            "DefinitionResourcesProduct": {
+                "type": "object",
+                "description": "A serializer for product model which only bind the related\ndefinition resources.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "primary key for the record as UUID"
+                    },
+                    "contract_definition_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "readOnly": true
+                    },
+                    "certificate_definition_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "certificate_definition_id",
+                    "contract_definition_id",
+                    "id"
+                ]
+            },
             "Enrollment": {
                 "type": "object",
                 "description": "Enrollment model serializer",
@@ -5286,8 +5346,24 @@
                 "type": "object",
                 "description": "Serializer for orders made on courses.",
                 "properties": {
-                    "id": {
+                    "certificate_id": {
                         "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "readOnly": true
+                    },
+                    "contract": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ContractLight"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "course_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
                         "readOnly": true
                     },
                     "created_on": {
@@ -5295,6 +5371,16 @@
                         "format": "date-time",
                         "readOnly": true,
                         "description": "date and time at which a record was created"
+                    },
+                    "enrollment_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "organization": {
                         "allOf": [
@@ -5312,22 +5398,12 @@
                         ],
                         "readOnly": true
                     },
-                    "course_id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "primary key for the record as UUID",
-                        "readOnly": true
-                    },
-                    "enrollment_id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "primary key for the record as UUID",
-                        "readOnly": true
-                    },
-                    "product_id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "description": "primary key for the record as UUID",
+                    "product": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DefinitionResourcesProduct"
+                            }
+                        ],
                         "readOnly": true
                     },
                     "state": {
@@ -5340,13 +5416,15 @@
                     }
                 },
                 "required": [
+                    "certificate_id",
+                    "contract",
                     "course_id",
                     "created_on",
                     "enrollment_id",
                     "id",
                     "organization",
                     "owner",
-                    "product_id",
+                    "product",
                     "state"
                 ]
             },


### PR DESCRIPTION
## Purpose

From the `NestedOrderCourseSerializer` endpoint, consumer api would like to get data to guess the contract signature state and the certificate state. We bind all information required to process those information.

Resolve #613
