### PR TITLE
✨(backend) bind enrollment into certificate serializer

### DIFF
--- a/src/backend/joanie/core/api/client.py
+++ b/src/backend/joanie/core/api/client.py
@@ -600,6 +600,7 @@ class CertificateViewSet(
         "order__organization",
         "order__owner",
         "order__product",
+        "enrollment__course_run__course",
     )
 
     def get_queryset(self):

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -392,10 +392,17 @@ class CertificateSerializer(serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, required=False)
     certificate_definition = CertificationDefinitionSerializer(read_only=True)
     order = NestedOrderSerializer(read_only=True)
+    enrollment = EnrollmentLightSerializer(read_only=True)
 
     class Meta:
         model = models.Certificate
-        fields = ["id", "certificate_definition", "issued_on", "order"]
+        fields = [
+            "id",
+            "certificate_definition",
+            "issued_on",
+            "order",
+            "enrollment",
+        ]
         read_only_fields = fields
 
     def get_context(self, certificate) -> dict:
@@ -550,17 +557,17 @@ class EnrollmentSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Enrollment
         fields = [
-            "id",
             "certificate_id",
             "course_run",
             "created_on",
+            "id",
             "is_active",
             "orders",
             "product_relations",
             "state",
             "was_created_by_order",
         ]
-        read_only_fields = ["id", "course_run", "created_on", "state"]
+        read_only_fields = ["course_run", "created_on", "id", "state"]
 
     def create(self, validated_data, **kwargs):
         """

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -100,6 +100,45 @@ class CertificateApiTest(BaseAPITestCase):
                         },
                         "issued_on": format_date(certificate_enrollment_3.issued_on),
                         "order": None,
+                        "enrollment": {
+                            "course_run": {
+                                "course": {
+                                    "code": enrollment_3.course_run.course.code,
+                                    "cover": "_this_field_is_mocked",
+                                    "id": str(enrollment_3.course_run.course.id),
+                                    "title": enrollment_3.course_run.course.title,
+                                },
+                                "end": format_date(enrollment_3.course_run.end),
+                                "enrollment_end": format_date(
+                                    enrollment_3.course_run.enrollment_end
+                                ),
+                                "enrollment_start": format_date(
+                                    enrollment_3.course_run.enrollment_start
+                                ),
+                                "id": str(enrollment_3.course_run.id),
+                                "languages": enrollment_3.course_run.languages,
+                                "resource_link": enrollment_3.course_run.resource_link,
+                                "start": format_date(enrollment_3.course_run.start),
+                                "state": {
+                                    "call_to_action": enrollment_3.course_run.state.get(
+                                        "call_to_action"
+                                    ),
+                                    "datetime": format_date(
+                                        enrollment_3.course_run.state.get("datetime")
+                                    ),
+                                    "priority": enrollment_3.course_run.state.get(
+                                        "priority"
+                                    ),
+                                    "text": enrollment_3.course_run.state.get("text"),
+                                },
+                                "title": enrollment_3.course_run.title,
+                            },
+                            "created_on": format_date(enrollment_3.created_on),
+                            "id": str(enrollment_3.id),
+                            "is_active": enrollment_3.is_active,
+                            "state": enrollment_3.state,
+                            "was_created_by_order": enrollment_3.was_created_by_order,
+                        },
                     },
                     {
                         "id": str(other_certificate.id),
@@ -109,6 +148,7 @@ class CertificateApiTest(BaseAPITestCase):
                             "title": other_certificate.certificate_definition.title,
                         },
                         "issued_on": format_date(other_certificate.issued_on),
+                        "enrollment": None,
                         "order": {
                             "id": str(other_order.id),
                             "course": None,
@@ -188,6 +228,45 @@ class CertificateApiTest(BaseAPITestCase):
                         },
                         "issued_on": format_date(certificate_enrollment_2.issued_on),
                         "order": None,
+                        "enrollment": {
+                            "course_run": {
+                                "course": {
+                                    "code": enrollment_2.course_run.course.code,
+                                    "cover": "_this_field_is_mocked",
+                                    "id": str(enrollment_2.course_run.course.id),
+                                    "title": enrollment_2.course_run.course.title,
+                                },
+                                "end": format_date(enrollment_2.course_run.end),
+                                "enrollment_end": format_date(
+                                    enrollment_2.course_run.enrollment_end
+                                ),
+                                "enrollment_start": format_date(
+                                    enrollment_2.course_run.enrollment_start
+                                ),
+                                "id": str(enrollment_2.course_run.id),
+                                "languages": enrollment_2.course_run.languages,
+                                "resource_link": enrollment_2.course_run.resource_link,
+                                "start": format_date(enrollment_2.course_run.start),
+                                "state": {
+                                    "call_to_action": enrollment_2.course_run.state.get(
+                                        "call_to_action"
+                                    ),
+                                    "datetime": format_date(
+                                        enrollment_2.course_run.state.get("datetime")
+                                    ),
+                                    "priority": enrollment_2.course_run.state.get(
+                                        "priority"
+                                    ),
+                                    "text": enrollment_2.course_run.state.get("text"),
+                                },
+                                "title": enrollment_2.course_run.title,
+                            },
+                            "created_on": format_date(enrollment_2.created_on),
+                            "id": str(enrollment_2.id),
+                            "is_active": enrollment_2.is_active,
+                            "state": enrollment_2.state,
+                            "was_created_by_order": enrollment_2.was_created_by_order,
+                        },
                     },
                     {
                         "id": str(certificate_enrollment_1.id),
@@ -198,6 +277,45 @@ class CertificateApiTest(BaseAPITestCase):
                         },
                         "issued_on": format_date(certificate_enrollment_1.issued_on),
                         "order": None,
+                        "enrollment": {
+                            "course_run": {
+                                "course": {
+                                    "code": enrollment_1.course_run.course.code,
+                                    "cover": "_this_field_is_mocked",
+                                    "id": str(enrollment_1.course_run.course.id),
+                                    "title": enrollment_1.course_run.course.title,
+                                },
+                                "end": format_date(enrollment_1.course_run.end),
+                                "enrollment_end": format_date(
+                                    enrollment_1.course_run.enrollment_end
+                                ),
+                                "enrollment_start": format_date(
+                                    enrollment_1.course_run.enrollment_start
+                                ),
+                                "id": str(enrollment_1.course_run.id),
+                                "languages": enrollment_1.course_run.languages,
+                                "resource_link": enrollment_1.course_run.resource_link,
+                                "start": format_date(enrollment_1.course_run.start),
+                                "state": {
+                                    "call_to_action": enrollment_1.course_run.state.get(
+                                        "call_to_action"
+                                    ),
+                                    "datetime": format_date(
+                                        enrollment_1.course_run.state.get("datetime")
+                                    ),
+                                    "priority": enrollment_1.course_run.state.get(
+                                        "priority"
+                                    ),
+                                    "text": enrollment_1.course_run.state.get("text"),
+                                },
+                                "title": enrollment_1.course_run.title,
+                            },
+                            "created_on": format_date(enrollment_1.created_on),
+                            "id": str(enrollment_1.id),
+                            "is_active": enrollment_1.is_active,
+                            "state": enrollment_1.state,
+                            "was_created_by_order": enrollment_1.was_created_by_order,
+                        },
                     },
                     {
                         "id": str(certificate.id),
@@ -207,6 +325,7 @@ class CertificateApiTest(BaseAPITestCase):
                             "title": certificate.certificate_definition.title,
                         },
                         "issued_on": format_date(certificate.issued_on),
+                        "enrollment": None,
                         "order": {
                             "id": str(order.id),
                             "course": {
@@ -347,6 +466,7 @@ class CertificateApiTest(BaseAPITestCase):
                     "title": certificate.certificate_definition.title,
                 },
                 "issued_on": format_date(certificate.issued_on),
+                "enrollment": None,
                 "order": {
                     "id": str(certificate.order.id),
                     "course": {
@@ -436,6 +556,43 @@ class CertificateApiTest(BaseAPITestCase):
                 },
                 "issued_on": format_date(owned_certificate_enrollment.issued_on),
                 "order": None,
+                "enrollment": {
+                    "course_run": {
+                        "course": {
+                            "code": enrollment_2.course_run.course.code,
+                            "cover": "_this_field_is_mocked",
+                            "id": str(enrollment_2.course_run.course.id),
+                            "title": enrollment_2.course_run.course.title,
+                        },
+                        "end": format_date(enrollment_2.course_run.end),
+                        "enrollment_end": format_date(
+                            enrollment_2.course_run.enrollment_end
+                        ),
+                        "enrollment_start": format_date(
+                            enrollment_2.course_run.enrollment_start
+                        ),
+                        "id": str(enrollment_2.course_run.id),
+                        "languages": enrollment_2.course_run.languages,
+                        "resource_link": enrollment_2.course_run.resource_link,
+                        "start": format_date(enrollment_2.course_run.start),
+                        "state": {
+                            "call_to_action": enrollment_2.course_run.state.get(
+                                "call_to_action"
+                            ),
+                            "datetime": format_date(
+                                enrollment_2.course_run.state.get("datetime")
+                            ),
+                            "priority": enrollment_2.course_run.state.get("priority"),
+                            "text": enrollment_2.course_run.state.get("text"),
+                        },
+                        "title": enrollment_2.course_run.title,
+                    },
+                    "created_on": format_date(enrollment_2.created_on),
+                    "id": str(enrollment_2.id),
+                    "is_active": enrollment_2.is_active,
+                    "state": enrollment_2.state,
+                    "was_created_by_order": enrollment_2.was_created_by_order,
+                },
             },
         )
 

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -4233,10 +4233,19 @@
                             }
                         ],
                         "readOnly": true
+                    },
+                    "enrollment": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/EnrollmentLight"
+                            }
+                        ],
+                        "readOnly": true
                     }
                 },
                 "required": [
                     "certificate_definition",
+                    "enrollment",
                     "id",
                     "issued_on",
                     "order"
@@ -5079,10 +5088,6 @@
                 "type": "object",
                 "description": "Enrollment model serializer",
                 "properties": {
-                    "id": {
-                        "type": "string",
-                        "readOnly": true
-                    },
                     "certificate_id": {
                         "type": "string",
                         "format": "uuid",
@@ -5102,6 +5107,10 @@
                         "format": "date-time",
                         "readOnly": true,
                         "description": "date and time at which a record was created"
+                    },
+                    "id": {
+                        "type": "string",
+                        "readOnly": true
                     },
                     "is_active": {
                         "type": "boolean",


### PR DESCRIPTION
## Purpose

Some certificate can be link directly to an enrollment, not an order. Currently,
 we do not bind enrollment information the certificate that is weird as the
 frontend needs to get enrollment information to display this certificate.

## Proposal

- [x] Bind enrollment field into `CertificateSerializer`
