### PR TITLE
✨(Backend) Generate certificates from the backoffice for a course and its products relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Allow backoffice to generate certificates from a course and product relation
 - Bind remote catalog syllabus to contract template
 - Add redis backend to cache configuration
 - Add generate certificate button in Back Office

--- a/src/backend/joanie/core/helpers.py
+++ b/src/backend/joanie/core/helpers.py
@@ -2,7 +2,9 @@
 Helpers that can be useful throughout Joanie's core app
 """
 
-from joanie.core import enums
+from django.db.models.query import QuerySet
+
+from joanie.core import enums, models
 from joanie.core.exceptions import CertificateGenerationError
 
 
@@ -12,8 +14,15 @@ def generate_certificates_for_orders(orders):
     then return the count of generated certificates.
     """
     total = 0
+    if isinstance(orders, QuerySet):
+        orders_queryset = orders
+    elif isinstance(orders, list):
+        orders_queryset = models.Order.objects.filter(pk__in=orders)
+    else:
+        raise ValueError("orders must be either List or QuerySet")
+
     orders_filtered = (
-        orders.filter(
+        orders_queryset.filter(
             state=enums.ORDER_STATE_VALIDATED,
             certificate__isnull=True,
             product__type__in=enums.PRODUCT_TYPE_CERTIFICATE_ALLOWED,

--- a/src/backend/joanie/core/tasks.py
+++ b/src/backend/joanie/core/tasks.py
@@ -2,9 +2,11 @@
 
 from logging import getLogger
 
+from django.core.cache import cache
 from django.core.management import call_command
 
 from joanie.celery_app import app
+from joanie.core import helpers
 
 logger = getLogger(__name__)
 
@@ -19,3 +21,17 @@ def generate_zip_archive_task(options):
     logger.info("Starting Celery task, generating a ZIP Archive...")
     call_command("generate_zip_archive_of_contracts", **options)
     logger.info("Done executing Celery generating a ZIP Archive task...")
+
+
+@app.task
+def generate_certificates_task(order_ids, cache_key):
+    """
+    Task to generate certificates from orders. It calls the helper command to generate
+    certificates from an Order queryset. Once done, it cleans up the data in cache.
+    """
+    logger.info("Starting Celery task, generating certificates...")
+    try:
+        helpers.generate_certificates_for_orders(orders=order_ids)
+    finally:
+        cache.delete(cache_key)
+    logger.info("Done executing Celery generating certificates task...")

--- a/src/backend/joanie/core/utils/course_product_relation.py
+++ b/src/backend/joanie/core/utils/course_product_relation.py
@@ -1,0 +1,34 @@
+"""Utility methods to get all orders and/or certificates from a course product relation."""
+
+from joanie.core.enums import ORDER_STATE_VALIDATED, PRODUCT_TYPE_CERTIFICATE_ALLOWED
+from joanie.core.models import Certificate, Order
+
+
+def get_orders(course_product_relation):
+    """
+    Returns a list of all validated orders ids for a course product relation.
+    """
+    return [
+        str(order_id)
+        for order_id in Order.objects.filter(
+            course=course_product_relation.course,
+            product=course_product_relation.product,
+            product__type__in=PRODUCT_TYPE_CERTIFICATE_ALLOWED,
+            state=ORDER_STATE_VALIDATED,
+            certificate__isnull=True,
+        )
+        .values_list("pk", flat=True)
+        .distinct()
+    ]
+
+
+def get_generated_certificates(course_product_relation):
+    """
+    Return certificates that were published for a course product relation.
+    """
+    return Certificate.objects.filter(
+        order__product=course_product_relation.product,
+        order__course=course_product_relation.course,
+        order__certificate__isnull=False,
+        order__state=ORDER_STATE_VALIDATED,
+    )

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_generate_certificates.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_generate_certificates.py
@@ -1,0 +1,685 @@
+"""
+Test suite for Course Product Relation Admin API endpoints to generate certificates.
+"""
+
+import datetime
+from http import HTTPStatus
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import TestCase
+from django.utils import timezone
+
+from joanie.core import enums, factories
+from joanie.core.models import Certificate, CourseProductRelation
+from joanie.lms_handler.backends.dummy import DummyLMSBackend
+
+
+class AdminCourseProductRelationApiTest(TestCase):
+    """
+    Test suite for Admin Course Product Relation API endpoints to generate certificates.
+    """
+
+    maxDiff = None
+
+    def test_admin_api_course_product_relation_generate_certificates_anonymous(self):
+        """
+        Anonymous user should not be able to trigger the generation of certificates
+        for a course product relation (cpr).
+        """
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.post(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_admin_api_course_product_relation_generate_certificates_lambda_user(self):
+        """
+        Lambda user should not be able to trigger the generation of certificates
+        for a course product relation (cpr).
+        """
+        admin = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.post(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_admin_api_course_product_relation_generate_certificates_authenticated_get_method(
+        self,
+    ):
+        """
+        Authenticated staff user should not be able to use the 'GET' method for the
+        endpoint to generate certificates.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_admin_api_course_product_relation_generate_certificates_authenticated_partially_update(
+        self,
+    ):
+        """
+        Authenticated staff user should not be able to use the 'PATCH' method for the
+        endpoint to generate certificates.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_admin_api_course_product_relatio_generate_certificates_authenticated_update(
+        self,
+    ):
+        """
+        Authenticated staff user should not be able to use the 'PUT' method for the
+        endpoint to generate certificates.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_admin_api_course_product_relation_generate_certificates_authenticated_delete(
+        self,
+    ):
+        """
+        Authenticated staff user should not be able to use the 'DELETE' method for the
+        endpoint to generate certificates.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_admin_api_course_product_relation_generate_certificates_authenticated_create_status(
+        self,
+    ):
+        """
+        Authenticated staff user should be able to trigger the generation of certificate if the
+        course's product is eligible. We should get a status code 201 CREATED in return
+        if all certificates were generated. When the task has been successful, the cache data
+        is deleted.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        course = factories.CourseFactory(products=None)
+        product = factories.ProductFactory(
+            price="0.00",
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            courses=[course],
+        )
+        factories.CourseRunFactory(
+            course=course,
+            enrollment_end=timezone.now() + datetime.timedelta(hours=1),
+            enrollment_start=timezone.now() - datetime.timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - datetime.timedelta(hours=1),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course,
+            is_graded=True,
+        )
+        cpr = CourseProductRelation.objects.get(product=product, course=course)
+        orders = factories.OrderFactory.create_batch(
+            10,
+            product=cpr.product,
+            course=cpr.course,
+        )
+        for order in orders:
+            order.submit()
+
+        self.assertFalse(Certificate.objects.exists())
+
+        with mock.patch.object(DummyLMSBackend, "get_grades") as mock_get_grades:
+            mock_get_grades.return_value = {"passed": True}
+
+            response = self.client.post(
+                f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "course_product_relation_id": str(cpr.id),
+                "count_certificate_to_generate": len(orders),
+                "count_exist_before_generation": 0,
+            },
+        )
+
+        for order in orders:
+            order.refresh_from_db()
+            self.assertTrue(Certificate.objects.filter(order=order).exists())
+
+        self.assertIsNone(cache.get(f"celery_certificate_generation_{cpr.id}"))
+
+    @mock.patch("joanie.core.api.admin.generate_certificates_task")
+    def test_admin_api_course_product_relation_generate_certificates_authenticated_triggered_twice(
+        self, mock_generate_certificates_task
+    ):
+        """
+        Authenticated staff user should be able to call a second time the endpoint to
+        generate certificates and get a status code 'accepted' because the task is ongoing. It
+        will not trigger another generation since one is ongoing.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        course = factories.CourseFactory(products=None)
+        product = factories.ProductFactory(
+            price="0.00",
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            courses=[course],
+        )
+        factories.CourseRunFactory(
+            course=course,
+            enrollment_end=timezone.now() + datetime.timedelta(hours=1),
+            enrollment_start=timezone.now() - datetime.timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - datetime.timedelta(hours=1),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course,
+            is_graded=True,
+        )
+
+        cpr = CourseProductRelation.objects.get(product=product, course=course)
+
+        # Create some certificates that are already generated
+        orders_in_past = factories.OrderFactory.create_batch(
+            5,
+            product=cpr.product,
+            course=cpr.course,
+        )
+        for order in orders_in_past:
+            order.submit()
+            factories.OrderCertificateFactory(order=order)
+
+        self.assertEqual(Certificate.objects.count(), 5)
+
+        # Create orders where we will generate certificates
+        orders = factories.OrderFactory.create_batch(
+            10,
+            product=cpr.product,
+            course=cpr.course,
+        )
+        for order in orders:
+            order.submit()
+
+        mock_generate_certificates_task.delay.return_value = ""
+
+        with mock.patch.object(DummyLMSBackend, "get_grades") as mock_get_grades:
+            mock_get_grades.return_value = {"passed": True}
+
+            response = self.client.post(
+                f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+                content_type="application/json",
+            )
+            self.assertTrue(mock_generate_certificates_task.delay.called)
+
+        expected_cache_data_response = {
+            "course_product_relation_id": str(cpr.id),
+            "count_certificate_to_generate": len(orders),
+            "count_exist_before_generation": 5,
+        }
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertDictEqual(response.json(), expected_cache_data_response)
+
+        # When the endpoint is requested again with the same course product relation id
+        second_response = self.client.post(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(second_response.status_code, HTTPStatus.ACCEPTED)
+        self.assertDictEqual(second_response.json(), expected_cache_data_response)
+
+        cache_key = f"celery_certificate_generation_{cpr.id}"
+        cache_data = cache.get(cache_key)
+        self.assertDictEqual(cache_data, expected_cache_data_response)
+
+    @mock.patch("joanie.core.api.admin.generate_certificates_task")
+    def test_api_admin_course_product_relation_generate_certificates_exception_by_celery(
+        self, mock_generate_certificates_task
+    ):
+        """
+        If an exception occurs while triggering the task we must raise the
+        error. It must also delete the data in cache if there is an issue with celery to
+        enable to generate once more the same batch of certificates.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        course = factories.CourseFactory(products=None)
+        product = factories.ProductFactory(
+            price="0.00",
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            courses=[course],
+        )
+        factories.CourseRunFactory(
+            course=course,
+            enrollment_end=timezone.now() + datetime.timedelta(hours=1),
+            enrollment_start=timezone.now() - datetime.timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - datetime.timedelta(hours=1),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course,
+            is_graded=True,
+        )
+        cpr = CourseProductRelation.objects.get(product=product, course=course)
+        orders = factories.OrderFactory.create_batch(
+            4,
+            product=cpr.product,
+            course=cpr.course,
+        )
+        for order in orders:
+            order.submit()
+
+        mock_generate_certificates_task.delay.side_effect = Exception(
+            "Some error occured with Celery"
+        )
+
+        with mock.patch.object(DummyLMSBackend, "get_grades") as mock_get_grades:
+            mock_get_grades.return_value = {"passed": True}
+
+            response = self.client.post(
+                f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+                content_type="application/json",
+            )
+            self.assertTrue(mock_generate_certificates_task.delay.called)
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertDictEqual(
+            response.json(), {"details": "Some error occured with Celery"}
+        )
+        cache_data = cache.get(f"celery_certificate_generation_{cpr.id}")
+        self.assertIsNone(cache_data)
+
+    def test_api_admin_course_product_relation_check_certificates_generation_process_anonymous(
+        self,
+    ):
+        """
+        Anonymous user should not be able to request the state of the certificate generation.
+        """
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_api_admin_course_product_relation_check_certificates_generation_process_lambda(
+        self,
+    ):
+        """
+        Lambda user should not be able to request the state of the certificate generation.
+        """
+        admin = factories.UserFactory(is_staff=False, is_superuser=False)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_api_admin_course_product_relation_check_certificates_generation_process_post_method(
+        self,
+    ):
+        """
+        Authenticated user should not be able to request the state of the certificate generation
+        with the 'POST' method.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.post(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_api_admin_course_product_relation_check_certificates_generation_process_patch_method(
+        self,
+    ):
+        """
+        Authenticated user should not be able to request the state of the certificate generation
+        with the 'PATCH' method.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_api_admin_course_product_relation_check_certificates_generation_process_put_method(
+        self,
+    ):
+        """
+        Authenticated user should not be able to request the state of the certificate generation
+        with the 'PUT' method.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.put(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_api_admin_course_product_relation_check_certificates_generation_process_delete_method(
+        self,
+    ):
+        """
+        Authenticated user should not be able to request the state of the certificate generation
+        with the 'DELETE' method.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        cpr = factories.CourseProductRelationFactory(
+            course=factories.CourseFactory(),
+            product=factories.ProductFactory(
+                price="0.00",
+                type=enums.PRODUCT_TYPE_CERTIFICATE,
+                certificate_definition=factories.CertificateDefinitionFactory(),
+            ),
+        )
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    @mock.patch("joanie.core.api.admin.generate_certificates_task")
+    def test_api_admin_course_product_relation_check_certificates_generation_process_is_ongoing(
+        self, mock_generate_certificates_task
+    ):
+        """
+        Authenticated user should be able to know if the task of generating certificates
+        is in process. The cache data still must be accessible.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        course = factories.CourseFactory(products=None)
+        product = factories.ProductFactory(
+            price="0.00",
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            courses=[course],
+        )
+        factories.CourseRunFactory(
+            course=course,
+            enrollment_end=timezone.now() + datetime.timedelta(hours=1),
+            enrollment_start=timezone.now() - datetime.timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - datetime.timedelta(hours=1),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course,
+            is_graded=True,
+        )
+        cpr = CourseProductRelation.objects.get(product=product, course=course)
+        orders = factories.OrderFactory.create_batch(
+            10,
+            product=cpr.product,
+            course=cpr.course,
+        )
+        for order in orders:
+            order.submit()
+
+        self.assertFalse(Certificate.objects.exists())
+
+        mock_generate_certificates_task.delay.return_value = ""
+
+        with mock.patch.object(DummyLMSBackend, "get_grades") as mock_get_grades:
+            mock_get_grades.return_value = {"passed": True}
+
+            response = self.client.post(
+                f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+                content_type="application/json",
+            )
+
+        expected_cache_data_response = {
+            "course_product_relation_id": str(cpr.id),
+            "count_certificate_to_generate": len(orders),
+            "count_exist_before_generation": 0,
+        }
+
+        self.assertTrue(mock_generate_certificates_task.delay.called)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertDictEqual(response.json(), expected_cache_data_response)
+
+        second_response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(second_response.status_code, HTTPStatus.OK)
+        cache_data = cache.get(f"celery_certificate_generation_{cpr.id}")
+        self.assertIsNotNone(cache_data)
+        self.assertDictEqual(cache_data, expected_cache_data_response)
+
+    def test_api_admin_course_product_relation_check_certificates_generation_completed(
+        self,
+    ):
+        """
+        Authenticated user should be able to know if the task of generating certificates
+        is done. The cache data must not be accessible anymore because it has been deleted.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        course = factories.CourseFactory(products=None)
+        product = factories.ProductFactory(
+            price="0.00",
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            courses=[course],
+        )
+        factories.CourseRunFactory(
+            course=course,
+            enrollment_end=timezone.now() + datetime.timedelta(hours=1),
+            enrollment_start=timezone.now() - datetime.timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - datetime.timedelta(hours=1),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course,
+            is_graded=True,
+        )
+        cpr = CourseProductRelation.objects.get(product=product, course=course)
+        orders = factories.OrderFactory.create_batch(
+            10,
+            product=cpr.product,
+            course=cpr.course,
+        )
+        for order in orders:
+            order.submit()
+
+        self.assertFalse(Certificate.objects.exists())
+
+        with mock.patch.object(DummyLMSBackend, "get_grades") as mock_get_grades:
+            mock_get_grades.return_value = {"passed": True}
+
+            response = self.client.post(
+                f"/api/v1.0/admin/course-product-relations/{cpr.id}/generate_certificates/",
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "course_product_relation_id": str(cpr.id),
+                "count_certificate_to_generate": len(orders),
+                "count_exist_before_generation": 0,
+            },
+        )
+
+        second_response = self.client.get(
+            f"/api/v1.0/admin/course-product-relations/{cpr.id}"
+            "/check_certificates_generation_process/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(second_response.status_code, HTTPStatus.NOT_FOUND)
+        self.assertIsNone(cache.get(f"celery_certificate_generation_{cpr.id}"))
+        # Verify that certificates were generated
+        for order in orders:
+            self.assertTrue(Certificate.objects.filter(order=order).exists())

--- a/src/backend/joanie/tests/core/test_utils_course_product_relation.py
+++ b/src/backend/joanie/tests/core/test_utils_course_product_relation.py
@@ -1,0 +1,106 @@
+"""Test suite utility methods for course product relation to get orders and certificates"""
+
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+
+from joanie.core import enums, factories
+from joanie.core.models import CourseProductRelation
+from joanie.core.utils.course_product_relation import (
+    get_generated_certificates,
+    get_orders,
+)
+
+
+class UtilsCourseProductRelationTestCase(TestCase):
+    """Test suite utility methods for course product relation to get orders and certificates"""
+
+    def test_utils_course_product_relation_get_orders_made(self):
+        """
+        It should return the amount of orders that are validated for this course product
+        relation.
+        """
+        course = factories.CourseFactory(products=None)
+        product = factories.ProductFactory(
+            price="0.00",
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            courses=[course],
+        )
+        factories.CourseRunFactory(
+            course=course,
+            enrollment_end=timezone.now() + datetime.timedelta(hours=1),
+            enrollment_start=timezone.now() - datetime.timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - datetime.timedelta(hours=1),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course,
+            is_graded=True,
+        )
+        course_product_relation = CourseProductRelation.objects.get(
+            product=product, course=course
+        )
+        # Generate orders for the course product relation
+        orders = factories.OrderFactory.create_batch(
+            10,
+            product=course_product_relation.product,
+            course=course_product_relation.course,
+        )
+        for order in orders:
+            order.submit()
+
+        result = get_orders(course_product_relation=course_product_relation)
+
+        self.assertEqual(len(result), 10)
+
+    def test_utils_course_product_relation_get_generated_certificates(self):
+        """
+        It should return the amount of certificates that were published for this course product
+        relation.
+        """
+        course = factories.CourseFactory(products=None)
+        product = factories.ProductFactory(
+            price="0.00",
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            certificate_definition=factories.CertificateDefinitionFactory(),
+            courses=[course],
+        )
+        factories.CourseRunFactory(
+            course=course,
+            enrollment_end=timezone.now() + datetime.timedelta(hours=1),
+            enrollment_start=timezone.now() - datetime.timedelta(hours=1),
+            is_gradable=True,
+            start=timezone.now() - datetime.timedelta(hours=1),
+        )
+        factories.ProductTargetCourseRelationFactory(
+            product=product,
+            course=course,
+            is_graded=True,
+        )
+        course_product_relation = CourseProductRelation.objects.get(
+            product=product, course=course
+        )
+
+        generated_certificates_queryset = get_generated_certificates(
+            course_product_relation=course_product_relation
+        )
+        self.assertEqual(generated_certificates_queryset.count(), 0)
+
+        # Generate certificates for the course product relation
+        orders = factories.OrderFactory.create_batch(
+            5,
+            product=course_product_relation.product,
+            course=course_product_relation.course,
+        )
+        for order in orders:
+            order.submit()
+            factories.OrderCertificateFactory(order=order)
+
+        generated_certificates_queryset = get_generated_certificates(
+            course_product_relation=course_product_relation
+        )
+
+        self.assertEqual(generated_certificates_queryset.count(), 5)

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -1189,6 +1189,115 @@
                 }
             }
         },
+        "/api/v1.0/admin/course-product-relations/{id}/check_certificates_generation_process/": {
+            "get": {
+                "operationId": "course_product_relations_check_certificates_generation_process_retrieve",
+                "description": "Checks whether the Celery task for generating certificates is in progress or completed.\nIf cached data is found, it indicates that the generation process is ongoing. Otherwise,\nit signifies that the task has been completed or has not been requested.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "course-product-relations"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1.0/admin/course-product-relations/{id}/generate_certificates/": {
+            "post": {
+                "operationId": "course_product_relations_generate_certificates_create",
+                "description": "Generate the certificates for a course product relation when it is eligible.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "course-product-relations"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "202": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/admin/course-runs/": {
             "get": {
                 "operationId": "course_runs_list",


### PR DESCRIPTION
## Purpose

New endpoint to allow the backoffice staff user to generate certificate from a course view, and launch the generation of certificates for its products relations.
To avoid having a heavy request, we decided to use celery to execute the task in background with celery.
We will create two new endpoints : 

1. To trigger the generation of certificates
2. To check the status of the ongoing generation of certificates

## Proposal

- [x] New endpoint to trigger the generation of certificates for the backoffice
- [x] New endpoint to check the generation of certificate process
- [x] Add new utility methods for course product relation to get all orders & all certificates that were generated.
- [x] Add a new celery task calling the helper method to generate certificates from orders 
- [x] Refactor the helper method to be able to parse different type of input parameters : Queryset or List of order ids(new). 
