### PR TITLE
🔊(backend) improve logs context for signature validity

### DIFF
--- a/src/backend/joanie/signature/backends/base.py
+++ b/src/backend/joanie/signature/backends/base.py
@@ -54,6 +54,7 @@ class BaseSignatureBackend:
             logger.error(
                 "When student signed, contract's validity date has passed for contract id : '%s'",
                 contract.id,
+                extra={"context": {"contract": contract.to_dict()}},
             )
             raise ValidationError(
                 "The contract validity date of expiration has passed."
@@ -81,6 +82,7 @@ class BaseSignatureBackend:
                 "When organization signed, "
                 "contract's validity date has passed for contract id : '%s'",
                 contract.id,
+                extra=contract.to_dict(),
             )
             raise ValidationError(
                 "The contract validity date of expiration has passed."

--- a/src/backend/joanie/signature/backends/dummy.py
+++ b/src/backend/joanie/signature/backends/dummy.py
@@ -107,9 +107,8 @@ class DummySignatureBackend(BaseSignatureBackend):
             logger.error("Failed to send mail: '%s'", exception)
 
         logger.info(
-            "Mail for '%s' is sent to %s from Dummy Signature Backend",
+            "Mail for '%s' is sent from Dummy Signature Backend",
             reference_id,
-            recipient_email,
         )
 
     def get_signed_file(self, reference_id: str) -> bytes:

--- a/src/backend/joanie/tests/base.py
+++ b/src/backend/joanie/tests/base.py
@@ -1,5 +1,5 @@
 """
-Common base API test case
+Common base test cases
 """
 from datetime import datetime, timedelta
 
@@ -61,3 +61,83 @@ class BaseAPITestCase(TestCase):
             token, the jwt token generated as it should
         """
         return generate_jwt_token_from_user(user, expires_at)
+
+
+class BaseLogMixinTestCase:
+    """Mixin for logging testing"""
+
+    maxDiff = None
+
+    def assertLogsEquals(self, records, expected_records):
+        """Check that the logs are as expected
+
+        Usage:
+        Wrap the method you want to test with an assertLogs:
+            with self.assertLogs("joanie") as logs:
+                method_to_test()
+
+        Check the logs by passing the logs.records and the expected logs:
+            self.assertLogsEquals(logs.records, [
+                ("INFO", "message", {"context_key": context_type}),
+                ("ERROR", "message"),
+            ])
+
+        Each log is a tuple, with the level, the message and the context.
+        The context is optional, and you can pass the type of the context key as a string.
+        If you don't pass the context, it will not be checked.
+        """
+        try:
+            self.assertEqual(len(records), len(expected_records))
+        except AssertionError:
+            if len(records) > len(expected_records):
+                real_records = "\n".join(
+                    [
+                        f"{record.levelname} log from {record.pathname[5:]}:{record.lineno}"
+                        for record in records
+                    ]
+                )
+                raise AssertionError(
+                    f"Too many logs were recorded: {len(records)} > {len(expected_records)} "
+                    f"\n{real_records}"
+                ) from None
+            raise AssertionError(
+                f"Too few logs were recorded: {len(records)} < {len(expected_records)}"
+            ) from None
+
+        for record, expected_record in zip(records, expected_records, strict=False):
+            assert_failed_message = (
+                f"{record.levelname}: {record.getMessage()} log from "
+                f"{record.pathname[5:]}:{record.lineno} has wrong"
+            )
+            self.assertEqual(
+                record.levelname, expected_record[0], f"{assert_failed_message} level"
+            )
+            self.assertEqual(
+                record.getMessage(),
+                expected_record[1],
+                f"{assert_failed_message} message",
+            )
+
+            context = getattr(record, "context", None)
+            try:
+                expected_context = expected_record[2]
+            except IndexError:
+                # if no context is expected, we don't want to check it
+                continue
+
+            try:
+                self.assertCountEqual(
+                    context.keys(),
+                    expected_context.keys(),
+                    f"{assert_failed_message} context keys",
+                )
+            except AttributeError as error:
+                raise AssertionError(
+                    f"{assert_failed_message} context : is not a dict"
+                ) from error
+            for key, _type in expected_context.items():
+                self.assertEqual(
+                    type(context[key]),
+                    _type,
+                    f"{assert_failed_message} context key {key}",
+                )

--- a/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
@@ -134,7 +134,9 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
         content = response.json()
-        self.assertEqual(content[0], "No contract definition attached to the product.")
+        self.assertEqual(
+            content[0], "No contract definition attached to the contract's product."
+        )
 
     def test_api_order_submit_for_signature_authenticated(self):
         """


### PR DESCRIPTION
## Purpose

As we have errors during signature process, our sentry issues may lack context to understand the problem.
By adding context with related contract state, we may have better debugging chances.
Could help with #595


## Proposal

Add extra data to logger.error, and more logger.info which will be displayed in the same sentry issue.

Sentry issue will look like this https://gip-fun-mooc.sentry.io/issues/4894381323/?environment=test&project=6599941&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=0
![image](https://github.com/openfun/joanie/assets/720491/097b2570-31d9-4a15-ac57-f7ce37fcf998)

![image](https://github.com/openfun/joanie/assets/720491/a5212261-1905-447a-81ec-585b05822f89)

