### PR TITLE
✨(backend) API - Contract Download - Learner should download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow student to download his owned contract once fully signed
 - Allow to filter course product relation by organization title or
   product title or by course code on the client API.
 - Allow to filter courses by course code or title on the client API

--- a/src/backend/joanie/core/models/contracts.py
+++ b/src/backend/joanie/core/models/contracts.py
@@ -283,3 +283,15 @@ class Contract(BaseModel):
         return {
             "sign": can_sign,
         }
+
+    @property
+    def is_fully_signed(self):
+        """
+        Determine if a contract is fully signed by all parties. Call this method on the contract
+        instance. It returns a boolean indicating whether the contract is fully signed or not.
+        """
+        return (
+            self.organization_signed_on is not None
+            and self.student_signed_on is not None
+            and not self.submitted_for_signature_on
+        )

--- a/src/backend/joanie/tests/core/test_models_contract.py
+++ b/src/backend/joanie/tests/core/test_models_contract.py
@@ -731,3 +731,73 @@ class ContractModelTestCase(TestCase):
                 "course run that is in archived state.']}"
             ),
         )
+
+    def test_models_contracts_is_fully_signed_property_should_return_true(self):
+        """
+        Check that the property `is_fully_signed` returns True when the contract
+        has values set on the fields `student_signed_on`, `organization_signed_on`
+        and for the field `submitted_for_signature_on` is set to None.
+        """
+        order = factories.OrderFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
+        contract = factories.ContractFactory(
+            order=order,
+            definition=order.product.contract_definition,
+            signature_backend_reference="wfl_id_fake",
+            definition_checksum="fake_test_file_hash",
+            context="content",
+            submitted_for_signature_on=None,
+            student_signed_on=django_timezone.now(),
+            organization_signed_on=django_timezone.now() + timedelta(days=1),
+        )
+
+        self.assertTrue(contract.is_fully_signed)
+
+    def test_models_contracts_is_fully_signed_property_should_return_false_missing_organization(
+        self,
+    ):
+        """
+        Check that the property `is_fully_signed` returns False when the contract
+        has values set on the fields `student_signed_on` and `submitted_for_signature_on`
+        and when the field `organization_signed_on` is set to None.
+        """
+        order = factories.OrderFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
+        contract = factories.ContractFactory(
+            order=order,
+            definition=order.product.contract_definition,
+            signature_backend_reference="wfl_id_fake",
+            definition_checksum="fake_test_file_hash",
+            context="content",
+            submitted_for_signature_on=django_timezone.now(),
+            student_signed_on=django_timezone.now() + timedelta(days=1),
+            organization_signed_on=None,
+        )
+
+        self.assertFalse(contract.is_fully_signed)
+
+    def test_models_contracts_is_fully_signed_property_should_return_false_missing_both_signatures(
+        self,
+    ):
+        """
+        Check that the property `is_fully_signed` returns False when the contract
+        has a value set on the field `submitted_for_signature_on` and when the
+        fields `student_signed_on` and `organization_signed_on` are set to None.
+        """
+        order = factories.OrderFactory(
+            product__contract_definition=factories.ContractDefinitionFactory()
+        )
+        contract = factories.ContractFactory(
+            order=order,
+            definition=order.product.contract_definition,
+            signature_backend_reference="wfl_id_fake",
+            definition_checksum="fake_test_file_hash",
+            context="content",
+            submitted_for_signature_on=django_timezone.now(),
+            student_signed_on=None,
+            organization_signed_on=None,
+        )
+
+        self.assertFalse(contract.is_fully_signed)

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -607,7 +607,7 @@
         "/api/v1.0/contracts/{id}/download/": {
             "get": {
                 "operationId": "contracts_download_retrieve",
-                "description": "Return the PDF in bytes to download of the contract's definition of an order.",
+                "description": "Return the PDF file in bytes fully signed to download from the signature provider.",
                 "parameters": [
                     {
                         "in": "path",


### PR DESCRIPTION
## Purpose

This PR solves this [issue](https://github.com/openfun/joanie/issues/642).

Currently, a learner is not able to download a fully signed contract document. Instead, it gets a PDF generated by Joanie so without signatures.

A learner should be able to download its original contract when this one has been fully signed.
So the endpoint to download a contract should check if the related contract has been fully signed. 
Otherwise, an error response should be returned, we should retrieve the document on our signature provider and return the file in the response.

## Proposal
- [x] Evolve existing endpoint in `ContractViewSet` : `download() `. It now retrieves the document from the signature provider if the file has been fully signed by the student and the organization and returns it as an attachment PDF to get download.
- [x] raise an **error message response** if a request to download has been triggered but the document has not been yet fully signed.
- [x] create utility method to **download one file with one signature backend reference**.
- [x] update test suite, add missing tests, and new tests for utility contract method : `get_signed_contract_pdf_bytes_from_provider`
