### PR TITLE
🐛(backend) do not store missing university logo

### DIFF
--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -111,7 +111,11 @@ def import_certificates_batch(start, stop, dry_run=False):
             if signature_image_path.startswith("/"):
                 signature_image_path = signature_image_path[1:]
             signature_path = download_and_store(signature_image_path)
-            signature = image_to_base64(default_storage.path(signature_path))
+            signature = (
+                image_to_base64(default_storage.path(signature_path))
+                if signature_path
+                else None
+            )
             signatory_name = signatory.get("name")
 
         certificate_context = {
@@ -135,7 +139,9 @@ def import_certificates_batch(start, stop, dry_run=False):
                         ),
                         "representative": signatory_name,
                         "signature": signature,
-                        "logo": image_to_base64(organization.logo),
+                        "logo": image_to_base64(organization.logo)
+                        if organization.logo
+                        else None,
                     }
                 ],
             }

--- a/src/backend/joanie/edx_imports/tasks/universities.py
+++ b/src/backend/joanie/edx_imports/tasks/universities.py
@@ -64,12 +64,12 @@ def import_universities_batch(start, stop, dry_run=False):
                 report["universities"]["created"] += 1
                 continue
 
+            logo_downloaded = download_and_store(university.logo, "media")
             models.Organization.objects.create(
                 code=utils.normalize_code(university.code),
                 title=university.name,
-                logo=university.logo,
+                logo=university.logo if logo_downloaded else None,
             )
-            download_and_store(university.logo, "media")
             report["universities"]["created"] += 1
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("Unable to import university %s", university.code)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_universities.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_universities.py
@@ -111,6 +111,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
 
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_universities_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_universities")
+    @responses.activate(assert_all_requests_are_fired=True)
     def test_command_migrate_universities_error(
         self, mock_get_universities, mock_get_universities_count
     ):
@@ -123,6 +124,12 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
         )
         mock_get_universities.return_value = [edx_university]
         mock_get_universities_count.return_value = len([edx_university])
+
+        responses.add(
+            responses.GET,
+            f"https://{settings.EDX_DOMAIN}/media/{edx_university.logo}",
+            body=LOGO_CONTENT,
+        )
 
         with self.assertLogs() as logger:
             call_command("migrate_edx", "--skip-check", "--universities")

--- a/src/backend/joanie/tests/edx_imports/test_import_universities.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_universities.py
@@ -120,8 +120,7 @@ class EdxImportUniversitiesTestCase(TestCase):
         self, mock_get_universities, mock_get_universities_count
     ):
         """
-        Test that universities are not created from the edx universities if the code
-        is null.
+        Test that logos are not stored if the logo is not found.
         """
         edx_university = edx_factories.EdxUniversityFactory()
         mock_get_universities.return_value = [edx_university]


### PR DESCRIPTION


## Purpose

When an universiy logo is not downloaded, we don't want to store the file path.