### PR TITLE
♻️(tray) rename pod name to distinguish wsgi and celery

### DIFF
--- a/src/tray/templates/services/app/_deploy_base.yml.j2
+++ b/src/tray/templates/services/app/_deploy_base.yml.j2
@@ -47,7 +47,7 @@ spec:
         - name: "{{ image_pull_secret_name }}"
 {% endif %}
       containers:
-        - name: joanie
+        - name: "{{ dc_name }}"
           image: "{{ joanie_image_name }}:{{ joanie_image_tag }}"
           imagePullPolicy: Always
 {% if service_variant=="app" %}


### PR DESCRIPTION
## Purpose

In the deployment, celery and app have the same container name. If we want to create a filter on the pod name we can't distinguish both. We add the service variant anem to the container name to allow this.


## Proposal

- [x]  rename container name to distinguish wsgi and celery


