### PR TITLE
⚡️(back) improve client certificate endpoint performance

### DIFF
--- a/src/backend/joanie/core/enums.py
+++ b/src/backend/joanie/core/enums.py
@@ -122,3 +122,11 @@ CERTIFICATE_NAME_CHOICES = (
     (CERTIFICATE, _("Certificate")),
     (DEGREE, _("Degree")),
 )
+
+# For filtering certificates by type
+CERTIFICATE_ORDER_TYPE = "order"
+CERTIFICATE_ENROLLMENT_TYPE = "enrollment"
+CERTIFICATE_TYPE_CHOICES = (
+    (CERTIFICATE_ORDER_TYPE, _("Order")),
+    (CERTIFICATE_ENROLLMENT_TYPE, _("Enrollment")),
+)

--- a/src/backend/joanie/core/filters/client/__init__.py
+++ b/src/backend/joanie/core/filters/client/__init__.py
@@ -10,6 +10,8 @@ from django_filters import rest_framework as filters
 
 from joanie.core import enums, models
 
+from .certificate import CertificateViewSetFilter
+
 
 class OrderViewSetFilter(filters.FilterSet):
     """

--- a/src/backend/joanie/core/filters/client/certificate.py
+++ b/src/backend/joanie/core/filters/client/certificate.py
@@ -1,0 +1,57 @@
+"""Module for certificate filters."""
+
+from typing import List
+
+from django_filters import rest_framework as filters
+
+from joanie.core import enums, models
+
+
+class CertificateViewSetFilter(filters.FilterSet):
+    """
+    Filter certificates by enrollment or order
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Use initial values as defaults for bound filterset."""
+        super().__init__(*args, **kwargs)
+        # if filterset is bound, use initial values as defaults
+        if self.data is not None:
+            # get a mutable copy of the QueryDict
+            data = self.data.copy()
+
+            for name, f in self.filters.items():
+                initial = f.extra.get("initial")
+
+                # filter param is either missing or empty, use initial as default
+                if not data.get(name) and initial:
+                    data[name] = initial
+
+            self.data = data
+
+    type = filters.ChoiceFilter(
+        choices=enums.CERTIFICATE_TYPE_CHOICES,
+        method="filter_by_type",
+        initial=enums.CERTIFICATE_ORDER_TYPE,
+    )
+
+    class Meta:
+        model = models.Certificate
+        fields: List[str] = []
+
+    def filter_by_type(self, queryset, _name, value):
+        """
+        Filter certificates by type
+        """
+        username = (
+            self.request.auth["username"]
+            if self.request.auth
+            else self.request.user.username
+        )
+        if value == enums.CERTIFICATE_ORDER_TYPE:
+            return queryset.filter(order__owner__username=username)
+
+        if value == enums.CERTIFICATE_ENROLLMENT_TYPE:
+            return queryset.filter(enrollment__user__username=username)
+
+        return queryset.none()

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -281,6 +281,18 @@
                         "schema": {
                             "type": "integer"
                         }
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "enrollment",
+                                "order"
+                            ]
+                        },
+                        "description": "* `order` - Order\n* `enrollment` - Enrollment"
                     }
                 ],
                 "tags": [


### PR DESCRIPTION
## Purpose

The client certificate endpoint has a performace issue. The sql query executed is not perofrmant at all. There are a lot of join made and the where clause is filtering on two of the join made (between enrollment and user + order and user).
On the retrieve action, the username check is made once the certificate retrieve in database.
On the list action, we filter certificated linked only on order or enrollment but never both at the same time. For this, a filterset is created and customize to have the type filter with a default value on order.


## Proposal

- [x] mprove client certificate endpoint performace
