### PR TITLE
✨(back) allow to configure mongo read preferences and replicaset

### DIFF
--- a/src/backend/joanie/edx_imports/edx_mongodb.py
+++ b/src/backend/joanie/edx_imports/edx_mongodb.py
@@ -12,6 +12,8 @@ def get_enrollment(course_id):
         username=settings.EDX_MONGODB_USER,
         password=settings.EDX_MONGODB_PASSWORD,
         authSource=settings.EDX_MONGODB_NAME,
+        readPreference=settings.EDX_MONGODB_READPREFERENCE,
+        replicaSet=settings.EDX_MONGODB_REPLICASET,
     )
     db = client.edxapp
     mongo_enrollment = db.modulestore.find_one(

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -512,6 +512,14 @@ class Base(Configuration):
     EDX_MONGODB_NAME = values.Value(
         None, environ_name="EDX_MONGODB_NAME", environ_prefix=None
     )
+    EDX_MONGODB_READPREFERENCE = values.Value(
+        "secondaryPreferred",
+        environ_name="EDX_MONGODB_READPREFERENCE",
+        environ_prefix=None,
+    )
+    EDX_MONGODB_REPLICASET = values.Value(
+        None, environ_name="EDX_MONGODB_REPLICASET", environ_prefix=None
+    )
 
     EDX_TIME_ZONE = values.Value(
         None, environ_name="EDX_TIME_ZONE", environ_prefix=None


### PR DESCRIPTION
## Purpose

We want to configure how the mongo read preferences to use first secondaries servers and also specify the replicaset to use.


## Proposal

- [x] allow to configure mongo read preferences and replicaset
