### PR TITLE
✨(back) endpoint to retrieve a course_run filter on its course_link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Endpoint to retrieve the first course_run related to a course_link
 - Add order payment schedule
 - Manage commercial newsletter subscriptions
 - Allow backoffice to generate certificates from a course and product relation

--- a/src/backend/joanie/edx_imports/api/__init__.py
+++ b/src/backend/joanie/edx_imports/api/__init__.py
@@ -1,0 +1,43 @@
+"""Viewset for course_run in the edx_imports app."""
+
+from http import HTTPStatus
+
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.generics import get_object_or_404
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from joanie.core.models import CourseRun
+from joanie.core.permissions import HasAPIKey
+from joanie.core.serializers import AdminCourseRunSerializer
+
+
+@api_view(["GET"])
+@permission_classes([HasAPIKey])
+@authentication_classes([])
+def course_run_view(request: Request):
+    """
+    Look for first course_runs related to a resource_link.
+    """
+    resource_link = request.query_params.get("resource_link")
+    if resource_link is None:
+        return Response(
+            {"detail": "Query parameter `resource_link` is required."},
+            status=HTTPStatus.BAD_REQUEST,
+        )
+
+    course_run = get_object_or_404(CourseRun, resource_link__icontains=resource_link)
+
+    if not course_run:
+        return Response(
+            {"detail": "Course run not found."},
+            status=HTTPStatus.NOT_FOUND,
+        )
+
+    serializer = AdminCourseRunSerializer(course_run)
+
+    return Response(serializer.data, status=HTTPStatus.OK)

--- a/src/backend/joanie/edx_imports/urls.py
+++ b/src/backend/joanie/edx_imports/urls.py
@@ -1,0 +1,16 @@
+"""
+API routes exposed for server to server. Requires a specific token to request.
+"""
+
+from django.conf import settings
+from django.urls import path
+
+from joanie.edx_imports.api import course_run_view
+
+urlpatterns = [
+    path(
+        f"api/{settings.API_VERSION}/edx_imports/course-run/",
+        course_run_view,
+        name="edx_imports_course_run",
+    )
+]

--- a/src/backend/joanie/tests/edx_imports/api/test_course_run.py
+++ b/src/backend/joanie/tests/edx_imports/api/test_course_run.py
@@ -1,0 +1,100 @@
+"""Test suite for remote API endpoints on course run in the edx_imports application."""
+
+from http import HTTPStatus
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from joanie.core import factories
+from joanie.tests import format_date
+
+
+class EdxImportsCourseRunApiTest(TestCase):
+    """Test suite for remote API endpoints on course run in the edx_imports application."""
+
+    maxDiff = None
+
+    def test_course_run_api_without_api_token(self):
+        """Test course run API without API token should return 403."""
+        response = self.client.get("/api/v1.0/edx_imports/course-run/")
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_course_run_api_with_invalid_api_token(self):
+        """Test course run API with invalid API token should return 403."""
+        response = self.client.get(
+            "/api/v1.0/edx_imports/course-run/",
+            HTTP_AUTHORIZATION="Bearer invalid_secret_token_sample",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_course_run_api_with_valid_api_token_but_no_resource_link_parameter(self):
+        """
+        Test course run API with valid API token but no resource_link parameter should return 400.
+        """
+        response = self.client.get(
+            "/api/v1.0/edx_imports/course-run/",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(
+            response.json(), {"detail": "Query parameter `resource_link` is required."}
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_course_run_api_valid_api_token_unknown_resource_link(self):
+        """Test course run API with valid API token and unknown resource_link should return 404."""
+        response = self.client.get(
+            "/api/v1.0/edx_imports/course-run/?resource_link=unknown_resource_link",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        self.assertEqual(
+            response.json(), {"detail": "No CourseRun matches the given query."}
+        )
+
+    @override_settings(JOANIE_AUTHORIZED_API_TOKENS=["valid_known_secret_token_sample"])
+    def test_course_run_api_valid_api_token_known_resource_link(self):
+        """Test course run API with valid API token and known resource_link should return 200."""
+        course = factories.CourseFactory.create()
+        course_run = factories.CourseRunFactory.create(course=course)
+        resource_link = f"{course_run.resource_link}".replace("+", "%2B")
+        response = self.client.get(
+            f"/api/v1.0/edx_imports/course-run/?resource_link={resource_link}",
+            HTTP_AUTHORIZATION="Bearer valid_known_secret_token_sample",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "id": str(course_run.id),
+                "start": format_date(course_run.start),
+                "end": format_date(course_run.end),
+                "enrollment_start": format_date(course_run.enrollment_start),
+                "enrollment_end": format_date(course_run.enrollment_end),
+                "course": {
+                    "code": course_run.course.code,
+                    "title": course_run.course.title,
+                    "id": str(course_run.course.id),
+                    "state": {
+                        "priority": course_run.course.state["priority"],
+                        "datetime": format_date(course_run.course.state["datetime"]),
+                        "call_to_action": course_run.course.state["call_to_action"],
+                        "text": course_run.course.state["text"],
+                    },
+                },
+                "resource_link": course_run.resource_link,
+                "title": course_run.title,
+                "is_gradable": course_run.is_gradable,
+                "is_listed": course_run.is_listed,
+                "languages": course_run.languages,
+                "uri": course_run.uri,
+                "state": {
+                    "priority": course_run.state["priority"],
+                    "datetime": format_date(course_run.state["datetime"]),
+                    "call_to_action": course_run.state["call_to_action"],
+                    "text": course_run.state["text"],
+                },
+            },
+        )

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -33,6 +33,7 @@ from joanie.core.views import (
     CertificateVerificationView,
 )
 from joanie.debug import urls as debug_urls
+from joanie.edx_imports import urls as edx_imports_urls
 
 API_VERSION = settings.API_VERSION
 
@@ -48,6 +49,7 @@ urlpatterns = (
     + admin_urls.urlpatterns
     + client_urls.urlpatterns
     + remote_endpoints_urls.urlpatterns
+    + edx_imports_urls.urlpatterns
 )
 
 urlpatterns += i18n_patterns(


### PR DESCRIPTION
## Purpose

To complete the import process from edx, we need to create a new endpoint able to return a course run filter on its course_link. The course_link parameter is mandatory and the AdminCourseRunSerializer is used, it contains all the information we need in the import process. This endpoint is a server to server endpoint, the HasApiKey permission is used here.

## Proposal

- [x] endpoint to retrieve a course_run filter on its course_link
