### PR TITLE
update circle-ci removed images and docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
       - <<: *generate-version-file
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 20.10.7
+          version: default
       # Each image is tagged with the current git commit sha1 to avoid collisions in parallel builds.
       - run:
           name: Build production image
@@ -416,7 +416,7 @@ jobs:
   # ---- Tray jobs (k8s) ----
   tray:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: default
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/joanie

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
   # Check that the CHANGELOG has been updated in the current branch
   check-changelog:
     docker:
-      - image: cimg/base:2022.06
+      - image: cimg/base:current
     working_directory: ~/joanie
     steps:
       - checkout:
@@ -74,7 +74,7 @@ jobs:
   # Build the Docker image ready for production
   build-docker:
     docker:
-      - image: cimg/base:2022.06
+      - image: cimg/base:current
     working_directory: ~/joanie
     steps:
       # Checkout repository sources
@@ -95,7 +95,7 @@ jobs:
 
   build-docker-admin:
     docker:
-      - image: cimg/base:2023.12
+      - image: cimg/base:current
     working_directory: ~/joanie
     steps:
       # Checkout repository sources
@@ -539,7 +539,7 @@ jobs:
   # ---- DockerHub publication job ----
   hub:
     docker:
-      - image: cimg/base:2023.10
+      - image: cimg/base:current
     working_directory: ~/joanie
     steps:
       # Checkout repository sources
@@ -609,7 +609,7 @@ jobs:
 
   hub-admin:
     docker:
-      - image: cimg/base:2023.12
+      - image: cimg/base:current
     working_directory: ~/joanie
     steps:
       # Checkout repository sources


### PR DESCRIPTION
## Purpose

Ubuntu images and docker versions have been removed from circle-ci. For
both case we can use the default tags to replace them.

Also the cimg/base image has a current tag we can use to avoid to have to
update themwhen circle will decide to remove old tags.

## Proposal

- [x] update circle-ci removed images and docker version
- [x] update cimg/base tag to use current