### PR TITLE
✨(frontend) add organization fields

### DIFF
--- a/src/frontend/admin/src/components/presentational/hook-form/RHFUploadImage.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFUploadImage.tsx
@@ -4,10 +4,10 @@ import { Controller, useFormContext } from "react-hook-form";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Collapse from "@mui/material/Collapse";
-import FormLabel from "@mui/material/FormLabel";
 import { TransitionGroup } from "react-transition-group";
 import UploadFileIcon from "@mui/icons-material/UploadFile";
 import { useIntl } from "react-intl";
+import Typography from "@mui/material/Typography";
 import { FileThumbnail } from "@/components/presentational/files/thumbnail/FileThumbnail";
 import { ThumbnailDetailField } from "@/services/api/models/Image";
 import { commonTranslations } from "@/translations/common/commonTranslations";
@@ -62,11 +62,7 @@ export function RHFUploadImage({
         render={({ field }) => {
           return (
             <>
-              {label && (
-                <FormLabel sx={{ mb: 1 }} component="legend">
-                  {label}
-                </FormLabel>
-              )}
+              {label && <Typography variant="caption">{label}</Typography>}
 
               <Button
                 variant="outlined"

--- a/src/frontend/admin/src/components/templates/organizations/form/translations.ts
+++ b/src/frontend/admin/src/components/templates/organizations/form/translations.ts
@@ -1,6 +1,37 @@
 import { defineMessages } from "react-intl";
 
 export const organizationFormMessages = defineMessages({
+  generalSectionTitle: {
+    id: "components.templates.organizations.form.translations.generalSectionTitle",
+    defaultMessage: "General",
+    description: "Title for the general section of organization form",
+  },
+  legalPartSectionTitle: {
+    id: "components.templates.organizations.form.translations.legalPartSectionTitle",
+    defaultMessage: "Legal part",
+    description: "Title for the legal part section of organization form",
+  },
+  contactSectionTitle: {
+    id: "components.templates.organizations.form.translations.contactSectionTitle",
+    defaultMessage: "Contact",
+    description: "Title for the contact section of organization form",
+  },
+  imagesSectionTitle: {
+    id: "components.templates.organizations.form.translations.imagesSectionTitle",
+    defaultMessage: "Images",
+    description: "Title for the images section of organization form",
+  },
+  signatoryDetailsSectionTitle: {
+    id: "components.templates.organizations.form.translations.signatoryDetailsSectionTitle",
+    defaultMessage: "Signatory details",
+    description: "Title for the signatory section of organization form",
+  },
+  signatoryDetailsSectionInfo: {
+    id: "components.templates.organizations.form.translations.signatoryDetails",
+    defaultMessage:
+      "If you do not specify the representative signatory, the representative name will be used.",
+    description: "Title for the signatory section info",
+  },
   codeLabel: {
     id: "components.templates.organizations.form.translations.codeLabel",
     defaultMessage: "Code",
@@ -40,5 +71,51 @@ export const organizationFormMessages = defineMessages({
     id: "components.templates.organizations.form.translations.membersSectionTitle",
     defaultMessage: "Organization members",
     description: "Title for the member section",
+  },
+
+  representativeProfessionLabel: {
+    id: "components.templates.organizations.form.translations.representativeProfessionLabel",
+    defaultMessage: "Profession of the representative",
+    description: "Label for the representative profession input",
+  },
+  signatoryRepresentativeLabel: {
+    id: "components.templates.organizations.form.translations.signatoryRepresentativeLabel",
+    defaultMessage: "Signatory representative",
+    description: "Label for the signatory representative input",
+  },
+  signatoryRepresentativeProfessionLabel: {
+    id: "components.templates.organizations.form.translations.signatoryRepresentativeProfessionLabel",
+    defaultMessage: "Profession of the signatory representative",
+    description: "Label for the signatory representative profession input",
+  },
+  signatoryRepresentativeProfessionHelperText: {
+    id: "components.templates.organizations.form.translations.signatoryRepresentativeProfessionHelperText",
+    defaultMessage: "Mandatory if signatory representative is set",
+    description: "Label for the signatory representative profession input",
+  },
+  enterpriseCodeLabel: {
+    id: "components.templates.organizations.form.translations.enterpriseCodeLabel",
+    defaultMessage: "Enterprise code",
+    description: "Label for the enterprise code input",
+  },
+  activityCategoryCodeLabel: {
+    id: "components.templates.organizations.form.translations.activityCategoryCodeLabel",
+    defaultMessage: "Activity category code",
+    description: "Label for the activity category code input",
+  },
+  contactPhoneLabel: {
+    id: "components.templates.organizations.form.translations.contactPhoneLabel",
+    defaultMessage: "Contact phone",
+    description: "Label for the activity contact phone input",
+  },
+  contactEmailLabel: {
+    id: "components.templates.organizations.form.translations.contactEmailLabel",
+    defaultMessage: "Contact email",
+    description: "Label for the activity contact email input",
+  },
+  dpoContactEmailLabel: {
+    id: "components.templates.organizations.form.translations.dpoContactEmailLabel",
+    defaultMessage: "DPO Contact email",
+    description: "Label for the activity DPO contact email input",
   },
 });

--- a/src/frontend/admin/src/services/api/models/Organization.ts
+++ b/src/frontend/admin/src/services/api/models/Organization.ts
@@ -11,6 +11,14 @@ export type Organization = {
   logo?: ThumbnailDetailField;
   accesses?: Accesses<OrganizationRoles>[];
   country?: string;
+  enterprise_code?: string; // SIRET in France
+  activity_category_code?: string; // APE in France
+  representative_profession?: string;
+  signatory_representative?: string;
+  signatory_representative_profession?: string;
+  contact_phone?: string;
+  contact_email?: string;
+  dpo_email?: string;
 };
 
 export enum OrganizationRoles {

--- a/src/frontend/admin/src/tests/course/course.test.e2e.ts
+++ b/src/frontend/admin/src/tests/course/course.test.e2e.ts
@@ -89,8 +89,8 @@ test.describe("Course form", async () => {
 
     await page.getByLabel("Title").click();
     await page.getByLabel("Title").fill("Test course");
-    await page.getByLabel("Code").click();
-    await page.getByLabel("Code").fill("Test_Course_Code");
+    await page.getByLabel("Code", { exact: true }).click();
+    await page.getByLabel("Code", { exact: true }).fill("Test_Course_Code");
     await page.getByLabel("Organizations").click();
     await page
       .getByRole("option", { name: store.organizations[0].title })
@@ -112,10 +112,14 @@ test.describe("Course form", async () => {
       .click();
     await page.getByRole("textbox", { name: "Title" }).click();
     await page.getByRole("textbox", { name: "Title" }).fill("Org title");
-    await page.getByRole("textbox", { name: "Code" }).click();
-    await page.getByRole("textbox", { name: "Code" }).fill("Org code");
-    await page.getByLabel("Representative").click();
-    await page.getByLabel("Representative").fill("john.doe@yoppmail.com");
+    await page.getByRole("textbox", { name: "Code", exact: true }).click();
+    await page
+      .getByRole("textbox", { name: "Code", exact: true })
+      .fill("Org code");
+    await page.getByLabel("Representative", { exact: true }).click();
+    await page
+      .getByLabel("Representative", { exact: true })
+      .fill("john.doe@yoppmail.com");
     await page.getByTestId("submit-button-organization-form").click();
     await page.getByText("Operation completed successfully.").click();
     await expect(page.getByRole("button", { name: "Org title" })).toBeVisible();
@@ -156,8 +160,8 @@ test.describe("Course form", async () => {
     await page.getByLabel("Title").click();
     await page.getByLabel("Title").fill("Test course");
     await expect(page.getByText("title is a required field")).toHaveCount(0);
-    await page.getByLabel("Code").click();
-    await page.getByLabel("Code").fill("fd");
+    await page.getByLabel("Code", { exact: true }).click();
+    await page.getByLabel("Code", { exact: true }).fill("fd");
     await expect(page.getByText("code is a required field")).toHaveCount(0);
     await page.getByLabel("Organizations").click();
     await page

--- a/src/frontend/admin/src/tests/organization/organization.test.e2e.ts
+++ b/src/frontend/admin/src/tests/organization/organization.test.e2e.ts
@@ -8,6 +8,7 @@ import {
 import { PATH_ADMIN } from "@/utils/routes/path";
 import { ORGANIZATION_OPTIONS_REQUEST_RESULT } from "@/tests/mocks/organizations/organization-mock";
 import { User } from "@/services/api/models/User";
+import { expectHaveClasses } from "@/tests/utils";
 
 const searchPlaceholder = "Search by title, code";
 
@@ -44,12 +45,51 @@ test.describe("Organization Form", () => {
     await page.getByLabel("Title").click();
     await page.getByLabel("Title").fill("Organization test");
     await page.getByLabel("Title").fill("Organization title");
-    await page.getByLabel("Code").click();
+    await page.getByLabel("Code", { exact: true }).click();
+    await page.getByLabel("Code", { exact: true }).fill("Organization code");
     await page.getByLabel("Country").click();
     await page.getByRole("option", { name: "United Kingdom" }).click();
-    await page.getByLabel("Code").fill("Organization code");
-    await page.getByLabel("Representative").click();
-    await page.getByLabel("Representative").fill("john.doe@yopmail.com");
+    await page.getByLabel("Representative", { exact: true }).click();
+    await page.getByLabel("Representative", { exact: true }).fill("John Doe");
+
+    await expect(
+      page.getByText("Mandatory if signatory representative is set"),
+    ).toBeVisible();
+
+    await page.getByLabel("Profession of the representative").click();
+    await page.getByLabel("Profession of the representative").fill("Director");
+    await page.getByLabel("Signatory representative", { exact: true }).click();
+
+    await page
+      .getByLabel("Signatory representative", { exact: true })
+      .fill("Doe John");
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expectHaveClasses(
+      page.getByText("signatory_representative_profession is a required field"),
+      "Mui-error",
+    );
+
+    await page.getByLabel("Profession of the signatory").click();
+    await page.getByLabel("Profession of the signatory").fill("CTO");
+    await page.getByLabel("Enterprise code").click();
+    await page.getByLabel("Enterprise code").fill("0001");
+    await page.getByLabel("Activity category code").click();
+    await page.getByLabel("Activity category code").fill("00002");
+    await page.getByLabel("Contact phone").click();
+    await page.getByLabel("Contact phone").fill("0000000000");
+    await page.getByLabel("Contact email", { exact: true }).click();
+    await page
+      .getByLabel("Contact email", { exact: true })
+      .fill("john.doe@yopmail.com");
+    await page.getByLabel("Contact email", { exact: true }).press("Tab");
+    await page.getByLabel("DPO Contact email").fill("dpo.contact@gmail.com");
+    await expect(page.getByRole("heading", { name: "Contact" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Legal part" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Signatory details" }),
+    ).toBeVisible();
     await page.getByRole("button", { name: "Submit" }).click();
 
     // Get the successfully notification


### PR DESCRIPTION
## Purpose

We recently added new fields into the Organization model. The back office should display those fields and allow administrator to edit them.

Before : 
<img width="2560" alt="Capture d’écran 2024-02-16 à 17 10 05" src="https://github.com/openfun/joanie/assets/19410531/83ba21ef-ba63-499c-b352-e848a7b00af9">

After : 
<img width="2560" alt="Capture d’écran 2024-02-19 à 13 56 30" src="https://github.com/openfun/joanie/assets/19410531/94c5de69-2f08-4976-a782-f6bf265a5942">
