### PR TITLE
♻️(tray) run probes in a bash process

### DIFF
--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -66,25 +66,21 @@ joanie_celery_command:
 joanie_celery_livenessprobe:
   exec:
     command:
-      - celery
-      - -A
-      - joanie.celery_app
-      - inspect
-      - ping
-      - -d
-      - joanie@$HOSTNAME
+      - /bin/bash
+      - -c
+      - "celery -A joanie.celery_app inspect ping -d joanie@$HOSTNAME"
   initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 5
 joanie_celery_readynessprobe:
   exec:
     command:
-      - celery
-      - -A
-      - joanie.celery_app
-      - inspect
-      - ping
-      - -d
-      - joanie@$HOSTNAME
+      - /bin/bash
+      - -c
+      - "celery -A joanie.celery_app inspect ping -d joanie@$HOSTNAME"
   initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
 
 # -- resources
 {% set app_resources = {


### PR DESCRIPTION
## Purpose

for the liveness and readyness probes we were directly using the celery command but without running it in a bash command we never have the return code and we always have a timeout.

## Proposal

- [x] run probes in a bash process