### PR TITLE
🌐(backend) add missing translation in contract template

### DIFF
--- a/src/backend/joanie/core/templates/certificate/verify.html
+++ b/src/backend/joanie/core/templates/certificate/verify.html
@@ -10,11 +10,11 @@
         </header>
         <main class="content">
             <section class="content__information">
-                <h1>{% trans "This certificate is genuine!" %}</h1>
+                <h1>{% translate "This certificate is genuine!" %}</h1>
                 <p>{%blocktranslate trimmed with creation_date=certificate_context.creation_date|date:"SHORT_DATE_FORMAT" learner_name=certificate_context.student.name organization_name=certificate_context.organizations.0.name%}
                     This certificate has been issued on {{ creation_date }} to {{ learner_name }} by {{ organization_name }}.
                     {% endblocktranslate %}</p>
-                <p>{% trans "Please compare information displayed on the certificate below with yours." %}</p>
+                <p>{% translate "Please compare information displayed on the certificate below with yours." %}</p>
             </section>
             <section class="content__document">
                 <iframe id="pdf-viewer" src="data:application/pdf;base64,{{base64_pdf}}" type="application/pdf"></iframe>

--- a/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
+++ b/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
@@ -4,7 +4,7 @@
             <img class="syllabus--header-illustration" src="{{syllabus.cover}}" />
             <div class="syllabus--header-content">
                 <h4>{{syllabus.title}}</h4>
-                <p>{% trans "Ref." %} {{ syllabus.reference }}</p>
+                <p>{% translate "Ref." %} {{ syllabus.reference }}</p>
                 <p>{{syllabus.abstract }}</p>
                 <dl>
                     <dt>{% translate "Total duration of the course: " %}&nbsp;</dt>
@@ -21,15 +21,15 @@
                         {% endif %}
                         {% endwith %}
                     </dd>
-                    <dt>{% trans "Available languages:" %}&nbsp;</dt>
+                    <dt>{% translate "Available languages:" %}&nbsp;</dt>
                     <dd>{{ syllabus.languages|default:"-" }}</dd>
-                    <dt>{% trans "Categories:" %}&nbsp;</dt>
+                    <dt>{% translate "Categories:" %}&nbsp;</dt>
                     <dd>{{ syllabus.categories|join:", "|default:"-" }}</dd>
                 </dl>
             </div>
     </header>
     <section class="syllabus--content">
-        <h5>{% trans "Description" %}</h5>
+        <h5>{% translate "Description" %}</h5>
         <div>{{ syllabus.description|default:"N/A"|safe|linebreaks }}</div>
     </section>
     {% for about in syllabus.abouts %}
@@ -39,15 +39,15 @@
     </section>
     {% endfor %}
     <section class="syllabus--content">
-        <h5>{% trans "Prerequisites" %}</h5>
+        <h5>{% translate "Prerequisites" %}</h5>
         <div>{{ syllabus.prerequisites|default:"N/A"|safe|linebreaks }}</div>
     </section>
     <section class="syllabus--content">
-        <h5>{% trans "Assessment and certification" %}</h5>
+        <h5>{% translate "Assessment and certification" %}</h5>
         <div>{{ syllabus.assessments|default:"N/A"|safe|linebreaks }}</div>
     </section>
     <section class="syllabus--content syllabus--organizations">
-        <h5>{% trans "Organizations" %}</h5>
+        <h5>{% translate "Organizations" %}</h5>
         {% if syllabus.organizations %}
         {% for organization in syllabus.organizations %}
         <div class="syllabus--organization">
@@ -60,7 +60,7 @@
         {% endif %}
     </section>
     <section class="syllabus--content syllabus--team">
-        <h5>{% trans "Course team" %}</h5>
+        <h5>{% translate "Course team" %}</h5>
         {% if syllabus.team %}
         {% for contributor in syllabus.team %}
         <div class="syllabus--contributor">
@@ -99,7 +99,7 @@
     {% endif %}
     </section>
     <section class="syllabus--content syllabus--licenses">
-    <h5>{% trans "Licenses" %}</h5>
+    <h5>{% translate "Licenses" %}</h5>
     {% if syllabus.licenses %}
         {% for license in syllabus.licenses %}
             <div>

--- a/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
+++ b/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
@@ -80,7 +80,7 @@
         {% endif %}
     </section>
     <section class="syllabus--content syllabus--course-plan">
-    <h5>Course plan</h5>
+    <h5>{% trans "Course plan" %}</h5>
     {% if syllabus.plan %}
     {% for plan in syllabus.plan %}
         {% if plan.name %}

--- a/src/backend/joanie/core/templates/issuers/contract_definition.html
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.html
@@ -28,9 +28,9 @@ this template as a base.
               <p>{{contract.description|linebreaks}}</p>
           </header>
           <section class="content--context">
-              <p>The current contract is formed between the University and the Learner, as identified below:</p>
+              <p>{% translate "The current contract is formed between the University and the Learner, as identified below:" %}</p>
               <dl>
-                  <dt>{% translate "University (hereinafter \"the University\"): "%}</dt>
+                  <dt>{% translate 'University (hereinafter "the University"): '%}</dt>
                   <dd>
                       <ul>
                           <li>{% translate "Name of the University: "%}{{ organization.name }}</li>
@@ -57,7 +57,7 @@ this template as a base.
                           <li>{% translate "Data Protection Officer contact: "%}{{ organization.dpo_email|default:"-" }}</li>
                       </ul>
                   </dd>
-                  <dt>{% translate "Learner (hereinafter \"the Learner\"):" %}</dt>
+                  <dt>{% translate 'Learner (hereinafter "the Learner"):' %}</dt>
                   <dd>
                       <ul>
                           <li>{% translate "Full name: " %}{{ student.name }}</li>
@@ -68,7 +68,7 @@ this template as a base.
                           <li>{% translate "Telephone number: " %}{{ student.phone_number|default:"-" }}</li>
                       </ul>
                   </dd>
-                  <dt>{% translate "Course (hereinafter \"the Course\"):" %}</dt>
+                  <dt>{% translate 'Course (hereinafter "the Course"):' %}</dt>
                   <dd>
                       <ul>
                           <li>{% translate "Course number: " %}{{ course.code }}</li>

--- a/src/backend/joanie/core/templates/issuers/invoice.html
+++ b/src/backend/joanie/core/templates/issuers/invoice.html
@@ -18,9 +18,9 @@
       </div>
       <h1 class="header-title light">
         {% if metadata.type == "invoice" %}
-          {% trans "Invoice" %}
+          {% translate "Invoice" %}
         {% else %}
-          {% trans "Credit note" %}
+          {% translate "Credit note" %}
         {% endif %}
       </h1>
     </header>
@@ -29,9 +29,9 @@
         <li class="invoice-stakeholders__item">
           <h5 class="invoice-stakeholders__item-label">
             {% if metadata.type == "invoice" %}
-              {% trans "Sold by" %}
+              {% translate "Sold by" %}
             {% else %}
-              {% trans "Refunded by" %}
+              {% translate "Refunded by" %}
             {% endif %}
           </h5>
           <address class="invoice-stakeholders__item-address">
@@ -41,9 +41,9 @@
         <li class="invoice-stakeholders__item">
           <h5 class="invoice-stakeholders__item-label">
             {% if metadata.type == "invoice" %}
-              {% trans "Billed to" %}
+              {% translate "Billed to" %}
             {% else %}
-              {% trans "Refunded to" %}
+              {% translate "Refunded to" %}
             {% endif %}
           </h5>
           <address class="invoice-stakeholders__item-address">
@@ -56,17 +56,17 @@
       <section class="invoice-metadata">
         <h5 class="invoice-metadata__title">
           {% if metadata.type == "invoice" %}
-            {% trans "Invoice information" %}
+            {% translate "Invoice information" %}
           {% else %}
-            {% trans "Credit note information" %}
+            {% translate "Credit note information" %}
           {% endif %}
         </h5>
         <ul class="invoice-list">
           <li class="invoice-list__item">
-            <strong>{% trans "Reference" %}</strong>&nbsp;{{ metadata.reference }}
+            <strong>{% translate "Reference" %}</strong>&nbsp;{{ metadata.reference }}
           </li>
           <li class="invoice-list__item">
-            <strong>{% trans "Issue date" %}</strong>&nbsp;{{ metadata.issued_on|date:"d/m/Y"}}
+            <strong>{% translate "Issue date" %}</strong>&nbsp;{{ metadata.issued_on|date:"d/m/Y"}}
           </li>
         </ul>
       </section>
@@ -75,7 +75,7 @@
         <thead class="product-table__head">
           <tr class="product-table__row">
             <th class="product-table__cell product-table__cell--head">
-              {% trans "Product" %}
+              {% translate "Product" %}
             </th>
             <th
               class="
@@ -84,7 +84,7 @@
                 product-table__cell--right
               "
             >
-              {% trans "Price" %}
+              {% translate "Price" %}
             </th>
             <th
               class="
@@ -93,7 +93,7 @@
                 product-table__cell--right
               "
             >
-              {% trans "VAT" %}&nbsp;({{ order.amount.vat }}%)
+              {% translate "VAT" %}&nbsp;({{ order.amount.vat }}%)
             </th>
             <th
               class="
@@ -102,7 +102,7 @@
                 product-table__cell--right
               "
             >
-              {% trans "Total" %}
+              {% translate "Total" %}
             </th>
           </tr>
         </thead>
@@ -127,15 +127,15 @@
       <div class="invoice_detail_container">
         <table class="invoice_detail_table">
           <tr>
-            <td class="invoice_category_item"><strong>{% trans "Subtotal" %}</strong></td>
+            <td class="invoice_category_item"><strong>{% translate "Subtotal" %}</strong></td>
             <td class="invoice_item_value">{{ order.amount.subtotal|floatformat:2 }}&nbsp;{{ currency }}</td>
           </tr>
           <tr>
-            <td class="invoice_category_item"><strong>{% trans "Sales Tax VAT" %} {{ order.amount.vat }}%</strong></td>
+            <td class="invoice_category_item"><strong>{% translate "Sales Tax VAT" %} {{ order.amount.vat }}%</strong></td>
             <td class="invoice_item_value">{{ order.amount.vat_amount|floatformat:2 }}&nbsp;{{ currency }}</td>
           </tr>
           <tr>
-            <td class="invoice_category_item"><strong>{% trans "Total" %}</strong></td>
+            <td class="invoice_category_item"><strong>{% translate "Total" %}</strong></td>
             <td class="invoice_item_value">{{ order.amount.total|floatformat:2 }}&nbsp;{{ currency }}</td>
           </tr>
         </table>


### PR DESCRIPTION
## Purpose

We forgot to wrap some strings into a `trans` tag


## Proposal

- [x] Add missing translated string into contract definition template
