### PR TITLE
🐛(backend) fix target_course_runs distinct issue

### DIFF
--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -614,15 +614,14 @@ class Order(BaseModel):
         course_relations_with_course_runs = self.course_relations.filter(
             course_runs__isnull=False
         ).only("pk")
+        target_courses_without_course_runs_subset = self.target_courses.exclude(
+            order_relations__in=course_relations_with_course_runs
+        )
 
         return CourseRun.objects.filter(
             models.Q(order_relations__in=course_relations_with_course_runs)
-            | models.Q(
-                course__in=self.target_courses.exclude(
-                    order_relations__in=course_relations_with_course_runs
-                )
-            )
-        )
+            | models.Q(course__in=target_courses_without_course_runs_subset)
+        ).distinct()
 
     @cached_property
     def main_invoice(self) -> dict | None:


### PR DESCRIPTION
## Purpose

`target_course_runs` property of Order model may could return duplicated CourseRun resource. So we had a distinct method to prevent that.

## Proposal

- [x] Fix `Order.target_course_runs` property 
