### PR TITLE
✨(back) add redis backend to cache configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add redis backend to cache configuration
 - Add generate certificate button in Back Office
 - Add admin Enrollment endpoint
 - Add tabs layout on back offices forms

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -801,6 +801,32 @@ class Production(Base):
         },
     }
 
+    # Cache
+    # Enable the alternate connection factory.
+    DJANGO_REDIS_CONNECTION_FACTORY = values.Value(
+        "django_redis.pool.ConnectionFactory",
+        environ_prefix=None,
+        environ_name="DJANGO_REDIS_CONNECTION_FACTORY",
+    )
+
+    CACHES = {
+        "default": {
+            "BACKEND": values.Value(
+                "django_redis.cache.RedisCache", environ_name="CACHE_DEFAULT_BACKEND"
+            ),
+            # The hostname in LOCATION
+            "LOCATION": values.Value(
+                "redis://redis/0", environ_name="CACHE_DEFAULT_LOCATION"
+            ),
+            "OPTIONS": values.DictValue(
+                {
+                    "CLIENT_CLASS": "django_redis.client.DefaultClient",
+                },
+                environ_name="CACHE_DEFAULT_OPTIONS",
+            ),
+        },
+    }
+
     THUMBNAIL_DEFAULT_STORAGE = values.Value(
         "joanie.core.storages.JoanieEasyThumbnailS3Storage"
     )

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "django-money==3.4.1",
     "django-object-actions==4.2.0",
     "django-parler==2.3",
+    "django-redis==5.4.0",
     "django-storages==1.14.2",
     "Django<5",
     "djangorestframework-simplejwt==5.3.1",


### PR DESCRIPTION
## Purpose

We want to use a redis backend for our cache in production. For this we are using django-redi library, this library is configurable with many different redis configuration. Every settings for the default cache can be configured.
https://github.com/jazzband/django-redis

## Proposal


- [x] add redis backend to cache configuration

Resolve #722
