### PR TITLE
🐛(backend) fix user list ordering

### DIFF
--- a/src/backend/joanie/core/api/admin/__init__.py
+++ b/src/backend/joanie/core/api/admin/__init__.py
@@ -144,6 +144,7 @@ class UserViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     filterset_class = filters.UserAdminFilterSet
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["created_on"]
+    ordering = "created_on"
 
     def get_queryset(self):
         """


### PR DESCRIPTION


## Purpose

We have a flaky test related to list ordering.
It appears that the viewset ordering is missing.


