### PR TITLE
🐛(backend) prevent to sign a document when signatories are missing

### DIFF
--- a/src/backend/joanie/signature/backends/lex_persona.py
+++ b/src/backend/joanie/signature/backends/lex_persona.py
@@ -12,6 +12,7 @@ import requests
 from rest_framework.request import Request
 
 from joanie.core import enums, models
+from joanie.core.utils.contract import order_has_organization_owner
 from joanie.signature import exceptions
 from joanie.signature.backends.base import BaseSignatureBackend
 
@@ -395,6 +396,14 @@ class LexPersonaBackend(BaseSignatureBackend):
         It returns the signature backend reference and the hash of the file from the signature
         provider.
         """
+        if not order_has_organization_owner(order=order):
+            error_msg = (
+                "No organization owner found to initiate "
+                f"the signature process for order {order.id}."
+            )
+            logger.warning(error_msg)
+            raise ValidationError(error_msg)
+
         student_recipient_data = self._prepare_recipient_data_for_student_signer(order)
         organization_recipient_data = (
             self._prepare_recipient_data_for_organization_signer(order)

--- a/src/backend/joanie/tests/core/utils/test_contract.py
+++ b/src/backend/joanie/tests/core/utils/test_contract.py
@@ -642,3 +642,47 @@ class UtilsContractTestCase(TestCase):
             signature_backend_references_list,
             ["wfl_fake_dummy_1"],
         )
+
+    def test_utils_contract_organization_has_owner_without_owners_returns_false(
+        self,
+    ):
+        """
+        When calling the method `order_has_organization_owner` with a order uuid but
+        the organization has not set any owner members yet with organization access,
+        it should return False.
+        """
+        user = factories.UserFactory()
+        order = factories.OrderFactory(
+            owner=user,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+            state=enums.ORDER_STATE_VALIDATED,
+        )
+        factories.ContractFactory(
+            order=order, definition=order.product.contract_definition
+        )
+
+        self.assertFalse(contract_utility.order_has_organization_owner(order=order))
+
+    def test_utils_contract_organization_has_owner_returns_true(
+        self,
+    ):
+        """
+        When calling the method `order_has_organization_owner` with a order uuid and
+        the organization has set owner members with organizationa access, it should return True.
+        """
+        user = factories.UserFactory()
+        order = factories.OrderFactory(
+            owner=user,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+            state=enums.ORDER_STATE_VALIDATED,
+        )
+        factories.ContractFactory(
+            order=order, definition=order.product.contract_definition
+        )
+
+        # When the organization has set some owners with access rights of "owner"
+        factories.UserOrganizationAccessFactory.create_batch(
+            3, organization=order.organization, role="owner"
+        )
+
+        self.assertTrue(contract_utility.order_has_organization_owner(order=order))


### PR DESCRIPTION
This PR solves this [issue](https://github.com/openfun/joanie/issues/713) 

To avoid the situation where the organization has not set any owner members, it causes the contract to have only the student to sign the document where we actually need the signature of both parties. The problem is that if the organization does not have at least one owner, the signature procedure will be created with only 1 signature required. We need two signatures, one from the student and one from the organization to make the contract valid.

To avoid this issue in the future, we've added a new method that will verify if there is one user with the role 'owner' for the organization that is attached to the order.

## Purpose

Prevent having a contract that is set as **fully signed**, but it has only been signed by the student. We must have both parties, the student and at least one of the owners of the organization attached to the order.

## Proposal

Create a util method where we will check if there is still at least 1 owner for the organization that is attached to the order's organization.

- [x] create util method to check the presence of an owner from the organization eligible to sign a contract.
- [x] block the creation of submitting for signature the contract if the organization has not set owner members.
- [x] add/update tests