### PR TITLE
Many migration fixes

### DIFF
--- a/src/backend/joanie/edx_imports/checks.py
+++ b/src/backend/joanie/edx_imports/checks.py
@@ -31,7 +31,6 @@ def check_import_env(style):
         "EDX_DATABASE_USER",
         "EDX_DATABASE_PASSWORD",
         "EDX_DATABASE_DEBUG",
-        "EDX_DATABASE_DEBUG",
         "EDX_TIME_ZONE",
         "EDX_SECRET",
         "EDX_MONGODB_HOST",
@@ -48,6 +47,30 @@ def check_import_env(style):
             logger.error(style.ERROR("    %s is not defined"), env_var)
             check_result = False
     return check_result
+
+
+def check_course_sync_env(style):
+    """
+    Check that the environment variables for the course sync is empty.
+    """
+    logger.info("\n- Checking course sync environment variables...")
+
+    env_var = "COURSE_WEB_HOOKS"
+    try:
+        course_web_hook_settings = getattr(settings, env_var)
+        if course_web_hook_settings:
+            logger.error(
+                style.ERROR("    %s is defined: %s"), env_var, course_web_hook_settings
+            )
+            logger.error(
+                style.ERROR("    Courses will be synced during the import process.")
+            )
+            return False
+    except AttributeError:
+        pass
+
+    logger.info(style.SUCCESS("    No course sync environment variables defined"))
+    return True
 
 
 def check_openedx_host(style):

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -75,7 +75,7 @@ class OpenEdxDB:
             return min(universities_count, limit)
         return universities_count
 
-    def get_universities(self, start, stop):
+    def get_universities(self, offset, limit):
         """
         Get universities from Open edX database
 
@@ -94,8 +94,8 @@ class OpenEdxDB:
                     self.University.logo,
                 )
             )
-            .offset(start)
-            .limit(stop)
+            .offset(offset)
+            .limit(limit)
         )
         return self.session.scalars(query).all()
 

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -116,7 +116,7 @@ class OpenEdxDB:
             return min(course_overviews_count, limit)
         return course_overviews_count
 
-    def get_course_overviews(self, start, stop):
+    def get_course_overviews(self, offset, limit):
         """
         Get course_overviews from Open edX database
 
@@ -156,8 +156,8 @@ class OpenEdxDB:
                 ),
             )
             .order_by(self.CourseOverview.id)
-            .offset(start)
-            .limit(stop)
+            .offset(offset)
+            .limit(limit)
         )
         return self.session.scalars(query).all()
 

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -94,7 +94,7 @@ class OpenEdxDB:
                     self.University.logo,
                 )
             )
-            .slice(start, stop)
+            .slice(start, start + stop)
         )
         return self.session.scalars(query).all()
 
@@ -154,7 +154,7 @@ class OpenEdxDB:
                     self.Course.language,
                 ),
             )
-            .slice(start, stop)
+            .slice(start, start + stop)
         )
         return self.session.scalars(query).all()
 
@@ -221,7 +221,7 @@ class OpenEdxDB:
                     self.UserProfile.name,
                 ),
             )
-            .slice(start, stop)
+            .slice(start, start + stop)
         )
         return self.session.scalars(query).unique().all()
 
@@ -300,7 +300,7 @@ class OpenEdxDB:
                     self.User.username,
                 ),
             )
-            .slice(start, stop)
+            .slice(start, start + stop)
         )
         return self.session.scalars(query).all()
 
@@ -347,6 +347,6 @@ class OpenEdxDB:
                 )
             )
             .where(self.Certificate.status == "downloadable")
-            .slice(start, stop)
+            .slice(start, start + stop)
         )
         return self.session.scalars(query).all()

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -259,7 +259,7 @@ class OpenEdxDB:
             return min(enrollments_count, limit)
         return enrollments_count
 
-    def get_enrollments(self, start, stop, course_id=None):
+    def get_enrollments(self, offset, limit, course_id=None):
         """
         Get enrollments from Open edX database by slicing
 
@@ -309,8 +309,8 @@ class OpenEdxDB:
                 ),
             )
             .order_by(self.StudentCourseEnrollment.course_id)
-            .offset(start)
-            .limit(stop)
+            .offset(offset)
+            .limit(limit)
         )
         if course_id:
             query = query.where(self.StudentCourseEnrollment.course_id == course_id)

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -178,7 +178,7 @@ class OpenEdxDB:
             return min(users_count, limit)
         return users_count
 
-    def get_users(self, start, stop):
+    def get_users(self, offset, limit):
         """
         Get users from Open edX database by slicing
 
@@ -224,8 +224,8 @@ class OpenEdxDB:
                     self.UserProfile.name,
                 ),
             )
-            .offset(start)
-            .limit(stop)
+            .offset(offset)
+            .limit(limit)
         )
         return self.session.scalars(query).unique().all()
 

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -335,7 +335,7 @@ class OpenEdxDB:
             return min(certificates_count, limit)
         return certificates_count
 
-    def get_certificates(self, start, stop, course_id=None):
+    def get_certificates(self, offset, limit, course_id=None):
         """
         Get downloadable certificates from Open edX database by slicing
 
@@ -362,8 +362,8 @@ class OpenEdxDB:
             )
             .where(self.Certificate.status == "downloadable")
             .order_by(self.Certificate.course_id)
-            .offset(start)
-            .limit(stop)
+            .offset(offset)
+            .limit(limit)
         )
         if course_id:
             query = query.where(self.Certificate.course_id == course_id)

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -157,7 +157,6 @@ class OpenEdxDB:
                     self.Course.language,
                 ),
             )
-            .order_by(self.CourseOverview.id)
             .offset(offset)
             .limit(limit)
         )
@@ -310,7 +309,6 @@ class OpenEdxDB:
                     self.User.username,
                 ),
             )
-            .order_by(self.StudentCourseEnrollment.course_id)
             .offset(offset)
             .limit(limit)
         )
@@ -363,7 +361,6 @@ class OpenEdxDB:
                 )
             )
             .where(self.Certificate.status == "downloadable")
-            .order_by(self.Certificate.course_id)
             .offset(offset)
             .limit(limit)
         )

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -94,7 +94,8 @@ class OpenEdxDB:
                     self.University.logo,
                 )
             )
-            .slice(start, start + stop)
+            .offset(start)
+            .limit(stop)
         )
         return self.session.scalars(query).all()
 
@@ -155,7 +156,8 @@ class OpenEdxDB:
                 ),
             )
             .order_by(self.CourseOverview.id)
-            .slice(start, start + stop)
+            .offset(start)
+            .limit(stop)
         )
         return self.session.scalars(query).all()
 
@@ -222,7 +224,8 @@ class OpenEdxDB:
                     self.UserProfile.name,
                 ),
             )
-            .slice(start, start + stop)
+            .offset(start)
+            .limit(stop)
         )
         return self.session.scalars(query).unique().all()
 
@@ -306,7 +309,8 @@ class OpenEdxDB:
                 ),
             )
             .order_by(self.StudentCourseEnrollment.course_id)
-            .slice(start, start + stop)
+            .offset(start)
+            .limit(stop)
         )
         if course_id:
             query = query.where(self.StudentCourseEnrollment.course_id == course_id)
@@ -358,7 +362,8 @@ class OpenEdxDB:
             )
             .where(self.Certificate.status == "downloadable")
             .order_by(self.Certificate.course_id)
-            .slice(start, start + stop)
+            .offset(start)
+            .limit(stop)
         )
         if course_id:
             query = query.where(self.Certificate.course_id == course_id)

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -46,7 +46,9 @@ class OpenEdxDB:
                 port=settings.EDX_DATABASE_PORT,
                 database=settings.EDX_DATABASE_NAME,
             )
-            self.engine = create_engine(url, echo=settings.EDX_DATABASE_DEBUG)
+            self.engine = create_engine(
+                url, echo=settings.EDX_DATABASE_DEBUG, pool_pre_ping=True
+            )
         if session is not None:
             self.session = session
         else:

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -226,7 +226,7 @@ class OpenEdxDB:
         )
         return self.session.scalars(query).unique().all()
 
-    def get_enrollments_count(self, offset=0, limit=0):
+    def get_enrollments_count(self, offset=0, limit=0, course_id=None):
         """
         Get enrollments count from Open edX database
 
@@ -246,13 +246,17 @@ class OpenEdxDB:
             )
             .join(self.User, self.StudentCourseEnrollment.user_id == self.User.id)
         )
+        if course_id:
+            query_count = query_count.where(
+                self.StudentCourseEnrollment.course_id == course_id
+            )
         enrollments_count = self.session.execute(query_count).scalar()
         enrollments_count -= offset
         if limit:
             return min(enrollments_count, limit)
         return enrollments_count
 
-    def get_enrollments(self, start, stop):
+    def get_enrollments(self, start, stop, course_id=None):
         """
         Get enrollments from Open edX database by slicing
 
@@ -304,9 +308,11 @@ class OpenEdxDB:
             .order_by(self.StudentCourseEnrollment.course_id)
             .slice(start, start + stop)
         )
+        if course_id:
+            query = query.where(self.StudentCourseEnrollment.course_id == course_id)
         return self.session.scalars(query).all()
 
-    def get_certificates_count(self, offset=0, limit=0):
+    def get_certificates_count(self, offset=0, limit=0, course_id=None):
         """
         Get downloadable certificates count from Open edX database
 
@@ -317,13 +323,15 @@ class OpenEdxDB:
         query_count = select(count(self.Certificate.id)).where(
             self.Certificate.status == "downloadable"
         )
+        if course_id:
+            query_count = query_count.where(self.Certificate.course_id == course_id)
         certificates_count = self.session.execute(query_count).scalar()
         certificates_count -= offset
         if limit:
             return min(certificates_count, limit)
         return certificates_count
 
-    def get_certificates(self, start, stop):
+    def get_certificates(self, start, stop, course_id=None):
         """
         Get downloadable certificates from Open edX database by slicing
 
@@ -352,4 +360,6 @@ class OpenEdxDB:
             .order_by(self.Certificate.course_id)
             .slice(start, start + stop)
         )
+        if course_id:
+            query = query.where(self.Certificate.course_id == course_id)
         return self.session.scalars(query).all()

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -70,7 +70,9 @@ class OpenEdxDB:
         SELECT count(universities_university.id) AS count_1
         FROM universities_university
         """
-        query_count = select(count(self.University.id))
+        query_count = select(count(self.University.id)).prefix_with(
+            "SQL_NO_CACHE", dialect="mysql"
+        )
         universities_count = self.session.execute(query_count).scalar()
         universities_count -= offset
         if limit:
@@ -89,6 +91,7 @@ class OpenEdxDB:
         """
         query = (
             select(self.University)
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
             .options(
                 load_only(
                     self.University.code,
@@ -108,9 +111,13 @@ class OpenEdxDB:
         SELECT count(course_overviews_courseoverview.id) AS count_1
         FROM course_overviews_courseoverview
         """
-        query_count = select(count(self.CourseOverview.id)).join(
-            self.Course,
-            self.CourseOverview.id == self.Course.key,
+        query_count = (
+            select(count(self.CourseOverview.id))
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
+            .join(
+                self.Course,
+                self.CourseOverview.id == self.Course.key,
+            )
         )
         course_overviews_count = self.session.execute(query_count).scalar()
         course_overviews_count -= offset
@@ -139,6 +146,7 @@ class OpenEdxDB:
         """
         query = (
             select(self.CourseOverview, self.Course.language)
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
             .join(
                 self.Course,
                 self.CourseOverview.id == self.Course.key,
@@ -170,8 +178,10 @@ class OpenEdxDB:
         FROM auth_user
                  JOIN auth_userprofile ON auth_user.id = auth_userprofile.user_id
         """
-        query_count = select(count(distinct(self.User.id))).join(
-            self.UserProfile, self.User.id == self.UserProfile.user_id
+        query_count = (
+            select(count(distinct(self.User.id)))
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
+            .join(self.UserProfile, self.User.id == self.UserProfile.user_id)
         )
         users_count = self.session.execute(query_count).scalar()
         users_count -= offset
@@ -206,6 +216,7 @@ class OpenEdxDB:
         """
         query = (
             select(self.User, self.UserProfile.name)
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
             .join(self.UserProfile, self.User.id == self.UserProfile.user_id)
             .options(
                 load_only(
@@ -244,6 +255,7 @@ class OpenEdxDB:
         """
         query_count = (
             select(count(self.StudentCourseEnrollment.id))
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
             .join(
                 self.CourseOverview,
                 self.StudentCourseEnrollment.course_id == self.CourseOverview.id,
@@ -293,6 +305,7 @@ class OpenEdxDB:
         """
         query = (
             select(self.StudentCourseEnrollment, self.User)
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
             .join(
                 self.CourseOverview,
                 self.StudentCourseEnrollment.course_id == self.CourseOverview.id,
@@ -324,8 +337,10 @@ class OpenEdxDB:
         FROM generated_certificate
         WHERE generated_certificate.status = "downloadable"
         """
-        query_count = select(count(self.Certificate.id)).where(
-            self.Certificate.status == "downloadable"
+        query_count = (
+            select(count(self.Certificate.id))
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
+            .where(self.Certificate.status == "downloadable")
         )
         if course_id:
             query_count = query_count.where(self.Certificate.course_id == course_id)
@@ -351,6 +366,7 @@ class OpenEdxDB:
         """
         query = (
             select(self.Certificate)
+            .prefix_with("SQL_NO_CACHE", dialect="mysql")
             .options(
                 load_only(
                     self.Certificate.id,

--- a/src/backend/joanie/edx_imports/edx_database.py
+++ b/src/backend/joanie/edx_imports/edx_database.py
@@ -154,6 +154,7 @@ class OpenEdxDB:
                     self.Course.language,
                 ),
             )
+            .order_by(self.CourseOverview.id)
             .slice(start, start + stop)
         )
         return self.session.scalars(query).all()
@@ -300,6 +301,7 @@ class OpenEdxDB:
                     self.User.username,
                 ),
             )
+            .order_by(self.StudentCourseEnrollment.course_id)
             .slice(start, start + stop)
         )
         return self.session.scalars(query).all()
@@ -347,6 +349,7 @@ class OpenEdxDB:
                 )
             )
             .where(self.Certificate.status == "downloadable")
+            .order_by(self.Certificate.course_id)
             .slice(start, start + stop)
         )
         return self.session.scalars(query).all()

--- a/src/backend/joanie/edx_imports/edx_factories.py
+++ b/src/backend/joanie/edx_imports/edx_factories.py
@@ -11,7 +11,7 @@ from joanie.core import enums
 from joanie.edx_imports import edx_models
 
 faker = Faker()
-engine = create_engine("sqlite+pysqlite:///:memory:", echo=True)
+engine = create_engine("sqlite+pysqlite:///:memory:", echo=False)
 session = Session(engine)
 registry().metadata.create_all(engine)
 

--- a/src/backend/joanie/edx_imports/edx_factories.py
+++ b/src/backend/joanie/edx_imports/edx_factories.py
@@ -11,7 +11,7 @@ from joanie.core import enums
 from joanie.edx_imports import edx_models
 
 faker = Faker()
-engine = create_engine("sqlite+pysqlite:///:memory:", echo=False)
+engine = create_engine("sqlite+pysqlite:///:memory:", echo=False, pool_pre_ping=True)
 session = Session(engine)
 registry().metadata.create_all(engine)
 

--- a/src/backend/joanie/edx_imports/edx_models.py
+++ b/src/backend/joanie/edx_imports/edx_models.py
@@ -12,6 +12,16 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 class Base(DeclarativeBase):
     """Base class for all models in the database."""
 
+    filtered_attrs = []
+
+    def safe_dict(self):
+        """Return a dictionary representation of the model."""
+        return {
+            c.name: getattr(self, c.name)
+            for c in self.__table__.columns
+            if c.name not in self.filtered_attrs
+        }
+
 
 class User(Base):
     """Model for the `auth_user` table."""
@@ -21,6 +31,8 @@ class User(Base):
         Index("email", "email", unique=True),
         Index("username", "username", unique=True),
     )
+
+    filtered_attrs = ["password", "username", "email"]
 
     id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
     username: Mapped[str] = mapped_column(String(30))
@@ -64,6 +76,20 @@ class UserProfile(Base):
         Index("auth_userprofile_fca3d292", "gender"),
         Index("user_id", "user_id", unique=True),
     )
+
+    filtered_attrs = [
+        "mailing_address",
+        "name",
+        "gender",
+        "year_of_birth",
+        "bio",
+        "country",
+        "goals",
+        "city",
+        "level_of_education",
+        "location",
+        "language",
+    ]
 
     id: Mapped[int] = mapped_column(INTEGER(11), primary_key=True)
     user_id: Mapped[int] = mapped_column(INTEGER(11))

--- a/src/backend/joanie/edx_imports/edx_mongodb.py
+++ b/src/backend/joanie/edx_imports/edx_mongodb.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from pymongo import MongoClient
 
 
-def get_enrollment(course_id):
-    """Get enrollment from mongodb"""
+def get_signature_from_enrollment(course_id):
+    """Get signature from mongodb enrollment"""
     client = MongoClient(
         host=settings.EDX_MONGODB_HOST,
         port=settings.EDX_MONGODB_PORT,
@@ -23,11 +23,6 @@ def get_enrollment(course_id):
     )
 
     try:
-        organization_code = mongo_enrollment.get("_id").get("org") or None
-    except AttributeError:
-        organization_code = None
-
-    try:
         signatory = (
             mongo_enrollment.get("metadata")
             .get("certificates")
@@ -37,4 +32,4 @@ def get_enrollment(course_id):
     except (AttributeError, IndexError):
         signatory = None
 
-    return organization_code, signatory
+    return signatory

--- a/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
+++ b/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
@@ -42,9 +42,9 @@ class Command(BaseCommand):
             default=0,
         )
         parser.add_argument(
-            "--universities-limit",
+            "--universities-size",
             type=int,
-            help="Limit of universities to import",
+            help="Size of universities to import",
             default=0,
         )
         parser.add_argument(
@@ -128,7 +128,7 @@ class Command(BaseCommand):
         import_all = options["all"]
         universities_import = options["universities"] or import_all
         universities_import_offset = options["universities_offset"]
-        universities_import_limit = options["universities_limit"]
+        universities_import_size = options["universities_size"]
         course_runs_import = options["course_runs"] or import_all
         course_runs_import_offset = options["course_runs_offset"]
         course_runs_import_size = options["course_runs_size"]
@@ -178,8 +178,8 @@ class Command(BaseCommand):
         if universities_import:
             logger.info("Importing universities...")
             import_universities(
-                offset=universities_import_offset,
-                limit=universities_import_limit,
+                global_offset=universities_import_offset,
+                import_size=universities_import_size,
                 dry_run=dry_run,
             )
 

--- a/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
+++ b/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
@@ -82,9 +82,9 @@ class Command(BaseCommand):
             default=0,
         )
         parser.add_argument(
-            "--enrollments-limit",
+            "--enrollments-size",
             type=int,
-            help="Limit of enrollments to import",
+            help="Size of enrollments to import",
             default=0,
         )
         parser.add_argument(
@@ -137,7 +137,7 @@ class Command(BaseCommand):
         users_import_size = options["users_size"]
         enrollments_import = options["enrollments"] or import_all
         enrollments_import_offset = options["enrollments_offset"]
-        enrollments_import_limit = options["enrollments_limit"]
+        enrollments_import_size = options["enrollments_size"]
         certificates_import = options["certificates"] or import_all
         certificates_import_offset = options["certificates_offset"]
         certificates_import_limit = options["certificates_limit"]
@@ -205,8 +205,8 @@ class Command(BaseCommand):
             logger.info("Importing enrollments...")
             import_enrollments(
                 batch_size=batch_size,
-                offset=enrollments_import_offset,
-                limit=enrollments_import_limit,
+                global_offset=enrollments_import_offset,
+                import_size=enrollments_import_size,
                 course_id=course_id,
                 dry_run=dry_run,
             )

--- a/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
+++ b/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
@@ -5,6 +5,7 @@ import logging
 from django.core.management import BaseCommand
 
 from joanie.edx_imports.checks import (
+    check_course_sync_env,
     check_import_db_connections,
     check_import_env,
     check_openedx_host,
@@ -141,6 +142,7 @@ class Command(BaseCommand):
         if not skip_check:
             logger.info("Checking the environment and database connections...")
             check_result = check_import_env(self.style)
+            check_result = check_course_sync_env(self.style) and check_result
             check_result = check_openedx_host(self.style) and check_result
             check_result = check_import_db_connections(self.style) and check_result
             if not check_result:

--- a/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
+++ b/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
@@ -102,6 +102,11 @@ class Command(BaseCommand):
             help="Limit of certificates to import",
             default=0,
         )
+        parser.add_argument(
+            "--course-id",
+            type=str,
+            help="Course id to import enrollments and certificates",
+        )
         parser.add_argument("--all", action="store_true", help="Import all")
         parser.add_argument(
             "--batch-size",
@@ -136,6 +141,7 @@ class Command(BaseCommand):
         certificates_import = options["certificates"] or import_all
         certificates_import_offset = options["certificates_offset"]
         certificates_import_limit = options["certificates_limit"]
+        course_id = options["course_id"]
         batch_size = options["batch_size"]
         dry_run = options["dry_run"]
 
@@ -200,6 +206,7 @@ class Command(BaseCommand):
                 batch_size=batch_size,
                 offset=enrollments_import_offset,
                 limit=enrollments_import_limit,
+                course_id=course_id,
                 dry_run=dry_run,
             )
 
@@ -209,5 +216,6 @@ class Command(BaseCommand):
                 batch_size=batch_size,
                 offset=certificates_import_offset,
                 limit=certificates_import_limit,
+                course_id=course_id,
                 dry_run=dry_run,
             )

--- a/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
+++ b/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
@@ -97,9 +97,9 @@ class Command(BaseCommand):
             default=0,
         )
         parser.add_argument(
-            "--certificates-limit",
+            "--certificates-size",
             type=int,
-            help="Limit of certificates to import",
+            help="Size of certificates to import",
             default=0,
         )
         parser.add_argument(
@@ -140,7 +140,7 @@ class Command(BaseCommand):
         enrollments_import_size = options["enrollments_size"]
         certificates_import = options["certificates"] or import_all
         certificates_import_offset = options["certificates_offset"]
-        certificates_import_limit = options["certificates_limit"]
+        certificates_import_size = options["certificates_size"]
         course_id = options["course_id"]
         batch_size = options["batch_size"]
         dry_run = options["dry_run"]
@@ -215,8 +215,8 @@ class Command(BaseCommand):
             logger.info("Importing certificates...")
             import_certificates(
                 batch_size=batch_size,
-                offset=certificates_import_offset,
-                limit=certificates_import_limit,
+                global_offset=certificates_import_offset,
+                import_size=certificates_import_size,
                 course_id=course_id,
                 dry_run=dry_run,
             )

--- a/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
+++ b/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
@@ -70,7 +70,7 @@ class Command(BaseCommand):
             default=0,
         )
         parser.add_argument(
-            "--users-limit", type=int, help="Limit of users to import", default=0
+            "--users-size", type=int, help="Size of users to import", default=0
         )
         parser.add_argument(
             "--enrollments", action="store_true", help="Import enrollments"
@@ -134,7 +134,7 @@ class Command(BaseCommand):
         course_runs_import_size = options["course_runs_size"]
         users_import = options["users"] or import_all
         users_import_offset = options["users_offset"]
-        users_import_limit = options["users_limit"]
+        users_import_size = options["users_size"]
         enrollments_import = options["enrollments"] or import_all
         enrollments_import_offset = options["enrollments_offset"]
         enrollments_import_limit = options["enrollments_limit"]
@@ -196,8 +196,8 @@ class Command(BaseCommand):
             logger.info("Importing users...")
             import_users(
                 batch_size=batch_size,
-                offset=users_import_offset,
-                limit=users_import_limit,
+                global_offset=users_import_offset,
+                import_size=users_import_size,
                 dry_run=dry_run,
             )
 

--- a/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
+++ b/src/backend/joanie/edx_imports/management/commands/migrate_edx.py
@@ -57,9 +57,9 @@ class Command(BaseCommand):
             default=0,
         )
         parser.add_argument(
-            "--course-runs-limit",
+            "--course-runs-size",
             type=int,
-            help="Limit of course runs to import",
+            help="Size of course runs to import",
             default=0,
         )
         parser.add_argument("--users", action="store_true", help="Import users")
@@ -131,7 +131,7 @@ class Command(BaseCommand):
         universities_import_limit = options["universities_limit"]
         course_runs_import = options["course_runs"] or import_all
         course_runs_import_offset = options["course_runs_offset"]
-        course_runs_import_limit = options["course_runs_limit"]
+        course_runs_import_size = options["course_runs_size"]
         users_import = options["users"] or import_all
         users_import_offset = options["users_offset"]
         users_import_limit = options["users_limit"]
@@ -186,8 +186,9 @@ class Command(BaseCommand):
         if course_runs_import:
             logger.info("Importing course runs...")
             import_course_runs(
-                offset=course_runs_import_offset,
-                limit=course_runs_import_limit,
+                batch_size=batch_size,
+                global_offset=course_runs_import_offset,
+                import_size=course_runs_import_size,
                 dry_run=dry_run,
             )
 

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -37,6 +37,8 @@ def import_certificates(batch_size=1000, offset=0, limit=0, dry_run=False):
         batch_count += 1
         start = current_certificate_index + offset
         stop = current_certificate_index + batch_size
+        if limit:
+            stop = min(stop, limit)
         import_certificates_batch_task.delay(
             start=start, stop=stop, total=certificates_count, dry_run=dry_run
         )

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -98,7 +98,16 @@ def import_certificates_batch(start, stop, total, dry_run=False):
         if not organization_code:
             report["certificates"]["errors"] += 1
             logger.error(
-                "No organization found in mongodb for %s", edx_certificate.course_id
+                "No organization found in mongodb for %s",
+                enrollment.course_run.course.code,
+                extra={
+                    "context": {
+                        "edx_certificate": vars(edx_certificate),
+                        "enrollment": enrollment.to_dict(),
+                        "course_run": enrollment.course_run.to_dict(),
+                        "course": enrollment.course_run.course.to_dict(),
+                    }
+                },
             )
             continue
 
@@ -108,7 +117,17 @@ def import_certificates_batch(start, stop, total, dry_run=False):
             )
         except models.Organization.DoesNotExist:
             report["certificates"]["errors"] += 1
-            logger.error("No organization found for %s", organization_code)
+            logger.error(
+                "No organization found for %s",
+                organization_code,
+                extra={
+                    "context": {
+                        "edx_certificate": vars(edx_certificate),
+                        "enrollment": enrollment.to_dict(),
+                        "course_run": enrollment.course_run.to_dict(),
+                    }
+                },
+            )
             continue
 
         verification_hash = hashids.encode(edx_certificate.id)

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -85,6 +85,10 @@ def import_certificates_batch(start, stop, total, dry_run=False):
             )
             continue
 
+        if models.Certificate.objects.filter(enrollment=enrollment).exists():
+            report["certificates"]["skipped"] += 1
+            continue
+
         organization_code, signatory = edx_mongodb.get_enrollment(
             edx_certificate.course_id
         )
@@ -150,9 +154,6 @@ def import_certificates_batch(start, stop, total, dry_run=False):
         certificate_name = (
             DEGREE if edx_certificate.mode == OPENEDX_MODE_VERIFIED else CERTIFICATE
         )
-        if models.Certificate.objects.filter(enrollment=enrollment).exists():
-            report["certificates"]["skipped"] += 1
-            continue
 
         certificates_to_create.append(
             models.Certificate(

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -94,8 +94,8 @@ def import_certificates_batch(
                     edx_certificate.course_id,
                     extra={
                         "context": {
-                            "edx_certificate": vars(edx_certificate),
-                            "edx_user": vars(edx_certificate.user),
+                            "edx_certificate": edx_certificate.safe_dict(),
+                            "edx_user": edx_certificate.user.safe_dict(),
                         }
                     },
                 )
@@ -126,7 +126,7 @@ def import_certificates_batch(
                     organization_code,
                     extra={
                         "context": {
-                            "edx_certificate": vars(edx_certificate),
+                            "edx_certificate": edx_certificate.safe_dict(),
                             "enrollment": enrollment.to_dict(),
                             "course_run": enrollment.course_run.to_dict(),
                         }
@@ -210,7 +210,7 @@ def import_certificates_batch(
                 extra={
                     "context": {
                         "exception": e,
-                        "edx_certificate": vars(edx_certificate),
+                        "edx_certificate": edx_certificate.safe_dict(),
                     }
                 },
             )

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -103,7 +103,9 @@ def import_certificates_batch(start, stop, total, dry_run=False):
             continue
 
         try:
-            organization = models.Organization.objects.get(code=organization_code)
+            organization = models.Organization.objects.get(
+                code__iexact=organization_code
+            )
         except models.Organization.DoesNotExist:
             report["certificates"]["errors"] += 1
             logger.error("No organization found for %s", organization_code)

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -92,7 +92,7 @@ def import_certificates_batch(start, stop, total, dry_run=False):
             continue
 
         organization_code, signatory = edx_mongodb.get_enrollment(
-            edx_certificate.course_id
+            enrollment.course_run.course.code
         )
 
         if not organization_code:
@@ -153,15 +153,17 @@ def import_certificates_batch(start, stop, total, dry_run=False):
                 ],
             }
 
-        certificate_name = (
+        certificate_template = (
             DEGREE if edx_certificate.mode == OPENEDX_MODE_VERIFIED else CERTIFICATE
         )
 
         certificates_to_create.append(
             models.Certificate(
-                certificate_definition=models.CertificateDefinition.objects.get(
-                    name=certificate_name
-                ),
+                certificate_definition=models.CertificateDefinition.objects.filter(
+                    template=certificate_template
+                )
+                .order_by("created_on")
+                .first(),
                 organization=organization,
                 enrollment=enrollment,
                 issued_on=make_date_aware(edx_certificate.created_date),

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -16,7 +16,12 @@ from joanie.core.enums import CERTIFICATE, DEGREE
 from joanie.core.utils import image_to_base64
 from joanie.edx_imports import edx_mongodb
 from joanie.edx_imports.edx_database import OpenEdxDB
-from joanie.edx_imports.utils import download_and_store, format_percent, make_date_aware
+from joanie.edx_imports.utils import (
+    download_and_store,
+    extract_organization_code,
+    format_percent,
+    make_date_aware,
+)
 from joanie.lms_handler.backends.openedx import OPENEDX_MODE_VERIFIED
 
 logger = getLogger(__name__)
@@ -97,9 +102,10 @@ def import_certificates_batch(start, stop, total, course_id, dry_run=False):
             report["certificates"]["skipped"] += 1
             continue
 
-        organization_code, signatory = edx_mongodb.get_enrollment(
+        signatory = edx_mongodb.get_signature_from_enrollment(
             enrollment.course_run.course.code
         )
+        organization_code = extract_organization_code(edx_certificate.course_id)
 
         if not organization_code:
             report["certificates"]["errors"] += 1

--- a/src/backend/joanie/edx_imports/tasks/course_runs.py
+++ b/src/backend/joanie/edx_imports/tasks/course_runs.py
@@ -15,6 +15,7 @@ from joanie.edx_imports.utils import (
     check_language_code,
     extract_course_number,
     format_date,
+    format_percent,
     make_date_aware,
 )
 
@@ -146,11 +147,15 @@ def import_course_runs_batch(start, stop, total, dry_run=False):
             course_run.save()
 
     courses_import_string = "%s courses created, %s skipped, %s errors"
-    course_runs_import_string = "%s-%s/%s %s course runs created, %s skipped, %s errors"
+    course_runs_import_string = (
+        "%s %s/%s : %s course runs created, %s skipped, %s errors"
+    )
     if dry_run:
         courses_import_string = "Dry run: " + courses_import_string
         course_runs_import_string = "Dry run: " + course_runs_import_string
 
+    stop = min(stop, total)
+    percent = format_percent(stop, total)
     logger.info(
         courses_import_string,
         report["courses"]["created"],
@@ -159,7 +164,7 @@ def import_course_runs_batch(start, stop, total, dry_run=False):
     )
     logger.info(
         course_runs_import_string,
-        start,
+        percent,
         stop,
         total,
         report["course_runs"]["created"],
@@ -167,4 +172,21 @@ def import_course_runs_batch(start, stop, total, dry_run=False):
         report["course_runs"]["errors"],
     )
 
-    return report
+    return (
+        courses_import_string
+        % (
+            report["course_runs"]["created"],
+            report["course_runs"]["skipped"],
+            report["course_runs"]["errors"],
+        )
+        + ", "
+        + course_runs_import_string
+        % (
+            percent,
+            stop,
+            total,
+            report["course_runs"]["created"],
+            report["course_runs"]["skipped"],
+            report["course_runs"]["errors"],
+        )
+    )

--- a/src/backend/joanie/edx_imports/tasks/course_runs.py
+++ b/src/backend/joanie/edx_imports/tasks/course_runs.py
@@ -39,6 +39,8 @@ def import_course_runs(batch_size=1000, offset=0, limit=0, dry_run=False):
         batch_count += 1
         start = current_course_overview_index + offset
         stop = current_course_overview_index + batch_size
+        if limit:
+            stop = min(stop, limit)
         import_course_runs_batch_task.delay(
             start=start, stop=stop, total=course_overviews_count, dry_run=dry_run
         )

--- a/src/backend/joanie/edx_imports/tasks/course_runs.py
+++ b/src/backend/joanie/edx_imports/tasks/course_runs.py
@@ -79,7 +79,7 @@ def import_course_runs_batch(start, stop, total, dry_run=False):
     for edx_course_overview in edx_course_overviews:
         # Select LMS from resource link
         resource_link = (
-            f"https://{settings.EDX_DOMAIN}/courses/{edx_course_overview.id}/course"
+            f"https://{settings.EDX_DOMAIN}/courses/{edx_course_overview.id}/info"
         )
 
         try:

--- a/src/backend/joanie/edx_imports/tasks/course_runs.py
+++ b/src/backend/joanie/edx_imports/tasks/course_runs.py
@@ -157,7 +157,7 @@ def import_course_runs_batch(batch_offset, batch_size, total, dry_run=False):
                 extra={
                     "context": {
                         "exception": e,
-                        "edx_course_overview": vars(edx_course_overview),
+                        "edx_course_overview": edx_course_overview.safe_dict(),
                     }
                 },
             )

--- a/src/backend/joanie/edx_imports/tasks/enrollments.py
+++ b/src/backend/joanie/edx_imports/tasks/enrollments.py
@@ -71,6 +71,15 @@ def import_enrollments_batch(start, stop, total, dry_run=False):
             report["enrollments"]["errors"] += 1
             logger.error("No CourseRun found for %s", edx_enrollment.course_id)
             continue
+        except models.CourseRun.MultipleObjectsReturned:
+            try:
+                course_run = models.CourseRun.objects.only("pk").get(
+                    resource_link__icontains=f"{edx_enrollment.course_id}/info"
+                )
+            except models.CourseRun.DoesNotExist:
+                report["enrollments"]["errors"] += 1
+                logger.error("No CourseRun found for %s", edx_enrollment.course_id)
+                continue
 
         user_name = edx_enrollment.user.username
         try:

--- a/src/backend/joanie/edx_imports/tasks/enrollments.py
+++ b/src/backend/joanie/edx_imports/tasks/enrollments.py
@@ -73,7 +73,7 @@ def import_enrollments_batch(batch_offset, batch_size, total, course_id, dry_run
                 logger.error(
                     "No CourseRun found for %s",
                     edx_enrollment.course_id,
-                    extra={"context": {"edx_enrollment": vars(edx_enrollment)}},
+                    extra={"context": {"edx_enrollment": edx_enrollment.safe_dict()}},
                 )
                 continue
             except models.CourseRun.MultipleObjectsReturned:
@@ -86,7 +86,9 @@ def import_enrollments_batch(batch_offset, batch_size, total, course_id, dry_run
                     logger.error(
                         "No CourseRun found for %s",
                         edx_enrollment.course_id,
-                        extra={"context": {"edx_enrollment": vars(edx_enrollment)}},
+                        extra={
+                            "context": {"edx_enrollment": edx_enrollment.safe_dict()}
+                        },
                     )
                     continue
 
@@ -100,8 +102,8 @@ def import_enrollments_batch(batch_offset, batch_size, total, course_id, dry_run
                     user_name,
                     extra={
                         "context": {
-                            "edx_enrollment": vars(edx_enrollment),
-                            "edx_user": vars(edx_enrollment.user),
+                            "edx_enrollment": edx_enrollment.safe_dict(),
+                            "edx_user": edx_enrollment.user.safe_dict(),
                         }
                     },
                 )
@@ -128,7 +130,10 @@ def import_enrollments_batch(batch_offset, batch_size, total, course_id, dry_run
                 "Error creating Enrollment: %s",
                 e,
                 extra={
-                    "context": {"exception": e, "edx_enrollment": vars(edx_enrollment)}
+                    "context": {
+                        "exception": e,
+                        "edx_enrollment": edx_enrollment.safe_dict(),
+                    }
                 },
             )
             continue

--- a/src/backend/joanie/edx_imports/tasks/universities.py
+++ b/src/backend/joanie/edx_imports/tasks/universities.py
@@ -73,7 +73,11 @@ def import_universities_batch(batch_offset, batch_size, total, dry_run=False):
             )
             report["universities"]["created"] += 1
         except Exception as exc:  # pylint: disable=broad-except
-            logger.error("Unable to import university %s", university.code)
+            logger.error(
+                "Unable to import university %s",
+                university.code,
+                extra={"context": {"university": vars(university)}},
+            )
             logger.exception(exc)
             report["universities"]["errors"] += 1
 

--- a/src/backend/joanie/edx_imports/tasks/universities.py
+++ b/src/backend/joanie/edx_imports/tasks/universities.py
@@ -76,7 +76,7 @@ def import_universities_batch(batch_offset, batch_size, total, dry_run=False):
             logger.error(
                 "Unable to import university %s",
                 university.code,
-                extra={"context": {"university": vars(university)}},
+                extra={"context": {"university": university.safe_dict()}},
             )
             logger.exception(exc)
             report["universities"]["errors"] += 1

--- a/src/backend/joanie/edx_imports/tasks/universities.py
+++ b/src/backend/joanie/edx_imports/tasks/universities.py
@@ -5,7 +5,7 @@ from logging import getLogger
 from joanie.celery_app import app
 from joanie.core import models, utils
 from joanie.edx_imports.edx_database import OpenEdxDB
-from joanie.edx_imports.utils import download_and_store
+from joanie.edx_imports.utils import download_and_store, format_percent
 
 logger = getLogger(__name__)
 
@@ -78,13 +78,15 @@ def import_universities_batch(start, stop, total, dry_run=False):
             logger.exception(exc)
             report["universities"]["errors"] += 1
 
-    import_string = "%s-%s/%s %s universities created, %s skipped, %s errors"
+    import_string = "%s %s/%s : %s universities created, %s skipped, %s errors"
     if dry_run:
         import_string = "Dry run: " + import_string
 
+    stop = min(stop, total)
+    percent = format_percent(stop, total)
     logger.info(
         import_string,
-        start,
+        percent,
         stop,
         total,
         report["universities"]["created"],
@@ -92,4 +94,11 @@ def import_universities_batch(start, stop, total, dry_run=False):
         report["universities"]["errors"],
     )
 
-    return report
+    return import_string % (
+        percent,
+        stop,
+        total,
+        report["universities"]["created"],
+        report["universities"]["skipped"],
+        report["universities"]["errors"],
+    )

--- a/src/backend/joanie/edx_imports/tasks/universities.py
+++ b/src/backend/joanie/edx_imports/tasks/universities.py
@@ -25,6 +25,8 @@ def import_universities(batch_size=1000, offset=0, limit=0, dry_run=False):
         batch_count += 1
         start = current_university_index + offset
         stop = current_university_index + batch_size
+        if limit:
+            stop = min(stop, limit)
         import_universities_batch_task.delay(
             start=start, stop=stop, total=universities_count, dry_run=dry_run
         )

--- a/src/backend/joanie/edx_imports/tasks/users.py
+++ b/src/backend/joanie/edx_imports/tasks/users.py
@@ -27,6 +27,8 @@ def import_users(batch_size=1000, offset=0, limit=0, dry_run=False):
         batch_count += 1
         start = current_user_index + offset
         stop = current_user_index + batch_size
+        if limit:
+            stop = min(stop, limit)
         import_users_batch_task.delay(
             start=start, stop=stop, total=users_count, dry_run=dry_run
         )

--- a/src/backend/joanie/edx_imports/tasks/users.py
+++ b/src/backend/joanie/edx_imports/tasks/users.py
@@ -68,7 +68,7 @@ def import_users_batch(batch_offset, batch_size, total, dry_run=False):
                 logger.error(
                     "Username too long: %s",
                     username,
-                    extra={"context": {"edx_user": vars(edx_user)}},
+                    extra={"context": {"edx_user": edx_user.safe_dict()}},
                 )
                 continue
 
@@ -77,7 +77,7 @@ def import_users_batch(batch_offset, batch_size, total, dry_run=False):
                 logger.error(
                     "Email too long: %s",
                     email,
-                    extra={"context": {"edx_user": vars(edx_user)}},
+                    extra={"context": {"edx_user": edx_user.safe_dict()}},
                 )
                 continue
 
@@ -86,7 +86,7 @@ def import_users_batch(batch_offset, batch_size, total, dry_run=False):
                 logger.error(
                     "First name too long: %s",
                     first_name,
-                    extra={"context": {"edx_user": vars(edx_user)}},
+                    extra={"context": {"edx_user": edx_user.safe_dict()}},
                 )
                 continue
 
@@ -112,7 +112,7 @@ def import_users_batch(batch_offset, batch_size, total, dry_run=False):
                 extra={
                     "context": {
                         "exception": e,
-                        "edx_user": vars(edx_user),
+                        "edx_user": edx_user.safe_dict(),
                     }
                 },
             )

--- a/src/backend/joanie/edx_imports/tasks/users.py
+++ b/src/backend/joanie/edx_imports/tasks/users.py
@@ -9,7 +9,7 @@ from django.contrib.auth.hashers import make_password
 from joanie.celery_app import app
 from joanie.core import models
 from joanie.edx_imports.edx_database import OpenEdxDB
-from joanie.edx_imports.utils import extract_language_code, format_date
+from joanie.edx_imports.utils import extract_language_code, format_date, format_percent
 
 logger = getLogger(__name__)
 
@@ -91,7 +91,7 @@ def import_users_batch(start, stop, total, dry_run=False):
             )
         )
 
-    import_string = "%s-%s/%s %s users created, %s skipped, %s errors"
+    import_string = "%s %s/%s : %s users created, %s skipped, %s errors"
     if dry_run:
         import_string = "Dry run: " + import_string
         report["users"]["created"] += len(users_to_create)
@@ -99,9 +99,11 @@ def import_users_batch(start, stop, total, dry_run=False):
         users_created = models.User.objects.bulk_create(users_to_create)
         report["users"]["created"] += len(users_created)
 
+    stop = min(stop, total)
+    percent = format_percent(stop, total)
     logger.info(
         import_string,
-        start,
+        percent,
         stop,
         total,
         report["users"]["created"],
@@ -110,7 +112,7 @@ def import_users_batch(start, stop, total, dry_run=False):
     )
 
     return import_string % (
-        start,
+        percent,
         stop,
         total,
         report["users"]["created"],

--- a/src/backend/joanie/edx_imports/utils.py
+++ b/src/backend/joanie/edx_imports/utils.py
@@ -76,3 +76,10 @@ def extract_language_code(edx_user):
     except StopIteration:
         language = settings.LANGUAGE_CODE
     return get_language_settings(language).get("code")
+
+
+def format_percent(current, total):
+    """Format a percentage"""
+    percent = (current / total) * 100
+    percent = f"{percent:.3f}%" if percent < 100 else "100%"  # noqa: PLR2004
+    return percent

--- a/src/backend/joanie/edx_imports/utils.py
+++ b/src/backend/joanie/edx_imports/utils.py
@@ -58,6 +58,11 @@ def extract_course_number(course_overview_id):
     return utils.normalize_code(split_course_key(course_overview_id)[1])
 
 
+def extract_organization_code(course_overview_id):
+    """Extract the organization code from a course overview id"""
+    return utils.normalize_code(split_course_key(course_overview_id)[0])
+
+
 def check_language_code(language_code):
     """Return the language code"""
     if language_code not in [language[0] for language in enums.ALL_LANGUAGES]:

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
@@ -113,7 +113,6 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
     @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
-    @responses.activate(assert_all_requests_are_fired=True)
     def test_command_migrate_certificates_update(
         self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
     ):
@@ -148,11 +147,6 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             mongo_enrollments[edx_certificate.id] = (
                 course.organizations.first().code,
                 edx_mongo_signatory,
-            )
-            responses.add(
-                responses.GET,
-                f"https://{settings.EDX_DOMAIN}{edx_mongo_signatory.get('signature_image_path')}",
-                body=SIGNATURE_CONTENT,
             )
 
         mock_get_certificates.return_value = edx_certificates

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
@@ -105,9 +105,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "Starting Celery task, importing certificates...",
-            "10 certificates created, 0 errors",
-            "Done executing Celery importing certificates task...",
+            "0-1000/10 10 certificates created, 0 skipped, 0 errors",
             "1 import certificates tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -171,9 +169,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "Starting Celery task, importing certificates...",
-            "0 certificates created, 0 errors",
-            "Done executing Celery importing certificates task...",
+            "0-1000/10 0 certificates created, 10 skipped, 0 errors",
             "1 import certificates tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -245,9 +241,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "Starting Celery task, importing certificates...",
-            "5 certificates created, 5 errors",
-            "Done executing Celery importing certificates task...",
+            "0-1000/10 5 certificates created, 0 skipped, 5 errors",
             "1 import certificates tasks launched",
         ] + [
             f"No Enrollment found for {edx_certificate.user.username} {edx_certificate.course_id}"
@@ -323,9 +317,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "Starting Celery task, importing certificates...",
-            "5 certificates created, 5 errors",
-            "Done executing Celery importing certificates task...",
+            "0-1000/10 5 certificates created, 0 skipped, 5 errors",
             "1 import certificates tasks launched",
         ] + [
             f"No organization found in mongodb for {edx_certificate.course_id}"

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
@@ -270,7 +270,7 @@ class MigrateOpenEdxCertificatesTestCase(
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=False)
-    def test_command_migrate_certificates_create_dry_run_offset_limit(
+    def test_command_migrate_certificates_create_dry_run_offset_size(
         self,
         mock_get_certificates,
         mock_get_certificates_count,
@@ -335,7 +335,7 @@ class MigrateOpenEdxCertificatesTestCase(
                 "--skip-check",
                 "--certificates",
                 "--certificates-offset=20",
-                "--certificates-limit=10",
+                "--certificates-size=10",
                 "--dry-run",
             )
 
@@ -343,7 +343,7 @@ class MigrateOpenEdxCertificatesTestCase(
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "100% 10/10 : 10 certificates created, 0 skipped, 0 errors",
+            "100% 100/10 : 80 certificates created, 0 skipped, 0 errors",
             "1 import certificates tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
@@ -13,6 +13,7 @@ from django.test import override_settings
 import responses
 
 from joanie.core import factories, models
+from joanie.core.enums import CERTIFICATE, DEGREE
 from joanie.core.utils import image_to_base64
 from joanie.edx_imports import edx_factories
 from joanie.edx_imports.utils import extract_course_number, make_date_aware
@@ -44,8 +45,8 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
 
     def setUp(self):
         super().setUp()
-        factories.CertificateDefinitionFactory.create(name="degree")
-        factories.CertificateDefinitionFactory.create(name="certificate")
+        factories.CertificateDefinitionFactory.create(template=DEGREE)
+        factories.CertificateDefinitionFactory.create(template=CERTIFICATE)
 
     @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
@@ -105,7 +105,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "0-1000/10 10 certificates created, 0 skipped, 0 errors",
+            "100% 10/10 : 10 certificates created, 0 skipped, 0 errors",
             "1 import certificates tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -163,7 +163,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "0-1000/10 0 certificates created, 10 skipped, 0 errors",
+            "100% 10/10 : 0 certificates created, 10 skipped, 0 errors",
             "1 import certificates tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -235,7 +235,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "0-1000/10 5 certificates created, 0 skipped, 5 errors",
+            "100% 10/10 : 5 certificates created, 0 skipped, 5 errors",
             "1 import certificates tasks launched",
         ] + [
             f"No Enrollment found for {edx_certificate.user.username} {edx_certificate.course_id}"
@@ -311,7 +311,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing certificates...",
             "10 certificates to import by batch of 1000",
-            "0-1000/10 5 certificates created, 0 skipped, 5 errors",
+            "100% 10/10 : 5 certificates created, 0 skipped, 5 errors",
             "1 import certificates tasks launched",
         ] + [
             f"No organization found in mongodb for {edx_certificate.course_id}"

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_course_runs.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_course_runs.py
@@ -35,10 +35,8 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing course runs...",
             "10 course_overviews to import by batch of 1000",
-            "Starting Celery task, importing course runs...",
-            "10 courses created, 0 errors",
-            "10 course runs created, 0 errors",
-            "Done executing Celery importing course runs task...",
+            "10 courses created, 0 skipped, 0 errors",
+            "0-1000/10 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -68,10 +66,8 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing course runs...",
             "1 course_overviews to import by batch of 1000",
-            "Starting Celery task, importing course runs...",
-            "1 courses created, 0 errors",
-            "1 course runs created, 0 errors",
-            "Done executing Celery importing course runs task...",
+            "1 courses created, 0 skipped, 0 errors",
+            "0-1000/1 1 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -103,10 +99,8 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing course runs...",
             "1 course_overviews to import by batch of 1000",
-            "Starting Celery task, importing course runs...",
-            "1 courses created, 0 errors",
-            "1 course runs created, 0 errors",
-            "Done executing Celery importing course runs task...",
+            "1 courses created, 0 skipped, 0 errors",
+            "0-1000/1 1 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -134,10 +128,8 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing course runs...",
             "10 course_overviews to import by batch of 1000",
-            "Starting Celery task, importing course runs...",
-            "1 courses created, 0 errors",
-            "10 course runs created, 0 errors",
-            "Done executing Celery importing course runs task...",
+            "1 courses created, 0 skipped, 0 errors",
+            "0-1000/10 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -165,10 +157,8 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing course runs...",
             "10 course_overviews to import by batch of 1000",
-            "Starting Celery task, importing course runs...",
-            "0 courses created, 0 errors",
-            "10 course runs created, 0 errors",
-            "Done executing Celery importing course runs task...",
+            "0 courses created, 0 skipped, 0 errors",
+            "0-1000/10 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -193,10 +183,8 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing course runs...",
             "Dry run: no course run will be imported",
             "10 course_overviews to import by batch of 1000",
-            "Starting Celery task, importing course runs...",
-            "Dry run: 10 courses would be created, 0 errors",
-            "Dry run: 10 course runs would be created, 0 errors",
-            "Done executing Celery importing course runs task...",
+            "Dry run: 10 courses created, 0 skipped, 0 errors",
+            "Dry run: 0-1000/10 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_course_runs.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_course_runs.py
@@ -36,7 +36,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing course runs...",
             "10 course_overviews to import by batch of 1000",
             "10 courses created, 0 skipped, 0 errors",
-            "0-1000/10 10 course runs created, 0 skipped, 0 errors",
+            "100% 10/10 : 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -67,7 +67,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing course runs...",
             "1 course_overviews to import by batch of 1000",
             "1 courses created, 0 skipped, 0 errors",
-            "0-1000/1 1 course runs created, 0 skipped, 0 errors",
+            "100% 1/1 : 1 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -100,7 +100,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing course runs...",
             "1 course_overviews to import by batch of 1000",
             "1 courses created, 0 skipped, 0 errors",
-            "0-1000/1 1 course runs created, 0 skipped, 0 errors",
+            "100% 1/1 : 1 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -129,7 +129,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing course runs...",
             "10 course_overviews to import by batch of 1000",
             "1 courses created, 0 skipped, 0 errors",
-            "0-1000/10 10 course runs created, 0 skipped, 0 errors",
+            "100% 10/10 : 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -158,7 +158,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing course runs...",
             "10 course_overviews to import by batch of 1000",
             "0 courses created, 0 skipped, 0 errors",
-            "0-1000/10 10 course runs created, 0 skipped, 0 errors",
+            "100% 10/10 : 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -184,7 +184,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Dry run: no course run will be imported",
             "10 course_overviews to import by batch of 1000",
             "Dry run: 10 courses created, 0 skipped, 0 errors",
-            "Dry run: 0-1000/10 10 course runs created, 0 skipped, 0 errors",
+            "Dry run: 100% 10/10 : 10 course runs created, 0 skipped, 0 errors",
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_course_runs.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_course_runs.py
@@ -188,3 +188,47 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "1 import course runs tasks launched",
         ]
         self.assertLogsContains(logger, expected)
+
+    @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_course_overviews_count")
+    @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_course_overviews")
+    def test_command_migrate_course_runs_create_dry_run_offset_size(
+        self, mock_get_course_overviews, mock_get_course_overviews_count
+    ):
+        """
+        Test that course runs are not created from the edx course overviews if the dry-run
+        """
+        edx_course_overviews = edx_factories.EdxCourseOverviewFactory.create_batch(80)
+        mock_get_course_overviews.return_value = edx_course_overviews
+        mock_get_course_overviews_count.return_value = len(edx_course_overviews)
+
+        def get_edx_certificates(*args, **kwargs):
+            start = args[0]
+            stop = start + args[1]
+            return edx_course_overviews[start:stop]
+
+        mock_get_course_overviews.side_effect = get_edx_certificates
+        mock_get_course_overviews_count.return_value = 60
+
+        with self.assertLogs() as logger:
+            call_command(
+                "migrate_edx",
+                "--skip-check",
+                "--course-runs",
+                "--course-runs-offset=20",
+                "--course-runs-size=60",
+                "--batch-size=30",
+                "--dry-run",
+            )
+
+        expected = [
+            "Importing data from Open edX database...",
+            "Importing course runs...",
+            "Dry run: no course run will be imported",
+            "60 course_overviews to import by batch of 30",
+            "Dry run: 30 courses created, 0 skipped, 0 errors",
+            "Dry run: 83.333% 50/60 : 30 course runs created, 0 skipped, 0 errors",
+            "Dry run: 30 courses created, 0 skipped, 0 errors",
+            "Dry run: 100% 80/60 : 30 course runs created, 0 skipped, 0 errors",
+            "2 import course runs tasks launched",
+        ]
+        self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_enrollments.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_enrollments.py
@@ -42,9 +42,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing enrollments...",
             "10 enrollments to import by batch of 1000",
-            "Starting Celery task, importing enrollments...",
-            "10 enrollments created, 0 errors",
-            "Done executing Celery importing enrollments task...",
+            "0-1000/10 10 enrollments created, 0 skipped, 0 errors",
             "1 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -77,9 +75,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing enrollments...",
             "1 enrollments to import by batch of 1000",
-            "Starting Celery task, importing enrollments...",
-            "0 enrollments created, 0 errors",
-            "Done executing Celery importing enrollments task...",
+            "0-1000/1 0 enrollments created, 1 skipped, 0 errors",
             "1 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -118,14 +114,12 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing enrollments...",
             "10 enrollments to import by batch of 1000",
-            "Starting Celery task, importing enrollments...",
             f"No CourseRun found for {edx_enrollments_without_course_run[0].course_id}",
             f"No CourseRun found for {edx_enrollments_without_course_run[1].course_id}",
             f"No CourseRun found for {edx_enrollments_without_course_run[2].course_id}",
             f"No CourseRun found for {edx_enrollments_without_course_run[3].course_id}",
             f"No CourseRun found for {edx_enrollments_without_course_run[4].course_id}",
-            "5 enrollments created, 5 errors",
-            "Done executing Celery importing enrollments task...",
+            "0-1000/10 5 enrollments created, 0 skipped, 5 errors",
             "1 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -156,9 +150,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing enrollments...",
             "Dry run: no enrollment will be imported",
             "10 enrollments to import by batch of 1000",
-            "Starting Celery task, importing enrollments...",
-            "Dry run: 10 enrollments would be created, 0 errors",
-            "Done executing Celery importing enrollments task...",
+            "Dry run: 0-1000/10 10 enrollments created, 0 skipped, 0 errors",
             "1 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_enrollments.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_enrollments.py
@@ -42,7 +42,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing enrollments...",
             "10 enrollments to import by batch of 1000",
-            "0-1000/10 10 enrollments created, 0 skipped, 0 errors",
+            "100% 10/10 : 10 enrollments created, 0 skipped, 0 errors",
             "1 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -75,7 +75,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing enrollments...",
             "1 enrollments to import by batch of 1000",
-            "0-1000/1 0 enrollments created, 1 skipped, 0 errors",
+            "100% 1/1 : 0 enrollments created, 1 skipped, 0 errors",
             "1 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -119,7 +119,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             f"No CourseRun found for {edx_enrollments_without_course_run[2].course_id}",
             f"No CourseRun found for {edx_enrollments_without_course_run[3].course_id}",
             f"No CourseRun found for {edx_enrollments_without_course_run[4].course_id}",
-            "0-1000/10 5 enrollments created, 0 skipped, 5 errors",
+            "100% 10/10 : 5 enrollments created, 0 skipped, 5 errors",
             "1 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -132,7 +132,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
         """
         Test that enrollments are not created from the edx enrollments if the dry-run
         """
-        edx_enrollments = edx_factories.EdxEnrollmentFactory.create_batch(10)
+        edx_enrollments = edx_factories.EdxEnrollmentFactory.create_batch(37)
         for edx_enrollment in edx_enrollments:
             factories.CourseRunFactory.create(
                 course__code=extract_course_number(edx_enrollment.course_id),
@@ -143,14 +143,22 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
         mock_get_enrollments_count.return_value = len(edx_enrollments)
 
         with self.assertLogs() as logger:
-            call_command("migrate_edx", "--skip-check", "--enrollments", "--dry-run")
+            call_command(
+                "migrate_edx",
+                "--skip-check",
+                "--enrollments",
+                "--dry-run",
+                "--batch-size=17",
+            )
 
         expected = [
             "Importing data from Open edX database...",
             "Importing enrollments...",
             "Dry run: no enrollment will be imported",
-            "10 enrollments to import by batch of 1000",
-            "Dry run: 0-1000/10 10 enrollments created, 0 skipped, 0 errors",
-            "1 import enrollments tasks launched",
+            "37 enrollments to import by batch of 17",
+            "Dry run: 45.946% 17/37 : 37 enrollments created, 0 skipped, 0 errors",
+            "Dry run: 91.892% 34/37 : 37 enrollments created, 0 skipped, 0 errors",
+            "Dry run: 100% 37/37 : 37 enrollments created, 0 skipped, 0 errors",
+            "3 import enrollments tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_universities.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_universities.py
@@ -65,9 +65,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing universities...",
             "10 universities to import by batch of 1000",
-            "Starting Celery task, importing universities...",
-            "10 universities created, 0 errors",
-            "Done executing Celery importing universities task...",
+            "0-1000/10 10 universities created, 0 skipped, 0 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -102,9 +100,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing universities...",
             "1 universities to import by batch of 1000",
-            "Starting Celery task, importing universities...",
-            "0 universities created, 0 errors",
-            "Done executing Celery importing universities task...",
+            "0-1000/1 0 universities created, 1 skipped, 0 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -138,11 +134,9 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing universities...",
             "1 universities to import by batch of 1000",
-            "Starting Celery task, importing universities...",
             f"Unable to import university {edx_university.code}",
             "{'code': ['This field cannot be null.']}",
-            "0 universities created, 1 errors",
-            "Done executing Celery importing universities task...",
+            "0-1000/1 0 universities created, 0 skipped, 1 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -168,9 +162,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing universities...",
             "Dry run: no university will be imported",
             "10 universities to import by batch of 1000",
-            "Starting Celery task, importing universities...",
-            "Dry run: 10 universities would be created, 0 errors",
-            "Done executing Celery importing universities task...",
+            "Dry run: 0-1000/10 10 universities created, 0 skipped, 0 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_universities.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_universities.py
@@ -65,7 +65,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing universities...",
             "10 universities to import by batch of 1000",
-            "0-1000/10 10 universities created, 0 skipped, 0 errors",
+            "100% 10/10 : 10 universities created, 0 skipped, 0 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -100,7 +100,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing universities...",
             "1 universities to import by batch of 1000",
-            "0-1000/1 0 universities created, 1 skipped, 0 errors",
+            "100% 1/1 : 0 universities created, 1 skipped, 0 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -136,7 +136,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "1 universities to import by batch of 1000",
             f"Unable to import university {edx_university.code}",
             "{'code': ['This field cannot be null.']}",
-            "0-1000/1 0 universities created, 0 skipped, 1 errors",
+            "100% 1/1 : 0 universities created, 0 skipped, 1 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -162,7 +162,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing universities...",
             "Dry run: no university will be imported",
             "10 universities to import by batch of 1000",
-            "Dry run: 0-1000/10 10 universities created, 0 skipped, 0 errors",
+            "Dry run: 100% 10/10 : 10 universities created, 0 skipped, 0 errors",
             "1 import universities tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_users.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_users.py
@@ -32,7 +32,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing users...",
             "10 users to import by batch of 1000",
-            "0-1000/10 10 users created, 0 skipped, 0 errors",
+            "100% 10/10 : 10 users created, 0 skipped, 0 errors",
             "1 import users tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -67,7 +67,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing data from Open edX database...",
             "Importing users...",
             "1 users to import by batch of 1000",
-            "0-1000/11 0 users created, 11 skipped, 0 errors",
+            "100% 11/11 : 0 users created, 11 skipped, 0 errors",
             "1 import users tasks launched",
         ]
         self.assertLogsContains(logger, expected)
@@ -92,7 +92,7 @@ class MigrateOpenEdxTestCase(MigrateOpenEdxBaseTestCase):
             "Importing users...",
             "Dry run: no user will be imported",
             "10 users to import by batch of 1000",
-            "Dry run: 0-1000/10 10 users created, 0 skipped, 0 errors",
+            "Dry run: 100% 10/10 : 10 users created, 0 skipped, 0 errors",
             "1 import users tasks launched",
         ]
         self.assertLogsContains(logger, expected)

--- a/src/backend/joanie/tests/edx_imports/test_edx_database.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_database.py
@@ -207,7 +207,7 @@ class OpenEdxDBTestCase(TestCase):
                 EdxEnrollmentFactory(
                     course_id=edx_course_overview.id, user_id=edx_user.id, user=edx_user
                 )
-        enrollments = self.db.get_enrollments(start=0, stop=9)
+        enrollments = self.db.get_enrollments(offset=0, limit=9)
 
         self.assertEqual(len(enrollments), 9)
 
@@ -220,7 +220,7 @@ class OpenEdxDBTestCase(TestCase):
                 EdxEnrollmentFactory(
                     course_id=edx_course_overview.id, user_id=edx_user.id, user=edx_user
                 )
-        enrollments = self.db.get_enrollments(start=20, stop=10)
+        enrollments = self.db.get_enrollments(offset=20, limit=10)
 
         self.assertEqual(len(enrollments), len(edx_course_overviews[20:30]))
 

--- a/src/backend/joanie/tests/edx_imports/test_edx_database.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_database.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-public-methods
 """Module for testing the Open edX database class."""
 
 from django.test import TestCase
@@ -99,9 +100,9 @@ class OpenEdxDBTestCase(TestCase):
         """Test the get_users_count method with an offset and a limit."""
         EdxUserFactory.create_batch(10)
 
-        users_count = self.db.get_users_count(offset=1, limit=5)
+        users_count = self.db.get_users_count(offset=8, limit=5)
 
-        self.assertEqual(users_count, 5)
+        self.assertEqual(users_count, 2)
 
     def test_edx_database_get_users(self):
         """Test the get_users method."""
@@ -152,6 +153,16 @@ class OpenEdxDBTestCase(TestCase):
 
         self.assertEqual(enrollments_count, 3)
 
+    def test_edx_database_get_enrollments_count_offset_limit(self):
+        """Test the get_enrollments_count method."""
+        edx_course_overviews = EdxCourseOverviewFactory.create_batch(100)
+        for edx_course_overview in edx_course_overviews:
+            EdxEnrollmentFactory(course_id=edx_course_overview.id)
+
+        enrollments_count = self.db.get_enrollments_count(offset=20, limit=10)
+
+        self.assertEqual(enrollments_count, 10)
+
     def test_edx_database_get_enrollments_count_empty(self):
         """Test the get_enrollments_count method when there are no enrollments."""
         enrollments_count = self.db.get_enrollments_count()
@@ -170,6 +181,19 @@ class OpenEdxDBTestCase(TestCase):
         enrollments = self.db.get_enrollments(start=0, stop=9)
 
         self.assertEqual(len(enrollments), 9)
+
+    def test_edx_database_get_enrollments_offset_limit(self):
+        """Test the get_enrollments method."""
+        edx_course_overviews = EdxCourseOverviewFactory.create_batch(100)
+        edx_users = EdxUserFactory.create_batch(3)
+        for edx_course_overview in edx_course_overviews:
+            for edx_user in edx_users:
+                EdxEnrollmentFactory(
+                    course_id=edx_course_overview.id, user_id=edx_user.id, user=edx_user
+                )
+        enrollments = self.db.get_enrollments(start=20, stop=10)
+
+        self.assertEqual(len(enrollments), len(edx_course_overviews[20:30]))
 
     def test_edx_database_get_certificates_count(self):
         """Test the get_certificates_count method."""

--- a/src/backend/joanie/tests/edx_imports/test_edx_database.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_database.py
@@ -86,10 +86,7 @@ class OpenEdxDBTestCase(TestCase):
 
         self.assertEqual(len(course_overviews), 3)
         self.assertEqual(len(edx_course_overviews), 100)
-        self.assertCountEqual(
-            course_overviews,
-            sorted(edx_course_overviews, key=lambda course: course.id)[10:13],
-        )
+        self.assertCountEqual(course_overviews, edx_course_overviews[10:13])
 
     def test_edx_database_get_users_count(self):
         """Test the get_users_count method."""

--- a/src/backend/joanie/tests/edx_imports/test_edx_database.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_database.py
@@ -34,7 +34,7 @@ class OpenEdxDBTestCase(TestCase):
         """Test the get_universities method."""
         edx_universities = EdxUniversityFactory.create_batch(3)
 
-        universities = self.db.get_universities(start=0, stop=9)
+        universities = self.db.get_universities(offset=0, limit=9)
 
         self.assertEqual(len(universities), 3)
         self.assertEqual(len(edx_universities), 3)
@@ -42,7 +42,7 @@ class OpenEdxDBTestCase(TestCase):
 
     def test_edx_database_get_universities_empty(self):
         """Test the get_universities method when there are no universities."""
-        universities = self.db.get_universities(start=0, stop=9)
+        universities = self.db.get_universities(offset=0, limit=9)
 
         self.assertEqual(universities, [])
 

--- a/src/backend/joanie/tests/edx_imports/test_edx_database.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_database.py
@@ -46,11 +46,27 @@ class OpenEdxDBTestCase(TestCase):
 
         self.assertEqual(universities, [])
 
+    def test_edx_database_get_course_overviews_count(self):
+        """Test the get_course_overviews method."""
+        EdxCourseOverviewFactory.create_batch(3)
+
+        course_overviews_count = self.db.get_course_overviews_count()
+
+        self.assertEqual(course_overviews_count, 3)
+
+    def test_edx_database_get_course_overviews_count_offset_limit(self):
+        """Test the get_course_overviews method."""
+        EdxCourseOverviewFactory.create_batch(100)
+
+        course_overviews_count = self.db.get_course_overviews_count(offset=10, limit=30)
+
+        self.assertEqual(course_overviews_count, 30)
+
     def test_edx_database_get_course_overviews(self):
         """Test the get_course_overviews method."""
         edx_course_overviews = EdxCourseOverviewFactory.create_batch(3)
 
-        course_overviews = self.db.get_course_overviews(start=0, stop=9)
+        course_overviews = self.db.get_course_overviews(offset=0, limit=9)
 
         self.assertEqual(len(course_overviews), 3)
         self.assertEqual(len(edx_course_overviews), 3)
@@ -58,9 +74,22 @@ class OpenEdxDBTestCase(TestCase):
 
     def test_edx_database_get_course_overviews_empty(self):
         """Test the get_course_overviews method when there are no course_overviews."""
-        course_overviews = self.db.get_course_overviews(start=0, stop=9)
+        course_overviews = self.db.get_course_overviews(offset=0, limit=9)
 
         self.assertEqual(course_overviews, [])
+
+    def test_edx_database_get_course_overviews_offset_limit(self):
+        """Test the get_course_overviews method."""
+        edx_course_overviews = EdxCourseOverviewFactory.create_batch(100)
+
+        course_overviews = self.db.get_course_overviews(offset=10, limit=3)
+
+        self.assertEqual(len(course_overviews), 3)
+        self.assertEqual(len(edx_course_overviews), 100)
+        self.assertCountEqual(
+            course_overviews,
+            sorted(edx_course_overviews, key=lambda course: course.id)[10:13],
+        )
 
     def test_edx_database_get_users_count(self):
         """Test the get_users_count method."""

--- a/src/backend/joanie/tests/edx_imports/test_edx_database.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_database.py
@@ -142,7 +142,7 @@ class OpenEdxDBTestCase(TestCase):
         edx_user_no_preference = EdxUserFactory(user_api_userpreference=None)
         edx_users.append(edx_user_no_preference)
 
-        users = self.db.get_users(start=0, stop=9)
+        users = self.db.get_users(offset=0, limit=9)
 
         self.assertEqual(len(edx_users), 4, "Expected 4 edx_users")
         self.assertEqual(len(users), 4, "Expected 4 users")
@@ -150,7 +150,7 @@ class OpenEdxDBTestCase(TestCase):
 
     def test_edx_database_get_users_empty(self):
         """Test the get_users method when there are no users."""
-        users = self.db.get_users(start=0, stop=9)
+        users = self.db.get_users(offset=0, limit=9)
 
         self.assertEqual(users, [])
 
@@ -158,7 +158,7 @@ class OpenEdxDBTestCase(TestCase):
         """Test the get_users method with a slice."""
         edx_users = EdxUserFactory.create_batch(3)
 
-        users = self.db.get_users(start=0, stop=2)
+        users = self.db.get_users(offset=0, limit=2)
 
         self.assertEqual(len(users), 2)
         self.assertEqual(len(edx_users), 3)
@@ -168,7 +168,7 @@ class OpenEdxDBTestCase(TestCase):
         """Test the get_users method with a slice when there are no users."""
         EdxUserFactory.create_batch(3)
 
-        users = self.db.get_users(start=3, stop=9)
+        users = self.db.get_users(offset=3, limit=9)
 
         self.assertEqual(users, [])
 

--- a/src/backend/joanie/tests/edx_imports/test_edx_database.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_database.py
@@ -242,7 +242,7 @@ class OpenEdxDBTestCase(TestCase):
         )
         EdxGeneratedCertificateFactory.create_batch(3, status="unavailable")
 
-        certificates = self.db.get_certificates(start=0, stop=9)
+        certificates = self.db.get_certificates(offset=0, limit=9)
 
         self.assertEqual(len(certificates), 3)
         self.assertEqual(len(edx_certificates_downloadable), 3)

--- a/src/backend/joanie/tests/edx_imports/test_edx_models.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_models.py
@@ -1,0 +1,221 @@
+"""Module for testing the Open edX models."""
+# pylint: disable=protected-access
+
+from django.test import TestCase
+
+from joanie.edx_imports import edx_factories
+
+
+class OpenEdxModelsTestCase(TestCase):
+    """Test case for the Open edX models."""
+
+    def test_edx_models_user_safe_dict(self):
+        """Test the safe_dict method of the EdxUser model."""
+        edx_user = edx_factories.EdxUserFactory()
+
+        self.assertEqual(
+            edx_user.safe_dict(),
+            {
+                "id": edx_user.id,
+                "first_name": edx_user.first_name,
+                "last_name": edx_user.last_name,
+                "is_staff": edx_user.is_staff,
+                "is_active": edx_user.is_active,
+                "is_superuser": edx_user.is_superuser,
+                "date_joined": edx_user.date_joined,
+                "last_login": edx_user.last_login,
+            },
+        )
+
+    def test_edx_models_user_profile_safe_dict(self):
+        """Test the safe_dict method of the EdxUserProfile model."""
+        edx_user_profile = edx_factories.EdxUserProfileFactory()
+
+        self.assertEqual(
+            edx_user_profile.safe_dict(),
+            {
+                "id": edx_user_profile.id,
+                "user_id": edx_user_profile.user_id,
+                "meta": edx_user_profile.meta,
+                "courseware": edx_user_profile.courseware,
+                "allow_certificate": edx_user_profile.allow_certificate,
+                "profile_image_uploaded_at": edx_user_profile.profile_image_uploaded_at,
+            },
+        )
+
+    def test_edx_models_user_preference_safe_dict(self):
+        """Test the safe_dict method of the EdxUserPreference model."""
+        edx_user_preference = edx_factories.EdxUserPreferenceFactory()
+
+        self.assertEqual(
+            edx_user_preference.safe_dict(),
+            {
+                "id": edx_user_preference.id,
+                "user_id": edx_user_preference.user_id,
+                "key": edx_user_preference.key,
+                "value": edx_user_preference.value,
+            },
+        )
+
+    def test_edx_models_course_overview_safe_dict(self):
+        """Test the safe_dict method of the EdxCourseOverview model."""
+        edx_course_overview = edx_factories.EdxCourseOverviewFactory()
+
+        self.assertEqual(
+            edx_course_overview.safe_dict(),
+            {
+                "id": edx_course_overview.id,
+                "_location": edx_course_overview._location,
+                "display_number_with_default": edx_course_overview.display_number_with_default,
+                "display_org_with_default": edx_course_overview.display_org_with_default,
+                "course_image_url": edx_course_overview.course_image_url,
+                "certificates_show_before_end": edx_course_overview.certificates_show_before_end,
+                "has_any_active_web_certificate": (
+                    edx_course_overview.has_any_active_web_certificate
+                ),
+                "cert_name_short": edx_course_overview.cert_name_short,
+                "cert_name_long": edx_course_overview.cert_name_long,
+                "mobile_available": edx_course_overview.mobile_available,
+                "visible_to_staff_only": edx_course_overview.visible_to_staff_only,
+                "_pre_requisite_courses_json": edx_course_overview._pre_requisite_courses_json,
+                "cert_html_view_enabled": edx_course_overview.cert_html_view_enabled,
+                "invitation_only": edx_course_overview.invitation_only,
+                "created": edx_course_overview.created,
+                "modified": edx_course_overview.modified,
+                "version": edx_course_overview.version,
+                "org": edx_course_overview.org,
+                "display_name": edx_course_overview.display_name,
+                "start": edx_course_overview.start,
+                "end": edx_course_overview.end,
+                "advertised_start": edx_course_overview.advertised_start,
+                "facebook_url": edx_course_overview.facebook_url,
+                "social_sharing_url": edx_course_overview.social_sharing_url,
+                "end_of_course_survey_url": edx_course_overview.end_of_course_survey_url,
+                "certificates_display_behavior": edx_course_overview.certificates_display_behavior,
+                "lowest_passing_grade": edx_course_overview.lowest_passing_grade,
+                "days_early_for_beta": edx_course_overview.days_early_for_beta,
+                "enrollment_start": edx_course_overview.enrollment_start,
+                "enrollment_end": edx_course_overview.enrollment_end,
+                "enrollment_domain": edx_course_overview.enrollment_domain,
+                "max_student_enrollments_allowed": (
+                    edx_course_overview.max_student_enrollments_allowed
+                ),
+                "announcement": edx_course_overview.announcement,
+                "catalog_visibility": edx_course_overview.catalog_visibility,
+                "course_video_url": edx_course_overview.course_video_url,
+                "effort": edx_course_overview.effort,
+                "short_description": edx_course_overview.short_description,
+            },
+        )
+
+    def test_edx_models_course_safe_dict(self):
+        """Test the safe_dict method of the EdxCourse model."""
+        edx_course = edx_factories.EdxCourseFactory()
+
+        self.assertEqual(
+            edx_course.safe_dict(),
+            {
+                "id": edx_course.id,
+                "key": edx_course.key,
+                "level": edx_course.level,
+                "score": edx_course.score,
+                "is_active": edx_course.is_active,
+                "prevent_auto_update": edx_course.prevent_auto_update,
+                "modification_date": edx_course.modification_date,
+                "title": edx_course.title,
+                "short_description": edx_course.short_description,
+                "image_url": edx_course.image_url,
+                "session_number": edx_course.session_number,
+                "university_display_name": edx_course.university_display_name,
+                "show_in_catalog": edx_course.show_in_catalog,
+                "language": edx_course.language,
+                "show_about_page": edx_course.show_about_page,
+                "start_date": edx_course.start_date,
+                "end_date": edx_course.end_date,
+                "thumbnails_info": edx_course.thumbnails_info,
+                "enrollment_start_date": edx_course.enrollment_start_date,
+                "enrollment_end_date": edx_course.enrollment_end_date,
+                "certificate_passing_grade": edx_course.certificate_passing_grade,
+            },
+        )
+
+    def test_edx_models_universities_safe_dict(self):
+        """Test the safe_dict method of the EdxUniversity model."""
+        edx_university = edx_factories.EdxUniversityFactory()
+
+        self.assertEqual(
+            edx_university.safe_dict(),
+            {
+                "id": edx_university.id,
+                "name": edx_university.name,
+                "slug": edx_university.slug,
+                "code": edx_university.code,
+                "logo": edx_university.logo,
+                "description": edx_university.description,
+                "detail_page_enabled": edx_university.detail_page_enabled,
+                "score": edx_university.score,
+                "short_name": edx_university.short_name,
+                "is_obsolete": edx_university.is_obsolete,
+                "prevent_auto_update": edx_university.prevent_auto_update,
+                "partnership_level": edx_university.partnership_level,
+                "banner": edx_university.banner,
+                "certificate_logo": edx_university.certificate_logo,
+            },
+        )
+
+    def test_edx_models_course_universitiy_relations_safe_dict(self):
+        """Test the safe_dict method of the EdxCourseUniversityRelations model."""
+        edx_course_university_relations = (
+            edx_factories.EdxCourseUniversityRelationFactory()
+        )
+
+        self.assertEqual(
+            edx_course_university_relations.safe_dict(),
+            {
+                "id": edx_course_university_relations.id,
+                "university_id": edx_course_university_relations.university_id,
+                "course_id": edx_course_university_relations.course_id,
+                "order": edx_course_university_relations.order,
+            },
+        )
+
+    def test_edx_models_course_enrollment_safe_dict(self):
+        """Test the safe_dict method of the EdxCourseEnrollment model."""
+        edx_enrollment = edx_factories.EdxEnrollmentFactory()
+
+        self.assertEqual(
+            edx_enrollment.safe_dict(),
+            {
+                "id": edx_enrollment.id,
+                "user_id": edx_enrollment.user_id,
+                "course_id": edx_enrollment.course_id,
+                "is_active": edx_enrollment.is_active,
+                "mode": edx_enrollment.mode,
+                "created": edx_enrollment.created,
+            },
+        )
+
+    def test_edx_models_generated_certificate_safe_dict(self):
+        """Test the safe_dict method of the EdxGeneratedCertificate model."""
+        edx_generated_certificate = edx_factories.EdxGeneratedCertificateFactory()
+
+        self.assertEqual(
+            edx_generated_certificate.safe_dict(),
+            {
+                "id": edx_generated_certificate.id,
+                "user_id": edx_generated_certificate.user_id,
+                "download_url": edx_generated_certificate.download_url,
+                "grade": edx_generated_certificate.grade,
+                "course_id": edx_generated_certificate.course_id,
+                "key": edx_generated_certificate.key,
+                "distinction": edx_generated_certificate.distinction,
+                "status": edx_generated_certificate.status,
+                "verify_uuid": edx_generated_certificate.verify_uuid,
+                "download_uuid": edx_generated_certificate.download_uuid,
+                "name": edx_generated_certificate.name,
+                "created_date": edx_generated_certificate.created_date,
+                "modified_date": edx_generated_certificate.modified_date,
+                "error_reason": edx_generated_certificate.error_reason,
+                "mode": edx_generated_certificate.mode,
+            },
+        )

--- a/src/backend/joanie/tests/edx_imports/test_edx_mongodb.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_mongodb.py
@@ -11,8 +11,8 @@ class TestGetEnrollment(TestCase):
     """Tests for the edx_mongodb module."""
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_enrollment(self, mock_mongo_client):
-        """Test the get_enrollment method."""
+    def test_edx_mongodb_get_signature_from_enrollment(self, mock_mongo_client):
+        """Test the get_signature_from_enrollment method."""
         course_id = "test_course"
         mock_mongo_client.return_value = MagicMock()
         mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
@@ -22,45 +22,15 @@ class TestGetEnrollment(TestCase):
             },
         }
 
-        result = edx_mongodb.get_enrollment(course_id)
+        result = edx_mongodb.get_signature_from_enrollment(course_id)
 
-        self.assertEqual(result, ("test_org", "test_signatory"))
-
-    @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_enrollment_no_org(self, mock_mongo_client):
-        """Test the get_enrollment method when there is no organization."""
-        course_id = "test_course"
-        mock_mongo_client.return_value = MagicMock()
-        mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
-            "_id": {"category": "course", "course": course_id},
-            "metadata": {
-                "certificates": {"certificates": [{"signatories": ["test_signatory"]}]}
-            },
-        }
-
-        result = edx_mongodb.get_enrollment(course_id)
-
-        self.assertEqual(result, (None, "test_signatory"))
+        self.assertEqual(result, "test_signatory")
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_enrollment_empty_org(self, mock_mongo_client):
-        """Test the get_enrollment method when the org is empty."""
-        course_id = "test_course"
-        mock_mongo_client.return_value = MagicMock()
-        mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
-            "_id": {"org": "", "category": "course", "course": course_id},
-            "metadata": {
-                "certificates": {"certificates": [{"signatories": ["test_signatory"]}]}
-            },
-        }
-
-        result = edx_mongodb.get_enrollment(course_id)
-
-        self.assertEqual(result, (None, "test_signatory"))
-
-    @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_enrollment_no_certificates(self, mock_mongo_client):
-        """Test the get_enrollment method when there are no certificates."""
+    def test_edx_mongodb_get_signature_from_enrollment_no_certificates(
+        self, mock_mongo_client
+    ):
+        """Test the get_signature_from_enrollment method when there are no certificates."""
         course_id = "test_course"
         mock_mongo_client.return_value = MagicMock()
         mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
@@ -68,13 +38,15 @@ class TestGetEnrollment(TestCase):
             "metadata": {},
         }
 
-        result = edx_mongodb.get_enrollment(course_id)
+        result = edx_mongodb.get_signature_from_enrollment(course_id)
 
-        self.assertEqual(result, ("test_org", None))
+        self.assertEqual(result, None)
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_enrollment_no_signatories(self, mock_mongo_client):
-        """Test the get_enrollment method when there are no certificates."""
+    def test_edx_mongodb_get_signature_from_enrollment_no_signatories(
+        self, mock_mongo_client
+    ):
+        """Test the get_signature_from_enrollment method when there are no certificates."""
         course_id = "test_course"
         mock_mongo_client.return_value = MagicMock()
         mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
@@ -82,17 +54,19 @@ class TestGetEnrollment(TestCase):
             "metadata": {"certificates": {"certificates": []}},
         }
 
-        result = edx_mongodb.get_enrollment(course_id)
+        result = edx_mongodb.get_signature_from_enrollment(course_id)
 
-        self.assertEqual(result, ("test_org", None))
+        self.assertEqual(result, None)
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_enrollment_no_result(self, mock_mongo_client):
-        """Test the get_enrollment method when there is no enrollment."""
+    def test_edx_mongodb_get_signature_from_enrollment_no_result(
+        self, mock_mongo_client
+    ):
+        """Test the get_signature_from_enrollment method when there is no enrollment."""
         course_id = "test_course"
         mock_mongo_client.return_value = MagicMock()
         mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = None
 
-        result = edx_mongodb.get_enrollment(course_id)
+        result = edx_mongodb.get_signature_from_enrollment(course_id)
 
-        self.assertEqual(result, (None, None))
+        self.assertEqual(result, None)

--- a/src/backend/joanie/tests/edx_imports/test_import_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_certificates.py
@@ -50,8 +50,8 @@ class EdxImportCertificatesTestCase(TestCase):
     def setUp(self):
         """Set up the test case."""
         self.hashids = Hashids(salt=settings.EDX_SECRET)
-        factories.CertificateDefinitionFactory.create(name=DEGREE)
-        factories.CertificateDefinitionFactory.create(name=CERTIFICATE)
+        factories.CertificateDefinitionFactory.create(template=DEGREE)
+        factories.CertificateDefinitionFactory.create(template=CERTIFICATE)
 
     def tearDown(self):
         """Tear down the test case."""
@@ -114,10 +114,12 @@ class EdxImportCertificatesTestCase(TestCase):
                     edx_certificate.course_id
                 ),
             )
-            certificate_name = (
+            certificate_template = (
                 DEGREE if edx_certificate.mode == OPENEDX_MODE_VERIFIED else CERTIFICATE
             )
-            self.assertEqual(certificate.certificate_definition.name, certificate_name)
+            self.assertEqual(
+                certificate.certificate_definition.template, certificate_template
+            )
             self.assertEqual(
                 certificate.organization.code,
                 mongo_enrollments[edx_certificate.id][0],
@@ -207,11 +209,11 @@ class EdxImportCertificatesTestCase(TestCase):
                 course_run=course_run,
                 was_created_by_order=False,
             )
-            certificate_name = (
+            certificate_template = (
                 DEGREE if edx_certificate.mode == OPENEDX_MODE_VERIFIED else CERTIFICATE
             )
             factories.EnrollmentCertificateFactory.create(
-                certificate_definition__name=certificate_name,
+                certificate_definition__template=certificate_template,
                 enrollment=enrollment,
                 issued_on=make_date_aware(edx_certificate.created_date),
             )
@@ -239,10 +241,12 @@ class EdxImportCertificatesTestCase(TestCase):
                     edx_certificate.course_id
                 ),
             )
-            certificate_name = (
+            certificate_template = (
                 DEGREE if edx_certificate.mode == OPENEDX_MODE_VERIFIED else CERTIFICATE
             )
-            self.assertEqual(certificate.certificate_definition.name, certificate_name)
+            self.assertEqual(
+                certificate.certificate_definition.template, certificate_template
+            )
             self.assertNotEqual(
                 certificate.organization.code,
                 mongo_enrollments[edx_certificate.id][0],
@@ -470,10 +474,12 @@ class EdxImportCertificatesTestCase(TestCase):
                     edx_certificate.course_id
                 ),
             )
-            certificate_name = (
+            certificate_template = (
                 DEGREE if edx_certificate.mode == OPENEDX_MODE_VERIFIED else CERTIFICATE
             )
-            self.assertEqual(certificate.certificate_definition.name, certificate_name)
+            self.assertEqual(
+                certificate.certificate_definition.template, certificate_template
+            )
             self.assertEqual(
                 certificate.organization.code,
                 mongo_enrollments[edx_certificate.id][0],
@@ -588,10 +594,12 @@ class EdxImportCertificatesTestCase(TestCase):
                 edx_certificate.course_id
             ),
         )
-        certificate_name = (
+        certificate_template = (
             DEGREE if edx_certificate.mode == OPENEDX_MODE_VERIFIED else CERTIFICATE
         )
-        self.assertEqual(certificate.certificate_definition.name, certificate_name)
+        self.assertEqual(
+            certificate.certificate_definition.template, certificate_template
+        )
         self.assertEqual(
             certificate.organization.code,
             mongo_enrollments[edx_certificate.id][0],

--- a/src/backend/joanie/tests/edx_imports/test_import_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_certificates.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.core.files.storage import default_storage
 from django.test import TestCase, override_settings
 
-import factory
 import responses
 from hashids import Hashids
 
@@ -18,7 +17,11 @@ from joanie.core.enums import CERTIFICATE, DEGREE
 from joanie.core.utils import image_to_base64
 from joanie.edx_imports import edx_factories
 from joanie.edx_imports.tasks.certificates import import_certificates
-from joanie.edx_imports.utils import extract_course_number, make_date_aware
+from joanie.edx_imports.utils import (
+    extract_course_number,
+    extract_organization_code,
+    make_date_aware,
+)
 from joanie.lms_handler.backends.openedx import OPENEDX_MODE_VERIFIED
 
 SIGNATURE_NAME = "creative_common.jpeg"
@@ -58,24 +61,27 @@ class EdxImportCertificatesTestCase(TestCase):
         """Tear down the test case."""
         edx_factories.session.rollback()
 
-    @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
     def test_import_certificates_create(
-        self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
+        self,
+        mock_get_certificates,
+        mock_get_certificates_count,
+        mock_get_signature_from_enrollment,
     ):
         """
         Test that certificates are created from the edx certificates.
         """
         edx_certificates = edx_factories.EdxGeneratedCertificateFactory.create_batch(10)
         mongo_enrollments = {}
-        for i, edx_certificate in enumerate(edx_certificates):
+        for edx_certificate in edx_certificates:
             course = factories.CourseFactory.create(
                 code=extract_course_number(edx_certificate.course_id),
                 organizations=[
                     factories.OrganizationFactory.create(
-                        code=factory.Sequence(lambda n: f"orga{n}")
+                        code=extract_organization_code(edx_certificate.course_id)
                     )
                 ],
             )
@@ -92,12 +98,7 @@ class EdxImportCertificatesTestCase(TestCase):
             )
 
             edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
-            mongo_enrollments[edx_certificate.id] = (
-                course.organizations.first().code.lower()
-                if i % 2 == 0
-                else course.organizations.first().code.upper(),
-                edx_mongo_signatory,
-            )
+            mongo_enrollments[edx_certificate.id] = edx_mongo_signatory
             responses.add(
                 responses.GET,
                 f"https://{settings.EDX_DOMAIN}{edx_mongo_signatory.get('signature_image_path')}",
@@ -106,7 +107,7 @@ class EdxImportCertificatesTestCase(TestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_enrollment.side_effect = [
+        mock_get_signature_from_enrollment.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -128,14 +129,10 @@ class EdxImportCertificatesTestCase(TestCase):
                 certificate.certificate_definition.template, certificate_template
             )
             self.assertEqual(
-                certificate.organization.code.upper(),
-                mongo_enrollments[edx_certificate.id][0].upper(),
-            )
-            self.assertEqual(
                 certificate.issued_on, make_date_aware(edx_certificate.created_date)
             )
 
-            mongo_signatory = mongo_enrollments[edx_certificate.id][1]
+            mongo_signatory = mongo_enrollments[edx_certificate.id]
             self.assertEqual(
                 certificate.localized_context,
                 {
@@ -189,11 +186,14 @@ class EdxImportCertificatesTestCase(TestCase):
                 )
             )
 
-    @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     def test_import_certificates_update(
-        self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
+        self,
+        mock_get_certificates,
+        mock_get_certificates_count,
+        mock_get_signature_from_enrollment,
     ):
         """
         Test that certificates are updated from the edx certificates.
@@ -203,7 +203,11 @@ class EdxImportCertificatesTestCase(TestCase):
         for edx_certificate in edx_certificates:
             course = factories.CourseFactory.create(
                 code=extract_course_number(edx_certificate.course_id),
-                organizations=[factories.OrganizationFactory.create()],
+                organizations=[
+                    factories.OrganizationFactory.create(
+                        code=extract_organization_code(edx_certificate.course_id)
+                    )
+                ],
             )
             course_run = factories.CourseRunFactory.create(
                 course=course,
@@ -226,14 +230,11 @@ class EdxImportCertificatesTestCase(TestCase):
             )
 
             edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
-            mongo_enrollments[edx_certificate.id] = (
-                course.organizations.first().code,
-                edx_mongo_signatory,
-            )
+            mongo_enrollments[edx_certificate.id] = edx_mongo_signatory
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_enrollment.side_effect = [
+        mock_get_signature_from_enrollment.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -256,18 +257,21 @@ class EdxImportCertificatesTestCase(TestCase):
             )
             self.assertNotEqual(
                 certificate.organization.code,
-                mongo_enrollments[edx_certificate.id][0],
+                extract_organization_code(edx_certificate.course_id),
             )
             self.assertNotEqual(
                 certificate.issued_on, make_date_aware(edx_certificate.created_date)
             )
 
-    @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
     def test_import_certificates_create_missing_joanie_enrollments(
-        self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
+        self,
+        mock_get_certificates,
+        mock_get_certificates_count,
+        mock_get_signature_from_enrollment,
     ):
         """
         Test that certificates are not created from the edx certificates if the enrollment
@@ -280,7 +284,11 @@ class EdxImportCertificatesTestCase(TestCase):
         for edx_certificate in edx_certificates:
             course = factories.CourseFactory.create(
                 code=extract_course_number(edx_certificate.course_id),
-                organizations=[factories.OrganizationFactory.create()],
+                organizations=[
+                    factories.OrganizationFactory.create(
+                        code=extract_organization_code(edx_certificate.course_id)
+                    )
+                ],
             )
 
             edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
@@ -306,15 +314,12 @@ class EdxImportCertificatesTestCase(TestCase):
                     f"{edx_mongo_signatory.get('signature_image_path')}",
                     body=SIGNATURE_CONTENT,
                 )
-            mongo_enrollments[edx_certificate.id] = (
-                course.organizations.first().code,
-                edx_mongo_signatory,
-            )
+            mongo_enrollments[edx_certificate.id] = edx_mongo_signatory
             i += 1
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_enrollment.side_effect = [
+        mock_get_signature_from_enrollment.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates_with_joanie_enrollments
         ]
@@ -335,99 +340,33 @@ class EdxImportCertificatesTestCase(TestCase):
                 ).exists()
             )
 
-    @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
-    @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
-    @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
-    @responses.activate(assert_all_requests_are_fired=True)
-    def test_import_certificates_create_missing_mongodb_orga(
-        self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
-    ):
-        """
-        Test that certificates are not created from the edx certificates if the organization
-        is missing in mongodb.
-        """
-        edx_certificates = edx_factories.EdxGeneratedCertificateFactory.create_batch(10)
-        mongo_enrollments = {}
-        edx_certificates_with_mongodb_enrollments = []
-        i = 0
-        for edx_certificate in edx_certificates:
-            course = factories.CourseFactory.create(
-                code=extract_course_number(edx_certificate.course_id),
-                organizations=[factories.OrganizationFactory.create()],
-            )
-            course_run = factories.CourseRunFactory.create(
-                course=course,
-                state=models.CourseState.ONGOING_OPEN,
-                resource_link=f"http://openedx.test/courses/{edx_certificate.course_id}/course/",
-                is_listed=True,
-            )
-            factories.EnrollmentFactory.create(
-                user__username=edx_certificate.user.username,
-                course_run=course_run,
-                was_created_by_order=False,
-            )
-
-            edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
-            if i % 2 == 0:
-                edx_certificates_with_mongodb_enrollments.append(edx_certificate)
-                mongo_enrollments[edx_certificate.id] = (
-                    course.organizations.first().code,
-                    edx_mongo_signatory,
-                )
-                responses.add(
-                    responses.GET,
-                    f"https://{settings.EDX_DOMAIN}"
-                    f"{edx_mongo_signatory.get('signature_image_path')}",
-                    body=SIGNATURE_CONTENT,
-                )
-            else:
-                mongo_enrollments[edx_certificate.id] = (
-                    None,
-                    edx_mongo_signatory,
-                )
-            i += 1
-
-        mock_get_certificates.return_value = edx_certificates
-        mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_enrollment.side_effect = [
-            mongo_enrollments[edx_certificate.id]
-            for edx_certificate in edx_certificates
-        ]
-
-        import_certificates()
-
-        self.assertEqual(
-            models.Certificate.objects.count(),
-            len(edx_certificates_with_mongodb_enrollments),
-        )
-        for edx_certificate in edx_certificates_with_mongodb_enrollments:
-            self.assertTrue(
-                models.Certificate.objects.filter(
-                    enrollment__user__username=edx_certificate.user.username,
-                    enrollment__course_run__course__code=extract_course_number(
-                        edx_certificate.course_id
-                    ),
-                ).exists()
-            )
-
-    @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
     def test_import_certificates_create_missing_mongodb_signatory(
-        self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
+        self,
+        mock_get_certificates,
+        mock_get_certificates_count,
+        mock_get_signature_from_enrollment,
     ):
         """
         Test that certificates are created from the edx certificates with missing signatory.
         """
-        edx_certificates = edx_factories.EdxGeneratedCertificateFactory.create_batch(10)
+        edx_certificates = edx_factories.EdxGeneratedCertificateFactory.create_batch(
+            10, mode=OPENEDX_MODE_VERIFIED
+        )
         mongo_enrollments = {}
         edx_certificates_with_mongodb_enrollments = []
         i = 0
         for edx_certificate in edx_certificates:
             course = factories.CourseFactory.create(
                 code=extract_course_number(edx_certificate.course_id),
-                organizations=[factories.OrganizationFactory.create()],
+                organizations=[
+                    factories.OrganizationFactory.create(
+                        code=extract_organization_code(edx_certificate.course_id)
+                    )
+                ],
             )
             course_run = factories.CourseRunFactory.create(
                 course=course,
@@ -444,10 +383,7 @@ class EdxImportCertificatesTestCase(TestCase):
                 edx_certificates_with_mongodb_enrollments.append(edx_certificate)
 
                 edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
-                mongo_enrollments[edx_certificate.id] = (
-                    course.organizations.first().code,
-                    edx_mongo_signatory,
-                )
+                mongo_enrollments[edx_certificate.id] = edx_mongo_signatory
                 responses.add(
                     responses.GET,
                     f"https://{settings.EDX_DOMAIN}"
@@ -455,15 +391,12 @@ class EdxImportCertificatesTestCase(TestCase):
                     body=SIGNATURE_CONTENT,
                 )
             else:
-                mongo_enrollments[edx_certificate.id] = (
-                    course.organizations.first().code,
-                    None,
-                )
+                mongo_enrollments[edx_certificate.id] = None
             i += 1
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_enrollment.side_effect = [
+        mock_get_signature_from_enrollment.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -488,10 +421,6 @@ class EdxImportCertificatesTestCase(TestCase):
                 certificate.certificate_definition.template, certificate_template
             )
             self.assertEqual(
-                certificate.organization.code,
-                mongo_enrollments[edx_certificate.id][0],
-            )
-            self.assertEqual(
                 certificate.issued_on, make_date_aware(edx_certificate.created_date)
             )
             if edx_certificate in edx_certificates_with_mongodb_enrollments:
@@ -499,7 +428,7 @@ class EdxImportCertificatesTestCase(TestCase):
             else:
                 signature = None
 
-            mongo_signatory = mongo_enrollments[edx_certificate.id][1]
+            mongo_signatory = mongo_enrollments[edx_certificate.id]
             mongo_signatory_name = (
                 mongo_signatory.get("name") if mongo_signatory else None
             )
@@ -549,12 +478,15 @@ class EdxImportCertificatesTestCase(TestCase):
                 },
             )
 
-    @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
     def test_import_certificates_download_error(
-        self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
+        self,
+        mock_get_certificates,
+        mock_get_certificates_count,
+        mock_get_signature_from_enrollment,
     ):
         """
         Test that signatures are not stored if the signature is not found.
@@ -563,7 +495,11 @@ class EdxImportCertificatesTestCase(TestCase):
         mongo_enrollments = {}
         course = factories.CourseFactory.create(
             code=extract_course_number(edx_certificate.course_id),
-            organizations=[factories.OrganizationFactory.create(logo=None)],
+            organizations=[
+                factories.OrganizationFactory.create(
+                    logo=None, code=extract_organization_code(edx_certificate.course_id)
+                )
+            ],
         )
         course_run = factories.CourseRunFactory.create(
             course=course,
@@ -578,10 +514,7 @@ class EdxImportCertificatesTestCase(TestCase):
         )
 
         edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
-        mongo_enrollments[edx_certificate.id] = (
-            course.organizations.first().code,
-            edx_mongo_signatory,
-        )
+        mongo_enrollments[edx_certificate.id] = edx_mongo_signatory
         responses.add(
             responses.GET,
             f"https://{settings.EDX_DOMAIN}{edx_mongo_signatory.get('signature_image_path')}",
@@ -590,7 +523,9 @@ class EdxImportCertificatesTestCase(TestCase):
 
         mock_get_certificates.return_value = [edx_certificate]
         mock_get_certificates_count.return_value = 1
-        mock_get_enrollment.side_effect = [mongo_enrollments[edx_certificate.id]]
+        mock_get_signature_from_enrollment.side_effect = [
+            mongo_enrollments[edx_certificate.id]
+        ]
 
         import_certificates()
 
@@ -609,13 +544,13 @@ class EdxImportCertificatesTestCase(TestCase):
         )
         self.assertEqual(
             certificate.organization.code,
-            mongo_enrollments[edx_certificate.id][0],
+            extract_organization_code(edx_certificate.course_id),
         )
         self.assertEqual(
             certificate.issued_on, make_date_aware(edx_certificate.created_date)
         )
 
-        mongo_signatory = mongo_enrollments[edx_certificate.id][1]
+        mongo_signatory = mongo_enrollments[edx_certificate.id]
         self.assertEqual(
             certificate.localized_context,
             {

--- a/src/backend/joanie/tests/edx_imports/test_import_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_certificates.py
@@ -183,7 +183,6 @@ class EdxImportCertificatesTestCase(TestCase):
     @patch("joanie.edx_imports.edx_mongodb.get_enrollment")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
-    @responses.activate(assert_all_requests_are_fired=True)
     def test_import_certificates_update(
         self, mock_get_certificates, mock_get_certificates_count, mock_get_enrollment
     ):
@@ -221,11 +220,6 @@ class EdxImportCertificatesTestCase(TestCase):
             mongo_enrollments[edx_certificate.id] = (
                 course.organizations.first().code,
                 edx_mongo_signatory,
-            )
-            responses.add(
-                responses.GET,
-                f"https://{settings.EDX_DOMAIN}{edx_mongo_signatory.get('signature_image_path')}",
-                body=SIGNATURE_CONTENT,
             )
 
         mock_get_certificates.return_value = edx_certificates

--- a/src/backend/joanie/tests/edx_imports/test_import_course_runs.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_course_runs.py
@@ -4,6 +4,7 @@
 from os.path import dirname, join, realpath
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import TestCase, override_settings
 
 import factory
@@ -95,6 +96,10 @@ class EdxImportCourseRunsTestCase(TestCase):
                 course=course,
             )
             course_run.set_current_language(edx_course_overview.course.language)
+            self.assertEqual(
+                course_run.resource_link,
+                f"https://{settings.EDX_DOMAIN}/courses/{edx_course_overview.id}/info",
+            )
             self.assertEqual(course_run.title, edx_course_overview.display_name)
             self.assertEqual(
                 course_run.start, make_date_aware(edx_course_overview.start)

--- a/src/backend/joanie/tests/edx_imports/test_import_enrollments.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_enrollments.py
@@ -105,9 +105,9 @@ class EdxImportEnrollmentsTestCase(TestCase):
         mock_get_enrollments.return_value = edx_enrollments[20:30]
         mock_get_enrollments_count.return_value = 10
 
-        import_enrollments(offset=20, limit=10)
+        import_enrollments(global_offset=20, import_size=10)
 
-        mock_get_enrollments.assert_called_once_with(20, 10, course_id=None)
+        mock_get_enrollments.assert_called_once_with(20, 1000, course_id=None)
 
         self.assertEqual(models.Enrollment.objects.count(), 10)
         for edx_enrollment in edx_enrollments[20:30]:

--- a/src/backend/joanie/tests/edx_imports/test_import_enrollments.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_enrollments.py
@@ -107,7 +107,7 @@ class EdxImportEnrollmentsTestCase(TestCase):
 
         import_enrollments(offset=20, limit=10)
 
-        mock_get_enrollments.assert_called_once_with(20, 10)
+        mock_get_enrollments.assert_called_once_with(20, 10, course_id=None)
 
         self.assertEqual(models.Enrollment.objects.count(), 10)
         for edx_enrollment in edx_enrollments[20:30]:


### PR DESCRIPTION
## Purpose

When importing Open edX data, logs were polluted with non relevant
messages. They have been improved.

When importing Open edX certificates, some useless process is done when
import should be skipped. We now skip earlier.

Adds a check to alert for course sync during import.

Adds import progression in logs.

Fix imports limits.

Fix similar resource link issue during enrollments import.

Select with order_by to allow matching limits across imports.

Find right certificate definition during certificates import.