### PR TITLE
✨(backend) bind related course syllabus into contract template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Bind remote catalog syllabus to contract template
 - Add redis backend to cache configuration
 - Add generate certificate button in Back Office
 - Add admin Enrollment endpoint

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -40,6 +40,9 @@ JOANIE_PAYMENT_BACKEND=joanie.payment.backends.dummy.DummyPaymentBackend
 DJANGO_EMAIL_HOST="mailcatcher"
 DJANGO_EMAIL_PORT=1025
 
+# Document issuer customization
+JOANIE_CONTRACT_CONTEXT_PROCESSORS =
+
 # Backoffice
 JOANIE_BACKOFFICE_BASE_URL="http://localhost:8072"
 

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -40,8 +40,10 @@ JOANIE_PAYMENT_BACKEND=joanie.payment.backends.dummy.DummyPaymentBackend
 DJANGO_EMAIL_HOST="mailcatcher"
 DJANGO_EMAIL_PORT=1025
 
-# Document issuer customization
-JOANIE_CONTRACT_CONTEXT_PROCESSORS =
+# Remote LCMS Backend
+# Richie
+JOANIE_CATALOG_BASE_URL=http://richie:8070
+JOANIE_CONTRACT_CONTEXT_PROCESSORS = 
 
 # Backoffice
 JOANIE_BACKOFFICE_BASE_URL="http://localhost:8072"

--- a/src/backend/joanie/core/context_processors/contract_definition.py
+++ b/src/backend/joanie/core/context_processors/contract_definition.py
@@ -1,0 +1,14 @@
+"""Context processors for contract definition."""
+
+from joanie.core.utils.contract_context_processors import parse_richie_syllabus
+
+
+def richie_syllabus(context):
+    """
+    This processor is in charge to retrieve/parse syllabus RDF attributes
+    from a remote Richie instance.
+    """
+    course_code = context["course"]["code"]
+    contract_language = context["contract"]["language"]
+
+    return {"syllabus": parse_richie_syllabus(course_code, contract_language)}

--- a/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
+++ b/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
@@ -1,0 +1,116 @@
+{% load i18n extra_tags %}
+<section class="contract--syllabus">
+    <header class="syllabus--header">
+            <img class="syllabus--header-illustration" src="{{syllabus.cover}}" />
+            <div class="syllabus--header-content">
+                <h4>{{syllabus.title}}</h4>
+                <p>{% trans "Ref." %} {{ syllabus.reference }}</p>
+                <p>{{syllabus.abstract }}</p>
+                <dl>
+                    <dt>{% translate "Total duration of the course: " %}&nbsp;</dt>
+                    <dd>
+                        {% with duration=syllabus.effort|iso8601_to_duration:"hours" %}
+                        {% if duration %}
+                        {% blocktranslate with duration=duration count duration=duration trimmed%}
+                        {{ duration }} hour
+                        {% plural %}
+                        {{ duration }} hours
+                        {% endblocktranslate %}
+                        {% else %}
+                        {{ syllabus.effort|default:"-" }}
+                        {% endif %}
+                        {% endwith %}
+                    </dd>
+                    <dt>{% trans "Available languages:" %}&nbsp;</dt>
+                    <dd>{{ syllabus.languages|default:"-" }}</dd>
+                    <dt>{% trans "Categories:" %}&nbsp;</dt>
+                    <dd>{{ syllabus.categories|join:", "|default:"-" }}</dd>
+                </dl>
+            </div>
+    </header>
+    <section class="syllabus--content">
+        <h5>{% trans "Description" %}</h5>
+        <div>{{ syllabus.description|default:"N/A"|safe|linebreaks }}</div>
+    </section>
+    {% for about in syllabus.abouts %}
+    <section class="syllabus--content">
+        <h5>{{ about.name }}</h5>
+        <div>{{ about.description|default:"N/A"|safe|linebreaks }}</div>
+    </section>
+    {% endfor %}
+    <section class="syllabus--content">
+        <h5>{% trans "Prerequisites" %}</h5>
+        <div>{{ syllabus.prerequisites|default:"N/A"|safe|linebreaks }}</div>
+    </section>
+    <section class="syllabus--content">
+        <h5>{% trans "Assessment and certification" %}</h5>
+        <div>{{ syllabus.assessments|default:"N/A"|safe|linebreaks }}</div>
+    </section>
+    <section class="syllabus--content syllabus--organizations">
+        <h5>{% trans "Organizations" %}</h5>
+        {% if syllabus.organizations %}
+        {% for organization in syllabus.organizations %}
+        <div class="syllabus--organization">
+            <img src="{{ organization.logo }}" />
+            <a href="{{ organization.url }}"><strong>{{ organization.name }}</strong></a>
+        </div>
+        {% endfor %}
+        {% else %}
+            <p>N/A</p>
+        {% endif %}
+    </section>
+    <section class="syllabus--content syllabus--team">
+        <h5>{% trans "Course team" %}</h5>
+        {% if syllabus.team %}
+        {% for contributor in syllabus.team %}
+        <div class="syllabus--contributor">
+            <img src="{{ contributor.avatar }}" />
+            <div>
+                <p>
+                    <a href="{{ contributor.url }}">
+                        <strong>{{ contributor.name }}</strong>
+                    </a>
+                </p>
+                <p>{{ contributor.description }}</p>
+            </div>
+        </div>
+        {% endfor %}
+        {% else %}
+            <p>N/A</p>
+        {% endif %}
+    </section>
+    <section class="syllabus--content syllabus--course-plan">
+    <h5>Course plan</h5>
+    {% if syllabus.plan %}
+    {% for plan in syllabus.plan %}
+        {% if plan.name %}
+        <p>{{ plan.name|linebreaks }}</p>
+        {% endif %}
+        {% if plan.parts %}
+            <ul>
+                {% for part in plan.parts|dictsort:"position" %}
+                {% include "contract_definition/fragment_course_plan.html" with plan=part %}
+                {% endfor %}
+            </ul>
+        {% endif %}
+    {% endfor %}
+    {% else %}
+    <p>N/A</p>
+    {% endif %}
+    </section>
+    <section class="syllabus--content syllabus--licenses">
+    <h5>{% trans "Licenses" %}</h5>
+    {% if syllabus.licenses %}
+        {% for license in syllabus.licenses %}
+            <div>
+                <img src="{{ license.logo }}" height="50" />
+                <h6>{{ license.name }}</h6>
+                <p><a href="{{ license.url }}">{{ license.url }}</a></p>
+                <div>{{ license.description|safe}}</div>
+            </div>
+        {% endfor %}
+    {% else %}
+        <p>N/A</p>
+    {% endif %}
+    </section>
+</section>

--- a/src/backend/joanie/core/templates/contract_definition/fragment_course_plan.html
+++ b/src/backend/joanie/core/templates/contract_definition/fragment_course_plan.html
@@ -1,0 +1,10 @@
+<li>
+    <p>{{ plan.name }}</p>
+    {% if plan.children %}
+        <ul>
+        {% for child in plan.children|dictsort:"position" %}
+            {% include "contract_definition/fragment_course_plan.html" with plan=child %}
+        {% endfor %}
+        </ul>
+    {% endif %}
+</li>

--- a/src/backend/joanie/core/templates/issuers/contract_definition.css
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.css
@@ -76,6 +76,7 @@
 
 .content--context dl {
   border: thin solid #BBB;
+  border-radius: 4px;
   line-height: 1.3;
   margin-top: 3mm;
   padding: 4mm;
@@ -124,4 +125,97 @@
   flex-direction: row;
   justify-content: space-between;
   margin-top: 20mm;
+}
+
+/* == Content - Syllabus appendix */
+.syllabus--header {
+  background: #e67a00;
+  border-radius: 4px;
+  display: block;
+  margin-bottom: 10mm;
+  overflow: hidden;
+}
+
+.syllabus--header > .syllabus--header-illustration {
+  padding: 0;
+  margin: 0;
+  display: block;
+  width: 100%;
+}
+
+.syllabus--header > .syllabus--header-content {
+  color: #FFF;
+  padding: 5mm;
+  margin-top: -7mm;
+}
+
+.syllabus--header > .syllabus--header-content h4 {
+  font-size: 20pt;
+  font-weight: 900;
+  line-height: 1.1;
+}
+
+.syllabus--header > .syllabus--header-content dt {
+  float: left;
+  font-weight: bold;
+}
+
+.syllabus--content {
+  margin-bottom: 5mm;
+  margin-top: 0;
+}
+
+.syllabus--content h5 {
+  font-size: 16pt;
+}
+
+.syllabus--content h6 {
+  font-size: 11pt;
+}
+
+.syllabus--content h5,
+.syllabus--content h6
+.syllabus--content p {
+  margin: 0;
+}
+
+.syllabus--organization,
+.syllabus--contributor {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 5mm;
+}
+
+.syllabus--organization div,
+.syllabus--contributor div {
+  flex: 1;
+}
+
+.syllabus--organization img,
+.syllabus--contributor  img {
+  border-radius: 4px;
+  border: solid thin #BBB;
+  display: block;
+  height: 20mm;
+  margin-right: 2.5mm;
+  object-fit: contain;
+  object-position: center;
+  width: 20mm;
+}
+
+.syllabus--contributor  img {
+  border-radius: 20mm;
+}
+
+.syllabus--contributor p{
+  margin: 0;
+}
+
+.syllabus--course-plan >  ul > li > p {
+  font-weight: bold;
+}
+.syllabus--course-plan >  ul > li > ul {
+  line-height: 1;
+  margin-bottom: 5mm;
 }

--- a/src/backend/joanie/core/templates/issuers/contract_definition.html
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.html
@@ -3,7 +3,7 @@
 {% load extra_tags %}
 
 {% comment %}
-This template aims to be used as a contract definition for training built by Unicamp© brand.
+This template aims to be used as a contract for training built by Unicamp© brand.
 Surely you will need to create a new contract template for your training, feel free to use
 this template as a base.
 {% endcomment %}
@@ -123,10 +123,16 @@ this template as a base.
               {% if contract %}
                   {{ contract.body|safe }}
               {% endif %}
+              {% if contract.terms_and_conditions or syllabus %}
+                <h2>{% translate "Appendices" %}</h2>
+              {% endif %}
               {% if contract.terms_and_conditions %}
-                  <h2>{% translate "Appendices" %}</h2>
                   <h3>{% translate "Terms and conditions" %}</h3>
                   {{ contract.terms_and_conditions|safe }}
+              {% endif %}
+              {% if syllabus %}
+                <h3>{% translate "Catalog syllabus" %}</h3>
+                {% include "contract_definition/fragment_appendice_syllabus.html" with syllabus=syllabus %}
               {% endif %}
           </section>
           <footer class="content-signatures">

--- a/src/backend/joanie/core/utils/contract_context_processors.py
+++ b/src/backend/joanie/core/utils/contract_context_processors.py
@@ -1,0 +1,185 @@
+"""Context processors for the contract definition template."""
+
+import io
+from http import HTTPStatus
+from logging import getLogger
+
+from django.conf import settings
+
+import html5lib
+import requests
+from pyRdfa import pyRdfa
+from rdflib.namespace import RDF, SDO
+from urllib3.util import Retry
+
+logger = getLogger(__name__)
+
+RETRY_STATUSES = [
+    HTTPStatus.INTERNAL_SERVER_ERROR,
+    HTTPStatus.BAD_GATEWAY,
+    HTTPStatus.SERVICE_UNAVAILABLE,
+    HTTPStatus.GATEWAY_TIMEOUT,
+]
+
+adapter = requests.adapters.HTTPAdapter(
+    max_retries=Retry(
+        total=3,
+        backoff_factor=0.1,
+        status_forcelist=RETRY_STATUSES,
+        allowed_methods=["GET"],
+    )
+)
+
+session = requests.Session()
+session.mount("http://", adapter)
+session.mount("https://", adapter)
+
+RDFA_PROCESSOR = pyRdfa()
+DOM_PARSER = html5lib.HTMLParser(tree=html5lib.getTreeBuilder("dom"))
+
+
+def parse_richie_syllabus(course_code: str, language_code: str | None) -> dict:
+    """
+    If a remote Richie instance is configured, retrieve the syllabus
+    through the provided `course_code` in the `language_code`
+    otherwise it returns an empty dict.
+    """
+    url = settings.JOANIE_CATALOG_BASE_URL
+
+    if not url:
+        raise ValueError(
+            "The origin of the Richie instance should "
+            "be set through `JOANIE_CATALOG_BASE_URL` setting."
+        )
+
+    try:
+        response = session.get(
+            f"{url}/redirects/courses/{course_code}/",
+            headers={"Accept-Language": language_code},
+            timeout=10,
+        )
+    except requests.exceptions.RetryError as exception:
+        logger.error(
+            "Cannot fetch the Richie syllabus due to max retries exceeded.",
+            exc_info=exception,
+            extra={
+                "context": {"course_code": course_code, "language_code": language_code}
+            },
+        )
+        response = None
+    except requests.exceptions.RequestException as exception:
+        logger.error(
+            "Cannot fetch the Richie syllabus: %s.",
+            exception,
+            exc_info=exception,
+            extra={
+                "context": {"course_code": course_code, "language_code": language_code}
+            },
+        )
+        response = None
+    else:
+        if response.status_code != HTTPStatus.OK:
+            logger.error(
+                "Cannot fetch the Richie syllabus: %s.",
+                response.status_code,
+                extra={
+                    "context": {
+                        "course_code": course_code,
+                        "language_code": language_code,
+                    },
+                    "response": response,
+                },
+            )
+            response = None
+
+    if response is None:
+        return {}
+
+    def get_object_repr(subject, predicate):
+        """
+        Retrieve the string representation of the first object
+        matching the given `subject` and `predicate`.
+        """
+        return str(next(graph.objects(subject, predicate), ""))
+
+    content = response.content.decode("utf-8")
+    dom = DOM_PARSER.parse(io.StringIO(content))
+    graph = RDFA_PROCESSOR.graph_from_DOM(dom)
+    course = next(graph.subjects(predicate=RDF.type, object=SDO.Course), None)
+
+    course_plans = graph.objects(course, SDO.syllabusSections)
+
+    def build_course_plan(subject):
+        """Recursively build the course plan of a Syllabus subject."""
+        return {
+            "name": get_object_repr(subject, SDO.name),
+            "position": get_object_repr(subject, SDO.position),
+            "children": [
+                build_course_plan(part) for part in graph.objects(subject, SDO.hasPart)
+            ],
+        }
+
+    context = {
+        "title": get_object_repr(subject=course, predicate=SDO.name),
+        "reference": get_object_repr(subject=course, predicate=SDO.courseCode),
+        "cover": get_object_repr(subject=course, predicate=SDO.image),
+        "abstract": get_object_repr(subject=course, predicate=SDO.abstract),
+        "effort": get_object_repr(subject=course, predicate=SDO.timeRequired),
+        "languages": get_object_repr(subject=course, predicate=SDO.availableLanguage),
+        "categories": [
+            get_object_repr(subject=c, predicate=SDO.name)
+            for c in graph.objects(subject=course, predicate=SDO.keywords)
+        ],
+        "organizations": [
+            {
+                "name": get_object_repr(subject=o, predicate=SDO.name),
+                "logo": get_object_repr(subject=o, predicate=SDO.logo),
+                "url": get_object_repr(subject=o, predicate=SDO.url),
+            }
+            for o in graph.objects(subject=course, predicate=SDO.author)
+        ],
+        "team": [
+            {
+                "avatar": get_object_repr(subject=p, predicate=SDO.image),
+                "name": get_object_repr(subject=p, predicate=SDO.name),
+                "description": get_object_repr(subject=p, predicate=SDO.description),
+                "url": get_object_repr(subject=p, predicate=SDO.url),
+            }
+            for p in graph.objects(subject=course, predicate=SDO.contributor)
+        ],
+        "description": get_object_repr(subject=course, predicate=SDO.description),
+        "prerequisites": get_object_repr(
+            subject=course, predicate=SDO.coursePrerequisites
+        ),
+        "abouts": [
+            {
+                "name": get_object_repr(about_subject, SDO.name),
+                "description": get_object_repr(about_subject, SDO.description),
+            }
+            for about_subject in graph.objects(subject=course, predicate=SDO.about)
+        ],
+        "assessments": get_object_repr(
+            subject=course, predicate=SDO.educationalCredentialAwarded
+        ),
+        "licenses": [
+            {
+                "logo": get_object_repr(subject=l, predicate=SDO.thumbnailUrl),
+                "name": get_object_repr(subject=l, predicate=SDO.name),
+                "description": get_object_repr(subject=l, predicate=SDO.abstract),
+                "url": get_object_repr(subject=l, predicate=SDO.url),
+            }
+            for l in graph.objects(subject=course, predicate=SDO.license)
+        ],
+        "plan": [
+            {
+                "name": get_object_repr(course_plan, SDO.name),
+                "parts": [
+                    build_course_plan(part)
+                    for part in graph.objects(course_plan, SDO.hasPart)
+                ],
+            }
+            for course_plan in course_plans
+        ],
+    }
+
+    return context

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -275,6 +275,15 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # Context processors for document issuers
+    JOANIE_DOCUMENT_ISSUER_CONTEXT_PROCESSORS = {
+        "contract_definition": values.ListValue(
+            [],
+            environ_name="JOANIE_CONTRACT_CONTEXT_PROCESSORS",
+            environ_prefix=None,
+        ),
+    }
+
     # Cache
     CACHES = {
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
@@ -679,6 +688,7 @@ class Test(Base):
     JOANIE_SIGNATURE_BACKEND = "joanie.signature.backends.dummy.DummySignatureBackend"
 
     JOANIE_ENROLLMENT_GRADE_CACHE_TTL = 0
+    JOANIE_DOCUMENT_ISSUER_CONTEXT_PROCESSORS = {"contract_definition": []}
 
     LOGGING = values.DictValue(
         {

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -275,6 +275,11 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    JOANIE_CATALOG_BASE_URL = values.Value(
+        environ_name="JOANIE_CATALOG_BASE_URL",
+        environ_prefix=None,
+    )
+
     # Context processors for document issuers
     JOANIE_DOCUMENT_ISSUER_CONTEXT_PROCESSORS = {
         "contract_definition": values.ListValue(

--- a/src/backend/joanie/tests/core/test_utils_contract_context_processors.py
+++ b/src/backend/joanie/tests/core/test_utils_contract_context_processors.py
@@ -1,0 +1,321 @@
+"""Test suite for the contract context processors utilities."""
+
+import random
+from http import HTTPStatus
+from logging import Logger
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+import requests
+import responses
+
+from joanie.core.utils.contract_context_processors import (
+    RETRY_STATUSES,
+    parse_richie_syllabus,
+)
+
+
+class UtilsContractContextProcessors(TestCase):
+    """Test suite for the contract context processors utilities."""
+
+    maxDiff = None
+
+    @override_settings(JOANIE_CATALOG_BASE_URL="http://richie.test")
+    def test_contract_context_processors_parse_richie_syllabus(self):
+        """
+        `parse_richie_syllabus` should return a dict a property "syllabus" containing all the
+        attributes of the syllabus extracted from the remote Richie instance through
+        RDF attributes.
+        """
+        with responses.RequestsMock() as m:
+            mock_request = m.get(
+                "http://richie.test/redirects/courses/178001/",
+                status=HTTPStatus.OK,
+                body="""
+                <body vocab="https://schema.org/" typeof="Course">
+                    <h1 property="name">Course title</h1>
+                    <img src="//fun-cdn.net/images/1" property="image" />
+                    <span property="courseCode">178001</span>
+                    <span property="timeRequired">PT3H</span>
+                    <span property="availableLanguage">French</span>
+                    <ul>
+                        <li property="keywords" typeof="DefinedTerm">
+                            <span property="name">Category 1</span>
+                        </li>
+                        <li property="keywords" typeof="DefinedTerm">
+                            <span property="name">Category 2</span>
+                        </li>
+                    </ul>
+                    <p property="abstract">Course short description</p>
+                    <p property="description">Course long description</p>
+                    <p property="coursePrerequisites">Course prerequisites</p>
+                    <p property="educationalCredentialAwarded">Course assessments and awards</p>
+                    <div property="about" typeof="Thing">
+                        <h2 property="name">Format</h2>
+                        <p property="description">Course format</p>
+                    </div>
+                    <div property="about" typeof="Thing">
+                        <h2 property="name">What you will learn?</h2>
+                        <p property="description">Course teaches</p>
+                    </div>
+                    <div property="author" typeof="Organization">
+                        <img src="//fun-cdn.net/images/2" property="logo" />
+                        <span property="name">Organization name</span>
+                        <meta property="url" content="http://richie.test/en/orgs/1" />
+                    </div>
+                    <div property="contributor" typeof="Person">
+                        <img src="//fun-cdn.net/images/3" property="image" />
+                        <span property="name">Contributor name</span>
+                        <span property="description">Contributor bio</span>
+                        <meta property="url" content="http://richie.test/en/person/1" />
+                    </div>
+                    <div property="license" typeof="CreativeWork">
+                        <img src="//fun-cdn.net/images/4" property="thumbnailUrl" />
+                        <span property="name">CC BY-NC-ND 4.0</span>
+                        <span property="abstract">License description</span>
+                        <meta property="url" content="https://creativecommons.org/licenses/by-nc-nd/4.0/deed.fr" />
+                    </div>
+                    <ul property="syllabusSections" typeof="Syllabus">
+                        <li property="hasPart" typeof="Syllabus">
+                            <h3 property="name">Chapter 1</h3>
+                            <meta property="position" content="0" />
+                            <ul>
+                                <li property="hasPart" typeof="Syllabus">
+                                    <h4 property="name">Part 1</h4>
+                                    <meta property="position" content="0" />
+                                </li>
+                                <li property="hasPart" typeof="Syllabus">
+                                    <h4 property="name">Part 2</h4>
+                                    <meta property="position" content="1" />
+                                </li>
+                            </ul>
+                        </li>
+                        <li property="hasPart" typeof="Syllabus">
+                            <h3 property="name">Chapter 2</h3>
+                            <meta property="position" content="1" />
+                        </li>
+                    </ul>
+                </body> 
+                """,
+            )
+            context = parse_richie_syllabus("178001", "fr-fr")
+
+        self.assertEqual(mock_request.call_count, 1)
+        self.assertEqual(
+            mock_request.calls[0].request.headers["Accept-Language"], "fr-fr"
+        )
+
+        self.assertEqual(context["title"], "Course title")
+        self.assertEqual(context["reference"], "178001")
+        self.assertEqual(context["cover"], "//fun-cdn.net/images/1")
+        self.assertEqual(context["abstract"], "Course short description")
+        self.assertEqual(context["description"], "Course long description")
+        self.assertEqual(context["prerequisites"], "Course prerequisites")
+        self.assertEqual(context["assessments"], "Course assessments and awards")
+        self.assertEqual(context["effort"], "PT3H")
+        self.assertEqual(context["languages"], "French")
+        self.assertCountEqual(context["categories"], ["Category 1", "Category 2"])
+        self.assertCountEqual(
+            context["abouts"],
+            [
+                {
+                    "name": "Format",
+                    "description": "Course format",
+                },
+                {
+                    "name": "What you will learn?",
+                    "description": "Course teaches",
+                },
+            ],
+        )
+        self.assertEqual(
+            context["organizations"],
+            [
+                {
+                    "logo": "//fun-cdn.net/images/2",
+                    "name": "Organization name",
+                    "url": "http://richie.test/en/orgs/1",
+                }
+            ],
+        )
+        self.assertEqual(
+            context["team"],
+            [
+                {
+                    "avatar": "//fun-cdn.net/images/3",
+                    "name": "Contributor name",
+                    "description": "Contributor bio",
+                    "url": "http://richie.test/en/person/1",
+                }
+            ],
+        )
+        self.assertEqual(
+            context["licenses"],
+            [
+                {
+                    "logo": "//fun-cdn.net/images/4",
+                    "name": "CC BY-NC-ND 4.0",
+                    "description": "License description",
+                    "url": "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.fr",
+                }
+            ],
+        )
+
+        course_plan = context["plan"]
+        self.assertEqual(len(course_plan), 1)
+        course_plan = course_plan[0]
+        self.assertEqual(course_plan["name"], "")
+        self.assertEqual(len(course_plan["parts"]), 2)
+        chapter_1 = next(
+            (x for x in course_plan["parts"] if x["name"] == "Chapter 1"), None
+        )
+        self.assertEqual(chapter_1["position"], "0")
+        self.assertEqual(len(chapter_1["children"]), 2)
+        part_1 = next((x for x in chapter_1["children"] if x["name"] == "Part 1"), None)
+        part_2 = next((x for x in chapter_1["children"] if x["name"] == "Part 2"), None)
+        self.assertEqual(part_1["position"], "0")
+        self.assertEqual(part_1["children"], [])
+        self.assertEqual(part_2["position"], "1")
+        self.assertEqual(part_2["children"], [])
+
+        chapter_2 = next(
+            (x for x in course_plan["parts"] if x["name"] == "Chapter 2"), None
+        )
+        self.assertEqual(chapter_2["position"], "1")
+        self.assertEqual(chapter_2["children"], [])
+
+    @override_settings(JOANIE_CATALOG_BASE_URL="http://richie.test")
+    def test_contract_context_processors_parse_richie_syllabus_empty_values(self):
+        """
+        `parse_richie_syllabus` should return a dict a property "syllabus" containing all the
+        attributes of the syllabus extracted from the remote Richie instance through
+        RDF attributes. If an attributes is not found, it should be set with an empty value.
+        """
+        with responses.RequestsMock() as m:
+            mock_request = m.get(
+                "http://richie.test/redirects/courses/178001/",
+                status=HTTPStatus.OK,
+            )
+            context = parse_richie_syllabus("178001", "en-us")
+
+        self.assertEqual(mock_request.call_count, 1)
+        self.assertEqual(
+            mock_request.calls[0].request.headers["Accept-Language"], "en-us"
+        )
+
+        self.assertEqual(
+            context,
+            {
+                "title": "",
+                "reference": "",
+                "cover": "",
+                "abstract": "",
+                "description": "",
+                "prerequisites": "",
+                "assessments": "",
+                "effort": "",
+                "languages": "",
+                "categories": [],
+                "abouts": [],
+                "organizations": [],
+                "team": [],
+                "licenses": [],
+                "plan": [],
+            },
+        )
+
+    @override_settings(JOANIE_CATALOG_BASE_URL=None)
+    def test_contract_context_processors_parse_richie_syllabus_missing_setting(self):
+        """
+        When the `parse_richie_syllabus_request` is called without JOANIE_CATALOG_BASE_URL
+        set a ValueError should be raised.
+        """
+
+        with self.assertRaises(ValueError) as context:
+            parse_richie_syllabus("178001", "en-us")
+
+        self.assertEqual(
+            str(context.exception),
+            "The origin of the Richie instance should "
+            "be set through `JOANIE_CATALOG_BASE_URL` setting.",
+        )
+
+    @override_settings(JOANIE_CATALOG_BASE_URL="http://richie.test")
+    @mock.patch.object(Logger, "error")
+    def test_contract_context_processors_parse_richie_syllabus_request_failure(
+        self, mock_logger
+    ):
+        """
+        When the request to the remote Richie instance fails,
+        an empty dict should be returned and an error should be logged.
+        """
+        with responses.RequestsMock() as m:
+            mock_request = m.get(
+                "http://richie.test/redirects/courses/178001/",
+                status=HTTPStatus.NOT_FOUND,
+            )
+            context = parse_richie_syllabus("178001", "fr-fr")
+
+        self.assertEqual(mock_request.call_count, 1)
+
+        # - The logger should have been called once with details about the error
+        self.assertEqual(mock_logger.call_count, 1)
+        self.assertEqual(
+            mock_logger.call_args_list[0][0],
+            ("Cannot fetch the Richie syllabus: %s.", HTTPStatus.NOT_FOUND),
+        )
+        self.assertEqual(
+            mock_logger.call_args_list[0][1]["extra"]["context"],
+            {"course_code": "178001", "language_code": "fr-fr"},
+        )
+        self.assertIsInstance(
+            mock_logger.call_args_list[0][1]["extra"]["response"],
+            requests.Response,
+        )
+
+        # - The context should be an empty dict
+        self.assertEqual(context, {})
+
+    @override_settings(JOANIE_CATALOG_BASE_URL="http://richie.test")
+    @mock.patch.object(Logger, "error")
+    def test_contract_context_processors_parse_richie_syllabus_request_failure_max_retries(
+        self, mock_logger
+    ):
+        """
+        When the request to the remote Richie instance fails with 5xx errors,
+        the request should be retried 3 times afterward an empty dict should be returned
+        and an error should be logged.
+        """
+        with responses.RequestsMock() as m:
+            mock_request = m.get(
+                "http://richie.test/redirects/courses/178001/",
+                status=random.choice(RETRY_STATUSES),
+            )
+            context = parse_richie_syllabus("178001", "en-us")
+
+        # - The request should be retried 3 times
+        self.assertEqual(mock_request.call_count, 4)
+
+        # - The logger should have been called once with details about the error
+        self.assertEqual(mock_logger.call_count, 1)
+        self.assertEqual(
+            mock_logger.call_args_list[0][0],
+            ("Cannot fetch the Richie syllabus due to max retries exceeded.",),
+        )
+        self.assertEqual(
+            mock_logger.call_args_list[0][1]["extra"],
+            {
+                "context": {
+                    "course_code": "178001",
+                    "language_code": "en-us",
+                }
+            },
+        )
+        self.assertIsInstance(
+            mock_logger.call_args_list[0][1]["exc_info"],
+            requests.exceptions.RetryError,
+        )
+
+        # - The context should be an empty dict
+        self.assertEqual(context, {})

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     "psycopg[binary]==3.1.18",
     "pydantic[email]>2",
     "PyJWT==2.8.0",
+    "pyRdfa3==3.6.2",
     "requests==2.31.0",
     "sentry-sdk==1.43.0",
     "timedelta-isoformat==0.6.2.11",


### PR DESCRIPTION
## Purpose

We would like to retrieve syllabus information from a remote Richie instance then bind those information contracts. In order to do that, from Richie, we complete the RDFa tagging on the syllabus page (https://github.com/openfun/richie/pull/2333).
Now, we implement the logic to retrieve a syllabus page from Richie then parse this document to bind syllabus into contract definition context then display it into contract template appendices.

![CleanShot 2024-03-28 at 21 19 02@2x](https://github.com/openfun/joanie/assets/9265241/79ae9b20-7ee8-4986-8585-c769736d384b)


## Proposal

- [x] Add contract context processors
- [x] Retrieve syllabus from configured Richie instance
- [x] Parse syllabus through RDF attributs
- [x] Display syllabus into contract template
