### PR TITLE
✨(backend) add order withdraw api endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ## Added
 
+- Add a new endpoint to withdraw an order
 - Endpoint to retrieve the first course_run related to a course_link
 - Add order payment schedule
 - Manage commercial newsletter subscriptions

--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -528,6 +528,27 @@ class OrderViewSet(
 
         return JsonResponse({"invitation_link": invitation_link}, status=HTTPStatus.OK)
 
+    @extend_schema(
+        request=None,
+        responses={
+            204: OpenApiTypes.NONE,
+            422: serializers.ErrorResponseSerializer,
+        },
+    )
+    @action(detail=True, methods=["POST"])
+    def withdraw(self, request, pk=None):  # pylint: disable=no-self-use, invalid-name, unused-argument
+        """Withdraw an order"""
+        order = self.get_object()
+
+        try:
+            order.withdraw()
+        except ValidationError as error:
+            return Response(
+                {"detail": f"{error}"}, status=HTTPStatus.UNPROCESSABLE_ENTITY
+            )
+
+        return Response(status=HTTPStatus.NO_CONTENT)
+
 
 class AddressViewSet(
     mixins.ListModelMixin,

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -1135,6 +1135,21 @@ class Order(BaseModel):
         """
         self._set_installment_state(due_date, enums.PAYMENT_STATE_REFUSED)
 
+    def withdraw(self):
+        """
+        Withdraw the order.
+        """
+        if not self.payment_schedule:
+            raise ValidationError("No payment schedule found for this order")
+
+        # check if current date is greater than the first installment due date
+        if timezone.now().isoformat() >= self.payment_schedule[0]["due_date"]:
+            raise ValidationError(
+                "Cannot withdraw order after the first installment due date"
+            )
+
+        self.cancel()
+
 
 @receiver(post_transition, sender=Order)
 def order_post_transition_callback(sender, instance, **kwargs):  # pylint: disable=unused-argument

--- a/src/backend/joanie/tests/core/api/order/test_withdraw.py
+++ b/src/backend/joanie/tests/core/api/order/test_withdraw.py
@@ -1,0 +1,160 @@
+"""Tests for the Order withdraw API."""
+
+import uuid
+from datetime import datetime
+from http import HTTPStatus
+from unittest import mock
+
+from django.core.cache import cache
+
+from joanie.core import enums, factories
+from joanie.tests.base import BaseAPITestCase
+
+
+class OrderWithdrawApiTest(BaseAPITestCase):
+    """Test the API of the Order withdraw endpoint."""
+
+    maxDiff = None
+
+    def setUp(self):
+        """Clear cache after each tests"""
+        cache.clear()
+
+    def test_api_order_withdraw_anonymous(self):
+        """
+        Anonymous user cannot withdraw order
+        """
+        order = factories.OrderFactory()
+
+        response = self.client.post(
+            f"/api/v1.0/orders/{order.id}/withdraw/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+        order.refresh_from_db()
+        self.assertNotEqual(order.state, enums.ORDER_STATE_CANCELED)
+
+    def test_api_order_withdraw_authenticated_unexisting(self):
+        """
+        User should receive 404 when withdrawing a non existing order
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+
+        response = self.client.post(
+            f"/api/v1.0/orders/{uuid.uuid4()}/withdraw/",
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_api_order_withdraw_authenticated_not_owned(self):
+        """
+        Authenticated user should not be able to withdraw order they don't own
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        order = factories.OrderFactory()
+
+        response = self.client.post(
+            f"/api/v1.0/orders/{order.id}/withdraw/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        order.refresh_from_db()
+        self.assertEqual(order.state, enums.ORDER_STATE_DRAFT)
+
+    def test_api_order_withdraw_authenticated_owned(self):
+        """
+        User should be able to withdraw owned orders as long as first payment
+        is not due
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        order = factories.OrderFactory(
+            owner=user,
+            payment_schedule=[
+                {
+                    "amount": "200.00",
+                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        mocked_now = datetime(2024, 1, 12, 8, 8)
+        with mock.patch("django.utils.timezone.now", return_value=mocked_now):
+            response = self.client.post(
+                f"/api/v1.0/orders/{order.id}/withdraw/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+        order.refresh_from_db()
+        self.assertEqual(order.state, enums.ORDER_STATE_CANCELED)
+
+    def test_api_order_withdraw_authenticated_owned_error(self):
+        """
+        User should not be able to withdraw owned orders if first payment is due
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        order = factories.OrderFactory(
+            owner=user,
+            payment_schedule=[
+                {
+                    "amount": "200.00",
+                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        mocked_now = datetime(2024, 1, 18, 8, 8)
+        with mock.patch("django.utils.timezone.now", return_value=mocked_now):
+            response = self.client.post(
+                f"/api/v1.0/orders/{order.id}/withdraw/",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        self.assertContains(
+            response,
+            "Cannot withdraw order after the first installment due date",
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        )
+        order.refresh_from_db()
+        self.assertEqual(order.state, enums.ORDER_STATE_DRAFT)
+
+    def test_api_order_withdraw_authenticated_no_payment_schedule(self):
+        """
+        User should not be able to withdraw owned orders if there is no payment schedule
+        """
+        user = factories.UserFactory()
+        token = self.generate_token_from_user(user)
+        order = factories.OrderFactory(owner=user, payment_schedule=[])
+
+        response = self.client.post(
+            f"/api/v1.0/orders/{order.id}/withdraw/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertContains(
+            response,
+            "No payment schedule found for this order",
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+        )
+        order.refresh_from_db()
+        self.assertEqual(order.state, enums.ORDER_STATE_DRAFT)

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -3142,6 +3142,52 @@
                 }
             }
         },
+        "/api/v1.0/orders/{id}/withdraw/": {
+            "post": {
+                "operationId": "orders_withdraw_create",
+                "description": "Withdraw an order",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "orders"
+                ],
+                "security": [
+                    {
+                        "DelegatedJWTAuthentication": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "content": {
+                            "application/json": {
+                                "schema": null
+                            }
+                        },
+                        "description": ""
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/organizations/": {
             "get": {
                 "operationId": "organizations_list",


### PR DESCRIPTION

## Purpose

Before the withdrawal date, users can withdraw their order.


## Proposal
Add an API endpoint to withdraw an order.
