### PR TITLE
✨ (Backend) Backoffice - enhance exception handling to generate certificate for an order

### DIFF
--- a/src/backend/joanie/core/api/admin.py
+++ b/src/backend/joanie/core/api/admin.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from joanie.core import filters, models, serializers
 from joanie.core.api.base import NestedGenericViewSet, SerializerPerActionMixin
 from joanie.core.authentication import SessionAuthenticationWithAuthenticateHeader
+from joanie.core.exceptions import CertificateGenerationError
 
 
 # pylint: disable=too-many-ancestors
@@ -492,12 +493,11 @@ class OrderViewSet(
         Generate the certificate for an order when it is eligible.
         """
         order = self.get_object()
-
-        certificate, created = order.get_or_generate_certificate()
-
-        if not certificate:
+        try:
+            certificate, created = order.get_or_generate_certificate()
+        except CertificateGenerationError as error:
             return JsonResponse(
-                {"details": f"Cannot issue certificate for order {order.id}"},
+                {"details": str(error)},
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,
             )
 

--- a/src/backend/joanie/core/exceptions.py
+++ b/src/backend/joanie/core/exceptions.py
@@ -22,3 +22,10 @@ class NoContractToSignError(Exception):
     """
     Exception raised when trying to bulk sign organization contracts but no contract is available.
     """
+
+
+class CertificateGenerationError(Exception):
+    """
+    Exception raised when the certificate generation process fails due to the order not meeting
+    all specified conditions.
+    """

--- a/src/backend/joanie/core/helpers.py
+++ b/src/backend/joanie/core/helpers.py
@@ -3,6 +3,7 @@ Helpers that can be useful throughout Joanie's core app
 """
 
 from joanie.core import enums
+from joanie.core.exceptions import CertificateGenerationError
 
 
 def generate_certificates_for_orders(orders):
@@ -22,7 +23,11 @@ def generate_certificates_for_orders(orders):
     )
 
     for order in orders_filtered:
-        _certificate, created = order.get_or_generate_certificate()
+        try:
+            _certificate, created = order.get_or_generate_certificate()
+        except CertificateGenerationError:
+            created = False
+
         if created is True:
             total += 1
 

--- a/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_enrollment_product.py
+++ b/src/backend/joanie/tests/core/test_models_order_get_or_generate_certificate_for_enrollment_product.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from joanie.core import factories
+from joanie.core.exceptions import CertificateGenerationError
 from joanie.core.models import Certificate
 
 
@@ -35,8 +36,11 @@ class EnrollmentProductGetOrGenerateCertificateOrderModelsTestCase(TestCase):
         factories.CourseFactory(products=[product])
         order = factories.OrderFactory(product=product)
 
-        new_certificate, created = order.get_or_generate_certificate()
+        with self.assertRaises(CertificateGenerationError) as context:
+            order.get_or_generate_certificate()
 
-        self.assertFalse(created)
+        self.assertEqual(
+            str(context.exception),
+            f"Product {order.product.title} does not allow to generate a certificate.",
+        )
         self.assertFalse(Certificate.objects.exists())
-        self.assertIsNone(new_certificate)


### PR DESCRIPTION
## Purpose

On the `Order` endpoint to `generate_certificate,` we have decided to return the reason why the certificate is not allowed to be generated. This allows the frontend consumers to understand the reason why the order is not eligible at this specific time when requesting the generation of the certificate.

## Proposal

- [x] Refactor `get_or_generate_certificate` in `Order` Model by returning a `ValidationError` instead of `None, False`
- [x] Refactor endpoint `generate_certificate` on the `OrderViewSet` in` joanie.core.api.admin.py`
- [x] Refactor helpers method to `generate_certificates_for_orders`.
- [x] New custom exception when the generation of a certificate fails (`CertificateGenerationError`) 
- [x] Adjust all tests linked to helpers, models.Order, and endpoint OrderViewSet to generate certificate from an order.

