### PR TITLE
:sparkles: (backend) API - Client - Filter enrollment, order, course and course product relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ## Added
 
+- Allow to filter course product relation by organization title or
+  product title or by course code on the client API.
 - Allow to filter courses by course code or title on the client API
 - Allow to filter orders by product title on the client API
 - Allow to filter enrollments by course title on the client API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow to filter courses by course code or title on the client API
 - Allow to filter orders by product title on the client API
 - Allow to filter enrollments by course title on the client API
 - Debug app to preview template (certificate, degree, invoice,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow to filter orders by product title on the client API
 - Allow to filter enrollments by course title on the client API
 - Debug app to preview template (certificate, degree, invoice,
   contract definition)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow to filter enrollments by course title on the client API
 - Debug app to preview template (certificate, degree, invoice,
   contract definition)
 - Allow to filter out organization through course product relation id on

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -56,10 +56,19 @@ class EnrollmentViewSetFilter(filters.FilterSet):
 
     course_run_id = filters.UUIDFilter(field_name="course_run__id")
     was_created_by_order = filters.BooleanFilter(field_name="was_created_by_order")
+    query = filters.CharFilter(method="filter_by_query")
 
     class Meta:
         model = models.Enrollment
         fields: List[str] = []
+
+    def filter_by_query(self, queryset, _name, value):
+        """
+        Filter resource by looking for course title
+        """
+        return queryset.filter(
+            course_run__course__translations__title__icontains=value
+        ).distinct()
 
 
 class CourseViewSetFilter(filters.FilterSet):

--- a/src/backend/joanie/core/filters/client.py
+++ b/src/backend/joanie/core/filters/client.py
@@ -31,10 +31,17 @@ class OrderViewSetFilter(filters.FilterSet):
         choices=enums.PRODUCT_TYPE_CHOICES,
         exclude=True,
     )
+    query = filters.CharFilter(method="filter_by_query")
 
     class Meta:
         model = models.Order
         fields: List[str] = []
+
+    def filter_by_query(self, queryset, _name, value):
+        """
+        Filter resource by product title
+        """
+        return queryset.filter(product__translations__title__icontains=value).distinct()
 
 
 class ProductViewSetFilter(filters.FilterSet):

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_course_product_relations.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_course_product_relations.py
@@ -399,3 +399,406 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
         self.assertTrue(
             models.CourseProductRelation.objects.filter(id=relation.id).exists()
         )
+
+    # pylint: disable=too-many-locals
+    def test_api_organizations_course_product_relations_filter_by_query_product_title(
+        self,
+    ):
+        """
+        An authenticated user should be able to filter course product relation by
+        product title if he has access to the organization.
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        organization_1 = factories.OrganizationFactory()
+        organization_2 = factories.OrganizationFactory()
+        organization_3 = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization_1, user=user)
+        factories.UserOrganizationAccessFactory(organization=organization_2, user=user)
+        product_1 = factories.ProductFactory(
+            title="Introduction to resource filtering", courses=[]
+        )
+        product_2 = factories.ProductFactory(
+            title="Advanced aerodynamic flows", courses=[]
+        )
+        product_3 = factories.ProductFactory(
+            title="Rubber management on a single-seater", courses=[]
+        )
+        product_4 = factories.ProductFactory(
+            title="Single-seater porpoising introduction", courses=[]
+        )
+        # Create translations title for products
+        product_1.translations.create(
+            language_code="fr-fr", title="Introduction au filtrage de resource"
+        )
+        product_2.translations.create(
+            language_code="fr-fr", title="Flux aérodynamiques avancés"
+        )
+        product_3.translations.create(
+            language_code="fr-fr", title="Gestion d'une gomme sur une monoplace"
+        )
+        product_4.translations.create(
+            language_code="fr-fr", title="Introduction au marsouinage d'une monoplace"
+        )
+        relations_organization_1 = []
+        for product in [product_1, product_3]:
+            relations_organization_1.append(
+                factories.CourseProductRelationFactory(
+                    organizations=[organization_1], product=product
+                )
+            )
+        course_product_relation_1 = factories.CourseProductRelationFactory(
+            product=product_2,
+            organizations=[organization_1],
+        )
+        relations_organization_1.append(course_product_relation_1)
+
+        course_product_relation_2 = factories.CourseProductRelationFactory(
+            product=product_4, organizations=[organization_2]
+        )
+        factories.CourseProductRelationFactory(organizations=[organization_3])
+
+        # Prepare queries to test
+        queries = [
+            "Flux aérodynamiques avancés",
+            "Flux+aérodynamiques+avancés",
+            "aérodynamiques",
+            "aerodynamic",
+            "aéro",
+            "aero",
+            "aer",
+            "advanced",
+            "flows",
+            "flo",
+            "Advanced aerodynamic flows",
+            "adv",
+            "dynamic",
+            "dyn",
+            "ows",
+            "av",
+            "ux",
+        ]
+        for query in queries:
+            response = self.client.get(
+                f"/api/v1.0/organizations/{organization_1.id}/"
+                f"course-product-relations/?query={query}",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            content = response.json()
+            self.assertEqual(content["count"], 1)
+            self.assertEqual(
+                content["results"][0].get("id"), str(course_product_relation_1.id)
+            )
+
+        # When parsing a product title that the organization is not linked to, it should
+        # return no result
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/"
+            f"course-product-relations/?query={course_product_relation_2.product.title}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+        # When parsing nothing we should find the 1 course product relation that is linked to the
+        # organization 2
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_2.id}/course-product-relations/?query=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(
+            content["results"][0].get("id"), str(course_product_relation_2.id)
+        )
+
+        # When parsing nothing we should find the 3 course product relations linked to the
+        # organization 1
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/course-product-relations/?query=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 3)
+        self.assertEqual(
+            {str(x["id"]) for x in content["results"]},
+            {str(x.id) for x in relations_organization_1},
+        )
+
+        # Should get 0 result in return with a title that does not exist
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/course-product-relations/?query=fake",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+        # Should get 0 result in return because we don't have organization access
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_3.id}/course-product-relations/?query=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+    # pylint: disable=too-many-locals
+    def test_api_organizations_course_product_relations_filter_by_query_course_code(
+        self,
+    ):
+        """
+        An authenticated user should be able to filter course product relation by
+        course code if he has access to the organization.
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        organization_1 = factories.OrganizationFactory()
+        organization_2 = factories.OrganizationFactory()
+        organization_3 = factories.OrganizationFactory()
+        factories.UserOrganizationAccessFactory(organization=organization_1, user=user)
+        factories.UserOrganizationAccessFactory(organization=organization_2, user=user)
+        course_1 = factories.CourseFactory(code="MYCODE_0095")
+        course_2 = factories.CourseFactory(code="MYCODE_0096")
+        course_3 = factories.CourseFactory(code="MYCODE_0097")
+        course_4 = factories.CourseFactory(code="MYCODE_0098")
+        # Create 3 CourseProductRelations for organization 1
+        relations_organization_1 = []
+        for course in [course_1, course_3]:
+            relations_organization_1.append(
+                factories.CourseProductRelationFactory(
+                    organizations=[organization_1], course=course
+                )
+            )
+        course_product_relation_1 = factories.CourseProductRelationFactory(
+            course=course_2,
+            organizations=[organization_1],
+        )
+        relations_organization_1.append(course_product_relation_1)
+
+        # 1 CourseProductRelation for organization 2
+        course_product_relation_2 = factories.CourseProductRelationFactory(
+            course=course_4, organizations=[organization_2]
+        )
+        # 1 CourseProductRelation for organization 3
+        factories.CourseProductRelationFactory(organizations=[organization_3])
+        # We should retrieve only one course out of 3 from the course code
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/"
+            f"course-product-relations/?query={course_product_relation_1.course.code}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(
+            content["results"][0].get("id"), str(course_product_relation_1.id)
+        )
+
+        # When parsing a course code that the organization is not linked to, it should
+        # return no result
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/"
+            f"course-product-relations/?query={course_product_relation_2.course.code}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+        # When parsing MYCODE_009 with organization 2, we should find 1 CourseProductRelation
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_2.id}/course-product-relations/"
+            f"?query={course_product_relation_2.course.code[:1]}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 1)
+        self.assertEqual(
+            content["results"][0].get("id"), str(course_product_relation_2.id)
+        )
+
+        # When parsing nothing we should find the 3 course product relations linked to the
+        # organization 1
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/course-product-relations/?query=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 3)
+        self.assertEqual(
+            {str(x["id"]) for x in content["results"]},
+            {str(x.id) for x in relations_organization_1},
+        )
+
+        # Should get 0 result in return with a title that does not exist
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/course-product-relations/?query=fake",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+        # Should get 0 result in return because we don't have organization access
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_3.id}/course-product-relations/?query=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+    def test_api_organizations_course_product_relations_filter_by_query_organization_title(
+        self,
+    ):
+        """
+        An authenticated user should be able to filter course product relation by
+        organization title if he has access to the organization.
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        organization_1 = factories.OrganizationFactory(
+            title="Digital University of Innovation"
+        )
+        organization_2 = factories.OrganizationFactory(
+            title="Online Digital University"
+        )
+        organization_3 = factories.OrganizationFactory(
+            title="University of Digital Learning"
+        )
+        organization_1.translations.create(
+            language_code="fr-fr", title="Université Numérique d'Innovation"
+        )
+        organization_2.translations.create(
+            language_code="fr-fr", title="Université digital en ligne"
+        )
+        organization_3.translations.create(
+            language_code="fr-fr", title="Université de l'Apprentissage Numérique"
+        )
+        factories.UserOrganizationAccessFactory(organization=organization_1, user=user)
+        factories.UserOrganizationAccessFactory(organization=organization_2, user=user)
+        # Create 3 CourseProductRelations for organization 1
+        cpr1 = factories.CourseProductRelationFactory(
+            organizations=[organization_1, organization_2],
+            # course=courses[0]
+        )
+        cpr2 = factories.CourseProductRelationFactory(
+            organizations=[organization_1, organization_2],
+            # course=courses[1]
+        )
+        cpr3 = factories.CourseProductRelationFactory(organizations=[organization_1])
+        # 1 CourseProductRelation for organization 3
+        factories.CourseProductRelationFactory(organizations=[organization_3])
+
+        # We should retrieve 3 CourseProductRelation from organization 1
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/"
+            f"course-product-relations/?query={organization_1.title}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 3)
+        self.assertCountEqual(
+            [result["id"] for result in content["results"]],
+            [str(cpr1.id), str(cpr2.id), str(cpr3.id)],
+        )
+
+        # We should retrieve 2 CourseProductRelation from organization 2
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_2.id}/"
+            f"course-product-relations/?query={organization_2.title}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 2)
+        self.assertCountEqual(
+            [result["id"] for result in content["results"]],
+            [str(cpr1.id), str(cpr2.id)],
+        )
+
+        # We should retrieve 0 CourseProductRelation from organization 3 because no access
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_3.id}/"
+            f"course-product-relations/?query={organization_3.title}",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)
+
+        # Prepare queries to test
+        queries = [
+            "Online Digital University",
+            "Université digital en ligne",
+            "Digital",
+            "Dig",
+            "Di",
+            "Uni",
+            "tal",
+            "ta",
+            "en",
+            "git",
+            "D",
+            "o",
+        ]
+
+        for query in queries:
+            # We should find 2 CourseProductRelation
+            response = self.client.get(
+                f"/api/v1.0/organizations/{organization_2.id}/"
+                f"course-product-relations/?query={query}",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            content = response.json()
+            self.assertEqual(content["count"], 2)
+            self.assertCountEqual(
+                [result["id"] for result in content["results"]],
+                [str(cpr1.id), str(cpr2.id)],
+            )
+
+        # We should retrieve 3 CourseProductRelation
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/"
+            f"course-product-relations/?query=",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 3)
+        self.assertCountEqual(
+            [result["id"] for result in content["results"]],
+            [str(cpr1.id), str(cpr2.id), str(cpr3.id)],
+        )
+
+        # We should retrieve 0 CourseProductRelation
+        response = self.client.get(
+            f"/api/v1.0/organizations/{organization_1.id}/"
+            f"course-product-relations/?query=fakeOrganizationTitle",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        content = response.json()
+        self.assertEqual(content["count"], 0)

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -2504,6 +2504,13 @@
                     },
                     {
                         "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
                         "name": "state",
                         "schema": {
                             "type": "array",

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -2207,6 +2207,13 @@
                     },
                     {
                         "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
                         "name": "was_created_by_order",
                         "schema": {
                             "type": "boolean"

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -994,6 +994,13 @@
                             ]
                         },
                         "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate"
+                    },
+                    {
+                        "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "tags": [
@@ -3649,6 +3656,13 @@
                             ]
                         },
                         "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate"
+                    },
+                    {
+                        "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "tags": [

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -784,6 +784,13 @@
                         "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
                         "explode": true,
                         "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "tags": [
@@ -1745,6 +1752,13 @@
                         "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
                         "explode": true,
                         "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "tags": [
@@ -3534,6 +3548,13 @@
                         "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
                         "explode": true,
                         "style": "form"
+                    },
+                    {
+                        "in": "query",
+                        "name": "query",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 ],
                 "tags": [


### PR DESCRIPTION
## Purpose

This PR will solve this [issue](https://github.com/openfun/joanie/issues/643).

## Proposal by the issue author

Here are the list of expected filters by resource:
- Enrollment
	- [x] query (full search text in course title)
- Order
	- [x] query (full search text in product title)
- Course
	- [x] query (full search text in course title, code)
- CourseProductRelation
	- [x] query (full search text in product title, course code, organizations__title)
