### PR TITLE
🐛(backend) zip archive of contract by organization

### DIFF
--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -1199,17 +1199,18 @@ class ContractViewSet(GenericContractViewSet):
         We return in the response the URL for polling the ZIP archive once it has been generated.
 
         Notes on possible `kwargs` as input parameters :
-            - string of an Organization UUID
-            OR
-            - string of an CourseProductRelation UUID
+            - string of an Organization UUID alone
+            - string of an CourseProductRelation UUID alone
+            - string of both Organization UUID & CourseProductRelation UUID
         """
         serializer = serializers.GenerateSignedContractsZipSerializer(data=request.data)
-
         serializer.is_valid(raise_exception=True)
 
         if not contract_utility.get_signature_backend_references_exists(
-            course_product_relation=serializer.data.get("course_product_relation"),
-            organization=serializer.data.get("organization"),
+            course_product_relation=serializer.validated_data.get(
+                "course_product_relation"
+            ),
+            organization=serializer.validated_data.get("organization"),
             extra_filters={"order__organization__accesses__user_id": request.user.id},
         ):
             raise ValidationError("No zip to generate")

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -993,11 +993,6 @@ class GenerateSignedContractsZipSerializer(serializers.Serializer):
         """
         course_product_relation_id = attrs.get("course_product_relation_id")
         organization_id = attrs.get("organization_id")
-        if course_product_relation_id and organization_id:
-            raise serializers.ValidationError(
-                "You must set exactly one parameter for the method. It cannot be both. "
-                "You must choose between an Organization UUID or a Course Product Relation UUID."
-            )
 
         if not course_product_relation_id and not organization_id:
             raise serializers.ValidationError(

--- a/src/backend/joanie/core/utils/contract.py
+++ b/src/backend/joanie/core/utils/contract.py
@@ -18,8 +18,10 @@ def _get_base_signature_backend_references(
     course_product_relation=None, organization=None, extra_filters=None
 ):
     """
-    Build the base query to get signature backend references from either a Course Product Relation
-    object or an Organization object when the contract is signed.
+    Build the base query to get signature backend references from a Course Product Relation
+    object or an Organization object when the contract is signed. You can pass both parameters if
+    you need to filter out by organization when the course product relation is shared between
+    many organizations.
 
     You may use an additional parameter `extra_filters` if you need to filter out even more the
     base queryset of the Contract (check if the user has access to the organization for example).

--- a/src/backend/joanie/signature/management/commands/generate_zip_archive_of_contracts.py
+++ b/src/backend/joanie/signature/management/commands/generate_zip_archive_of_contracts.py
@@ -100,8 +100,10 @@ class Command(BaseCommand):
             raise CommandError(error_message)
 
         signature_references = contract_utility.get_signature_backend_references(
-            course_product_relation=serializer.data.get("course_product_relation"),
-            organization=serializer.data.get("organization"),
+            course_product_relation=serializer.validated_data.get(
+                "course_product_relation"
+            ),
+            organization=serializer.validated_data.get("organization"),
             extra_filters={"order__organization__accesses__user_id": user_id},
         )  # extra filter to check the access of a user on an organization.
 

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -764,7 +764,7 @@
         "/api/v1.0/contracts/zip-archive/": {
             "post": {
                 "operationId": "contracts_zip_archive_create",
-                "description": "This endpoint is exclusive to users that have access rights on a specific organization.\n\nIt triggers the generation of a ZIP archive if the requesting has the correct access rights\non the organization. If a course product relation UUID is given from key word arguments,\nthe user requires to have access to the organization that is attached to the specific\ncourse product relation object.\nWe return in the response the URL for polling the ZIP archive once it has been generated.\n\nNotes on possible `kwargs` as input parameters :\n    - string of an Organization UUID\n    OR\n    - string of an CourseProductRelation UUID",
+                "description": "This endpoint is exclusive to users that have access rights on a specific organization.\n\nIt triggers the generation of a ZIP archive if the requesting has the correct access rights\non the organization. If a course product relation UUID is given from key word arguments,\nthe user requires to have access to the organization that is attached to the specific\ncourse product relation object.\nWe return in the response the URL for polling the ZIP archive once it has been generated.\n\nNotes on possible `kwargs` as input parameters :\n    - string of an Organization UUID alone\n    - string of an CourseProductRelation UUID alone\n    - string of both Organization UUID & CourseProductRelation UUID",
                 "tags": [
                     "contracts"
                 ],


### PR DESCRIPTION
This PR will solve this [issue](https://github.com/openfun/joanie/issues/714) 

When a user has access to several organizations and those ones are implied in the same `CourseProductRelation`, when the user asks to download an archive of all contracts, he gets all contracts from all the organizations he has access to. Before the fix, only one parameter (CPR or Org) could be used for this endpoint. Now, the endpoint accepts both parameters  `CourseProductRelation` UUID and  `Organization` UUID. Finally, only the contracts that are attached to a specific organization are now archived.

## Purpose

Allow the user (who has organization access) to get all archived contracts from a specific organization.

## Proposal

- Allow to parse 2 parameters with the endpoint to generate the archive of contracts. In the past, we only allowed one parameter at most, either the Organization UUID or the Course Product Relation UUID.

- [x] Find the bug
- [x] Make a test to fix the bug
