### PR TITLE
Refactor/product target courses modal

### DIFF
--- a/src/frontend/admin/src/components/templates/products/form/translations.ts
+++ b/src/frontend/admin/src/components/templates/products/form/translations.ts
@@ -166,6 +166,17 @@ export const productFormMessages = defineMessages({
     defaultMessage: "Add target courses",
     description: "Title for the add target courses modal",
   },
+  choiceTargetCourseCourseRunModalTitle: {
+    id: "components.templates.products.form.translations.choiceTargetCourseCourseRunModalTitle",
+    defaultMessage: "Course run selection",
+    description: "Title for the course runs selection section",
+  },
+  choiceTargetCourseCourseRunModalAlertContent: {
+    id: "components.templates.products.form.translations.choiceTargetCourseCourseRunModalAlertContent",
+    defaultMessage:
+      "By default all course runs are selected, turn this switch on if you want to choose which course runs are selected.",
+    description: "Content for the select course runs selection alert",
+  },
   addTargetCourseCourseRunModalTitle: {
     id: "components.templates.products.form.translations.addTargetCourseCourseRunModalTitle",
     defaultMessage: "List of available course runs",

--- a/src/frontend/admin/src/tests/product/product.test.e2e.ts
+++ b/src/frontend/admin/src/tests/product/product.test.e2e.ts
@@ -259,6 +259,19 @@ test.describe("Product form", () => {
     await page.getByLabel("Course search").fill(course.title);
     await page.getByRole("option", { name: course.title }).click();
 
+    await expect(
+      addTargetCourseModal
+        .getByTestId("product-target-course-runs-selection-alert")
+        .getByText(
+          "By default all course runs are selected, turn this switch on if you want to choose which course runs are selected.",
+        ),
+    ).toBeVisible();
+
+    await addTargetCourseModal
+      .getByTestId("product-target-course-runs-selection-alert")
+      .getByTestId("enable-course-runs-selection")
+      .click();
+
     await page
       .getByRole("row", { name: `Select row ${courseRuns[0].title} Click` })
       .getByLabel("Select row")


### PR DESCRIPTION
## Purpose

Currently there is a problem understanding how to add course runs to a product target course. We therefore add a switch with a detailed explanation to activate or not the choice of course runs


https://github.com/openfun/joanie/assets/19410531/e86f2a8d-05ca-4b94-a5f9-46f82a4be55c

