### PR TITLE
🔧(tray) complete admin nginx conf

### DIFF
--- a/src/tray/templates/services/admin/configs/admin.conf.j2
+++ b/src/tray/templates/services/admin/configs/admin.conf.j2
@@ -7,6 +7,16 @@ server {
   location / {
       try_files $uri $uri.html $uri/ =404;
   }
+
+    location ~ ^(?<base_uri>.*)/[0-9a-f-]*/(?<view>[a-z-]*)$ {
+        # Our next application is a static one and we are not able to generate at build time
+        # all the possible routes. As we deal with a static application, we can't take apart
+        # of the `fallback` feature of getStaticPaths method.
+        # So, as a workaround, we need to try to find the right html file for dynamic routes
+        # Try to find the right html file for dynamic routes containing an id parameter
+        # e.g /admin/courses/123/edit -> /admin/courses/[id]/edit.html
+        try_files $base_uri/[id]/$view.html =404;
+    }
  
   error_page 404 /404.html;
   location = /404.html {


### PR DESCRIPTION
## Purpose

**We did this modification for local environment but not for deployment purpose.**

Currently, on the back office, if a user tries to go directly on a resource page, it gets a 404 error. As we made a static export of our next application, we can't take apart of the fallback option from the getStaticPaths method. In order to prevent to have to build our next application to run through a node server, we decide to simply add a nginx location rule to try to find the right html file for dynamic routes containing an id parameter.
