### PR TITLE
:sparkles: (backend) Backoffice - Cancel order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow backoffice admin user to cancel an order
 - Add filter tag `iso8601_to_date`
 - Allow student to download his owned contract once fully signed
 - Allow to filter course product relation by organization title or

--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -408,6 +408,7 @@ class NestedCourseProductRelationOrderGroupViewSet(
 
 class OrderViewSet(
     SerializerPerActionMixin,
+    mixins.DestroyModelMixin,
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     viewsets.GenericViewSet,
@@ -437,6 +438,12 @@ class OrderViewSet(
         "order_group",
     )
     ordering = "created_on"
+
+    def destroy(self, request, *args, **kwargs):
+        """Cancels an order."""
+        order = self.get_object()
+        order.cancel()
+        return Response(status=HTTPStatus.NO_CONTENT)
 
 
 class OrganizationAddressViewSet(

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -2486,6 +2486,35 @@
                         "description": ""
                     }
                 }
+            },
+            "delete": {
+                "operationId": "orders_destroy",
+                "description": "Cancels an order.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "orders"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
             }
         },
         "/api/v1.0/admin/organizations/": {


### PR DESCRIPTION
This PR solves this [issue](https://github.com/openfun/joanie/issues/672).

## Purpose

In the Django admin, we have a custom action to cancel an order. We should port this action into our Back Office. In order to do that, an admin endpoint cancel should be created to allow to cancel an order.

With this new feature, the backoffice now has the action to cancel an order (whatever "state" the order is in at that specific time).

The method 'DELETE'' allowed for the endpoint : `/api/v1.0/admin/orders/<order_id>/`

## Proposal

- [x] import `DestroyModelMixin` for the `OrderViewSet` in `joanie.core.api.admin`
- [x] override the `destroy` method to softly cancel the order
- [x] add tests and adjust existing test (when delete method was not allowed on the viewset for example)
