### PR TITLE
✨(backend) add has_consent_to_terms into AdminOrderSerializer

### DIFF
--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -1035,6 +1035,7 @@ class AdminOrderSerializer(serializers.ModelSerializer):
             "contract",
             "certificate",
             "main_invoice",
+            "has_consent_to_terms",
         )
         read_only_fields = fields
 

--- a/src/backend/joanie/tests/core/test_api_admin_orders.py
+++ b/src/backend/joanie/tests/core/test_api_admin_orders.py
@@ -525,6 +525,7 @@ class OrdersAdminApiTestCase(TestCase):
                 "id": str(order.id),
                 "created_on": format_date(order.created_on),
                 "state": order.state,
+                "has_consent_to_terms": False,
                 "owner": {
                     "id": str(order.owner.id),
                     "username": order.owner.username,
@@ -670,6 +671,7 @@ class OrdersAdminApiTestCase(TestCase):
                 "id": str(order.id),
                 "created_on": format_date(order.created_on),
                 "state": order.state,
+                "has_consent_to_terms": False,
                 "owner": {
                     "id": str(order.owner.id),
                     "username": order.owner.username,

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -4796,6 +4796,11 @@
                     },
                     "main_invoice": {
                         "$ref": "#/components/schemas/AdminInvoice"
+                    },
+                    "has_consent_to_terms": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "User has consented to the platform terms and conditions."
                     }
                 },
                 "required": [
@@ -4804,6 +4809,7 @@
                     "course",
                     "created_on",
                     "enrollment",
+                    "has_consent_to_terms",
                     "id",
                     "main_invoice",
                     "order_group",


### PR DESCRIPTION
## Purpose

We recently add a field `has_consent_to_terms` to Order model and we want to display it within backoffice order detail view.
