### PR TITLE
:sparkles: (backend) API Client -  read list - Certificate enrollments owned by user 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ and this project adheres to
 
 ### Changed
 
+- Update the certificate viewset for the API client to return
+  certificates from orders and from enrollments owned by a user.
 - Update demo-dev command to add a second product purchase with learner
   signature.
 - Improve `degree` certificate template

--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -611,7 +611,9 @@ class CertificateViewSet(
             if self.request.auth
             else self.request.user.username
         )
-        return queryset.filter(order__owner__username=username)
+        return queryset.filter(
+            Q(order__owner__username=username) | Q(enrollment__user__username=username),
+        ).distinct()
 
     @extend_schema(
         responses={


### PR DESCRIPTION
## Purpose

The `CertificateViewSet` was missing a condition in its 'read_list' method (`get_queryset`) to return the certificates that are owned by a user which are linked to enrollments. Before starting the development, the 'read_list' would only return certificates that are linked to orders that are owned by a user.

To complete this, we have enhanced the queryset that is triggered in the `get_queryset` method of this viewset `CertificateViewSet`.

This feature enhances the `CertificateViewSet` to return certificates that are linked to enrollments owned by the user.

In conclusion, the `CertificateViewSet` **now returns certificates that are linked to orders and enrollments that are owned by a user.**

## Proposal

- [x] Add the missing condition in the queryset in the method of `get_queryset` in the `CertificateViewSet`.
- [x] Adjust the existing test to introduce certificates with enrollments in read_list certificate api tests.
- [x] Add a new test to retrieve a certificate that is linked to an enrollment owned by the user.
