### PR TITLE
✨(backend) new organization owner can sign contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Added 
+### Added
 
+- Update signatories for organization owners and student on ongoing
+  signature procedures
 - Add enrollments pages
 - Addition of clickable columns value in the different lists
 - Add admin page to decrypt additional data sent to Sentry

--- a/docs/explanation/lex-persona.md
+++ b/docs/explanation/lex-persona.md
@@ -848,3 +848,340 @@ headers = {
 }
 ```
 You will see that your workflow has been "stopped". It has been refused successfully.
+
+#### 6- Update signatories for signature procedures :
+
+When you need to add new signatories into existing signature procedures, the API allows you to
+update the signatories. For our case, we have two steps for the signature of a file. The first
+step is the student and the second step are all the organization's owners. When the student has
+already signed, you just need to update the organization signatories recipients (**example 1**),
+otherwise, you need to update both steps. (**example 2**)
+
+#### Example 1 - Update organization signatories
+
+**Endpoint** : /api/workflows/{workflow_id}/
+
+**Method** : PATCH
+
+**Payload** :
+```json
+{
+    "steps": [
+        {
+            "stepType": "signature",
+            "recipients": [
+                {
+                    "email": "richie@example.fr",
+                    "firstName": "Richie B",
+                    "lastName": ".",
+                    "country": "FR",
+                    "preferred_locale": "fr-fr",
+                    "consentPageId": "cop_id_fake",
+                },
+                {
+                    "email": "marsha@example.fr",
+                    "firstName": "Marsha C",
+                    "lastName": ".",
+                    "country": "FR",
+                    "preferred_locale": "fr-fr",
+                    "consentPageId": "cop_id_fake",
+                },
+            ],
+            "requiredRecipients": 1,
+            "validityPeriod": 1296000000,
+            "invitePeriod": null,
+            "maxInvites": 0,
+            "sendDownloadLink": true,
+            "allowComments": false,
+            "hideAttachments": false,
+            "hideWorkflowRecipients": false,
+        },
+    ],
+}
+```
+
+**Response** :
+```json
+{
+    "allowedCoManagerUsers": [],
+    "coManagerNotifiedEvents": [],
+    "created": 1713365328204,
+    "currentRecipientEmails": [
+        "marsha@example.fr",
+        "richie@example.fr"
+    ],
+    "currentRecipientUsers": [],
+    "description": "1 rue de l'exemple, 75000 Paris",
+    "email": "user@example.fr",
+    "firstName": "Fontzie",
+    "groupId": "grp_fake_id",
+    "id": "wfl_fake_id",
+    "jobOperation": "processWorkflow",
+    "lastName": "W",
+    "name": "Some title of signature procedure",
+    "notifiedEvents": [
+        "recipientFinished",
+        "workflowStopped",
+        "workflowFinished"
+    ],
+    "progress": 50,
+    "started": 1713365343105,
+    "steps": [
+        {
+            "allowComments": false,
+            "hideAttachments": false,
+            "hideWorkflowRecipients": false,
+            "id": "stp_fake_id_1",
+            "invitePeriod": 1296000000,
+            "isFinished": true,
+            "isStarted": true,
+            "logs": [
+                {
+                    "created": 1713365343105,
+                    "operation": "start"
+                },
+                {
+                    "created": 1713365343105,
+                    "operation": "notifyWorkflowStarted"
+                },
+                {
+                    "created": 1713365388165,
+                    "evidenceId": "evi_fake_id",
+                    "operation": "sign",
+                    "recipientEmail": "johndoe@example.fr"
+                },
+                {
+                    "created": 1713365388165,
+                    "operation": "notifyRecipientFinished",
+                    "recipientEmail": "johndoe@example.fr"
+                }
+            ],
+            "maxInvites": 0,
+            "recipients": [
+                {
+                    "consentPageId": "cop_fake_id",
+                    "country": "FR",
+                    "email": "johndoe@example.fr",
+                    "firstName": "John Doe",
+                    "lastName": ".",
+                    "phoneNumber": "",
+                    "preferredLocale": "fr"
+                }
+            ],
+            "requiredRecipients": 1,
+            "sendDownloadLink": true,
+            "stepType": "signature",
+            "validityPeriod": 1296000000
+        },
+        {
+            "allowComments": false,
+            "hideAttachments": false,
+            "hideWorkflowRecipients": false,
+            "id": "stp_fake_id_2",
+            "invitePeriod": 1296000000,
+            "isFinished": false,
+            "isStarted": false,
+            "logs": [],
+            "maxInvites": 0,
+            "recipients": [
+                {
+                    "email": "richie@example.fr",
+                    "firstName": "Richie B",
+                    "lastName": ".",
+                    "country": "FR",
+                    "preferred_locale": "fr-fr",
+                    "consentPageId": "cop_id_fake",
+                },
+                {
+                    "email": "marsha@example.fr",
+                    "firstName": "Marsha C",
+                    "lastName": ".",
+                    "country": "FR",
+                    "preferred_locale": "fr-fr",
+                    "consentPageId": "cop_id_fake",
+                },
+            ],
+            "requiredRecipients": 1,
+            "sendDownloadLink": true,
+            "stepType": "signature",
+            "validityPeriod": 1296000000
+        }
+    ],
+    "tenantId": "ten_fake_id",
+    "updated": 1713362137571,
+    "userId": "usr_fake_id",
+    "viewAuthorizedGroups": [
+        "grp_fake_id"
+    ],
+    "viewAuthorizedUsers": [],
+    "watchers": [],
+    "workflowStatus": "started"
+}
+```
+
+#### Example 2 - Update all signatories because no signature yet
+
+**Endpoint** : /api/workflows/{workflow_id}/
+
+**Method** : PATCH
+
+**Payload** :
+```json
+{
+    "steps": [
+        {
+            "allowComments": false,
+            "hideAttachments": false,
+            "hideWorkflowRecipients": false,
+            "invitePeriod": null,
+            "maxInvites": 0,
+            "recipients": [
+                {
+                    "consentPageId": "cop_id_fake",
+                    "email": "johndoe@example.fr",
+                    "firstName": "John Doe",
+                    "lastName": ".",
+                    "country": "FR",
+                    "preferred_locale": "fr-fr",
+                }
+            ],
+            "requiredRecipients": 1,
+            "sendDownloadLink": true,
+            "stepType": "signature",
+            "validityPeriod": 1296000000,
+        },
+        {
+            "steps": [
+                {
+                    "allowComments": false,
+                    "hideAttachments": false,
+                    "hideWorkflowRecipients": false,
+                    "invitePeriod": null,
+                    "maxInvites": 0,
+                    "recipients": [
+                        {
+                            "email": "richie@example.fr",
+                            "firstName": "Richie B",
+                            "lastName": ".",
+                            "country": "FR",
+                            "preferred_locale": "fr-fr",
+                            "consentPageId": "cop_id_fake",
+                        },
+                        {
+                            "email": "marsha@example.fr",
+                            "firstName": "Marsha C",
+                            "lastName": ".",
+                            "country": "FR",
+                            "preferred_locale": "fr-fr",
+                            "consentPageId": "cop_id_fake",
+                        },
+                    ],
+                    "requiredRecipients": 1,
+                    "sendDownloadLink": true,
+                    "stepType": "signature",
+                    "validityPeriod": 1296000000,
+                }
+            ]
+        },
+    ]
+    }
+```
+
+**Response** :
+```json
+{
+    "allowedCoManagerUsers": [],
+    "coManagerNotifiedEvents": [],
+    "created": 1713361998357,
+    "currentRecipientEmails": [
+        "johndoe@example.fr"
+    ],
+    "currentRecipientUsers": [],
+    "description": "1 rue de l'exemple, 75000 Paris",
+    "email": "user@example.fr",
+    "firstName": "Fontzie",
+    "groupId": "grp_fake_id",
+    "id": "wfl_fake_id",
+    "jobOperation": "processWorkflow",
+    "lastName": "W",
+    "logs": [],
+    "name": "Title of the signature procedure",
+    "notifiedEvents": [
+        "recipientFinished",
+        "workflowStopped",
+        "workflowFinished"
+    ],
+    "progress": 0,
+    "started": 1713362011673,
+    "steps": [
+        {
+            "allowComments": false,
+            "hideAttachments": false,
+            "hideWorkflowRecipients": false,
+            "id": "stp_fake_id_1",
+            "invitePeriod": 1296000000,
+            "isFinished": false,
+            "isStarted": false,
+            "logs": [],
+            "maxInvites": 0,
+            "recipients": [
+                {
+                    "consentPageId": "cop_fake_id",
+                    "country": "FR",
+                    "email": "johndoe@example.fr",
+                    "firstName": "Jon",
+                    "lastName": ".",
+                    "phoneNumber": "",
+                    "preferredLocale": "fr"
+                }
+            ],
+            "requiredRecipients": 1,
+            "sendDownloadLink": true,
+            "stepType": "signature",
+            "validityPeriod": 1296000000
+        },
+        {
+            "allowComments": false,
+            "hideAttachments": false,
+            "hideWorkflowRecipients": false,
+            "id": "stp_fake_id_2",
+            "invitePeriod": 1296000000,
+            "isFinished": false,
+            "isStarted": false,
+            "logs": [],
+            "maxInvites": 0,
+            "recipients": [
+                {
+                    "email": "richie@example.fr",
+                    "firstName": "Richie B",
+                    "lastName": ".",
+                    "country": "FR",
+                    "preferred_locale": "fr-fr",
+                    "consentPageId": "cop_id_fake",
+                },
+                {
+                    "email": "marsha@example.fr",
+                    "firstName": "Marsha C",
+                    "lastName": ".",
+                    "country": "FR",
+                    "preferred_locale": "fr-fr",
+                    "consentPageId": "cop_id_fake",
+                },
+            ],
+            "requiredRecipients": 1,
+            "sendDownloadLink": true,
+            "stepType": "signature",
+            "validityPeriod": 1296000000
+        }
+    ],
+    "tenantId": "ten_fake_id",
+    "updated": 1713362137571,
+    "userId": "usr_fake_id",
+    "viewAuthorizedGroups": [
+        "grp_fake_id"
+    ],
+    "viewAuthorizedUsers": [],
+    "watchers": [],
+    "workflowStatus": "started"
+}
+```

--- a/docs/explanation/signature_backend.md
+++ b/docs/explanation/signature_backend.md
@@ -40,6 +40,8 @@ On the other hand, your signature backend has to implement 4 methods :
 
 - **`handle_notification(self, request)`**
 
+- **`update_signatories(self, reference_id: str, all_signatories: bool)`**
+
 ## Supported providers
 
 You can find all signature backends at `src/backend/joanie/signature/backends`.

--- a/src/backend/joanie/core/tasks.py
+++ b/src/backend/joanie/core/tasks.py
@@ -7,6 +7,7 @@ from django.core.management import call_command
 
 from joanie.celery_app import app
 from joanie.core import helpers
+from joanie.core.utils.contract import update_signatories_for_contracts
 
 logger = getLogger(__name__)
 
@@ -35,3 +36,12 @@ def generate_certificates_task(order_ids, cache_key):
     finally:
         cache.delete(cache_key)
     logger.info("Done executing Celery generating certificates task...")
+
+
+@app.task
+def update_organization_signatories_contracts_task(organization_id: str):
+    """
+    Task to update the signatories for every signature procedures that are ongoing
+    for the given organization.
+    """
+    update_signatories_for_contracts(organization_id=organization_id)

--- a/src/backend/joanie/signature/backends/base.py
+++ b/src/backend/joanie/signature/backends/base.py
@@ -144,3 +144,12 @@ class BaseSignatureBackend:
         raise NotImplementedError(
             "subclasses of BaseSignatureBackend must provide a get_signed_file() method."
         )
+
+    def update_signatories(self, reference_id: str, all_signatories: bool):
+        """
+        Update the signatories on ongoing signature procedures.
+        """
+        raise NotImplementedError(
+            "subclasses of BaseSignatureBackend must provide a "
+            "update_signatories() method."
+        )

--- a/src/backend/joanie/signature/backends/dummy.py
+++ b/src/backend/joanie/signature/backends/dummy.py
@@ -132,3 +132,19 @@ class DummySignatureBackend(BaseSignatureBackend):
         )
 
         return file_bytes
+
+    def update_signatories(self, reference_id: str, all_signatories: bool) -> str:
+        """
+        Dummy method that verifies if the order is not fully signed yet, else it returns the
+        signature backend reference that has been updated.
+        """
+        if not reference_id.startswith(self.prefix_workflow):
+            raise ValidationError(f"The reference {reference_id} does not exist.")
+
+        contract = models.Contract.objects.get(
+            signature_backend_reference=reference_id,
+        )
+        if contract.is_fully_signed:
+            raise ValidationError(f"The contract {contract.id} is already fully signed")
+
+        return contract.signature_backend_reference

--- a/src/backend/joanie/signature/backends/lex_persona.py
+++ b/src/backend/joanie/signature/backends/lex_persona.py
@@ -591,7 +591,8 @@ class LexPersonaBackend(BaseSignatureBackend):
                         order
                     ),
                     "requiredRecipients": 1,
-                    "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS * 1000,
+                    "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS
+                    * 1000,
                     "invitePeriod": None,
                     "maxInvites": 0,
                     "sendDownloadLink": True,
@@ -611,7 +612,8 @@ class LexPersonaBackend(BaseSignatureBackend):
                         order
                     ),
                     "requiredRecipients": 1,
-                    "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS * 1000,
+                    "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS
+                    * 1000,
                     "invitePeriod": None,
                     "maxInvites": 0,
                     "sendDownloadLink": True,

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_update_organization_signatories.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_update_organization_signatories.py
@@ -1,0 +1,596 @@
+"""Lex Persona backend test for `update_signatories`."""
+
+from http import HTTPStatus
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+
+import responses
+
+from joanie.core import enums, factories, models
+from joanie.signature.backends import get_signature_backend
+
+
+@override_settings(
+    JOANIE_SIGNATURE_BACKEND="joanie.signature.backends.lex_persona.LexPersonaBackend",
+    JOANIE_SIGNATURE_LEXPERSONA_BASE_URL="https://lex_persona.test01.com",
+    JOANIE_SIGNATURE_LEXPERSONA_CONSENT_PAGE_ID="cop_id_fake",
+    JOANIE_SIGNATURE_LEXPERSONA_SESSION_USER_ID="usr_id_fake",
+    JOANIE_SIGNATURE_LEXPERSONA_PROFILE_ID="sip_profile_id_fake",
+    JOANIE_SIGNATURE_LEXPERSONA_TOKEN="token_id_fake",
+    JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
+    JOANIE_SIGNATURE_TIMEOUT=3,
+)
+class LexPersonaBackendUpdateSignatoriesTestCase(TestCase):
+    """Lex Persona backend test for `update_signatories`."""
+
+    # pylint:disable=too-many-locals, duplicate-key, unexpected-keyword-arg, no-value-for-parameter
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_backend_lex_persona_update_signatories_success(self):
+        """
+        When update an existing signature procedure to add new signatories to existing workflows,
+        it should return, if it succeeds, the signature backend reference that has been updated.
+        """
+        # Create learner and the order
+        user = factories.UserFactory(email="johndoe@example.fr")
+        order = factories.OrderFactory(
+            owner=user,
+            state=enums.ORDER_STATE_VALIDATED,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
+        factories.ContractFactory(
+            order=order,
+            definition=order.product.contract_definition,
+            definition_checksum="1234",
+            context="context",
+            signature_backend_reference="wfl_id_fake",
+            submitted_for_signature_on=timezone.now(),
+            student_signed_on=timezone.now(),
+            organization_signed_on=None,
+        )
+        # Create organization user with owner access on the organization
+        org_user_1 = factories.UserFactory(email="org_user_1@example.fr")
+        factories.UserOrganizationAccessFactory(
+            organization=order.organization, role=enums.OWNER, user=org_user_1
+        )
+        # Create a new organization owner linked to the order
+        org_user_2 = factories.UserFactory(email="org_user_2@example.fr")
+        factories.UserOrganizationAccessFactory(
+            organization=order.organization, role=enums.OWNER, user=org_user_2
+        )
+        all_organizaiton_accesses_owners = models.OrganizationAccess.objects.filter(
+            organization=order.organization, role=enums.OWNER
+        )
+        # Prepare data for workflow
+        workflow_id = "wfl_id_fake"
+        title = "Contract Definition"
+        validity_period_ms = settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS * 1000
+        # Update signature procedure signatories
+        update_signatories_procedure_api_url = (
+            f"https://lex_persona.test01.com/api/workflows/{workflow_id}/"
+        )
+        # Pretend that the learner has already signed the file
+        update_procedure_response_data = {
+            "allowedCoManagerUsers": [],
+            "coManagerNotifiedEvents": [],
+            "created": 1712739490564,
+            "currentRecipientEmails": [
+                "org_user_1@example.fr",
+                "org_user_2@example.fr",
+            ],
+            "currentRecipientUsers": [],
+            "description": title,
+            "email": "user@example.fr",
+            "firstName": order.owner.first_name,
+            "groupId": "grp_id_fake",
+            "id": "wfl_id_fake",
+            "jobOperation": "processWorkflow",
+            "lastName": ".",
+            "logs": [],
+            "name": title,
+            "notifiedEvents": [
+                "recipientRefused",
+                "recipientFinished",
+                "workflowFinished",
+            ],
+            "progress": 50,
+            "started": 1712739520954,
+            "steps": [
+                {
+                    "allowComments": False,
+                    "hideAttachments": False,
+                    "hideWorkflowRecipients": False,
+                    "id": "stp_id_fake",
+                    "invitePeriod": None,
+                    "isFinished": True,
+                    "isStarted": True,
+                    "logs": [
+                        {"created": 1712739520954, "operation": "start"},
+                        {
+                            "created": 1712739520954,
+                            "operation": "notifyWorkflowStarted",
+                        },
+                        {
+                            "created": 1712739520994,
+                            "operation": "invite",
+                            "recipientEmail": "johndoe@example.fr",
+                        },
+                        {
+                            "created": 1712739579338,
+                            "evidenceId": "evi_serversealingiframe_fake_id",
+                            "operation": "sign",
+                            "recipientEmail": "johndoe@example.fr",
+                        },
+                        {
+                            "created": 1712739579338,
+                            "operation": "notifyRecipientFinished",
+                            "recipientEmail": "johndoe@example.fr",
+                        },
+                    ],
+                    "maxInvites": 0,
+                    "recipients": [
+                        {
+                            "consentPageId": "cop_id_fake",
+                            "country": "FR",
+                            "email": "johndoe@example.fr",
+                            "firstName": "Jon",
+                            "lastName": ".",
+                            "phoneNumber": "",
+                            "preferredLocale": "fr",
+                        }
+                    ],
+                    "requiredRecipients": 1,
+                    "sendDownloadLink": True,
+                    "stepType": "signature",
+                    "validityPeriod": validity_period_ms,
+                },
+                {
+                    "allowComments": False,
+                    "hideAttachments": False,
+                    "hideWorkflowRecipients": False,
+                    "id": "stp_id_fake",
+                    "invitePeriod": None,
+                    "isFinished": False,
+                    "isStarted": False,
+                    "logs": [],
+                    "maxInvites": 0,
+                    "recipients": [
+                        {
+                            "email": access.user.email,
+                            "firstName": access.user.first_name,
+                            "lastName": ".",
+                            "country": order.organization.country.code.upper(),
+                            "preferred_locale": access.user.language.lower(),
+                            "consentPageId": "cop_id_fake",
+                        }
+                        for access in reversed(all_organizaiton_accesses_owners)
+                    ],
+                    "requiredRecipients": 1,
+                    "sendDownloadLink": True,
+                    "stepType": "signature",
+                    "validityPeriod": validity_period_ms,
+                },
+            ],
+            "tenantId": "ten_id_fake",
+            "updated": 1712739615424,
+            "userId": "usr_id_fake",
+            "viewAuthorizedGroups": ["grp_id_fake"],
+            "viewAuthorizedUsers": [],
+            "watchers": [],
+            "workflowStatus": "started",
+        }
+        responses.add(
+            responses.PATCH,
+            update_signatories_procedure_api_url,
+            status=HTTPStatus.OK,
+            json=update_procedure_response_data,
+            match=[
+                responses.matchers.header_matcher(
+                    {
+                        "Authorization": "Bearer token_id_fake",
+                    },
+                ),
+                responses.matchers.json_params_matcher(
+                    {
+                        "steps": [
+                            {
+                                "stepType": "signature",
+                                "recipients": [
+                                    {
+                                        "email": org_user_2.email,
+                                        "firstName": org_user_2.first_name,
+                                        "lastName": ".",
+                                        "country": order.organization.country.code.upper(),
+                                        "preferred_locale": org_user_2.language.lower(),
+                                        "consentPageId": "cop_id_fake",
+                                    },
+                                    {
+                                        "email": org_user_1.email,
+                                        "firstName": org_user_1.first_name,
+                                        "lastName": ".",
+                                        "country": order.organization.country.code.upper(),
+                                        "preferred_locale": org_user_1.language.lower(),
+                                        "consentPageId": "cop_id_fake",
+                                    },
+                                ],
+                                "requiredRecipients": 1,
+                                "validityPeriod": validity_period_ms,
+                                "invitePeriod": None,
+                                "maxInvites": 0,
+                                "sendDownloadLink": True,
+                                "allowComments": False,
+                                "hideAttachments": False,
+                                "hideWorkflowRecipients": False,
+                            },
+                        ],
+                    }
+                ),
+            ],
+        )
+
+        lex_persona_backend = get_signature_backend()
+        reference_id = lex_persona_backend.update_signatories(
+            reference_id=workflow_id,
+            all_signatories=False,
+        )
+
+        self.assertEqual(workflow_id, reference_id)
+        self.assertEqual("started", update_procedure_response_data["workflowStatus"])
+        # There should be only 2 signatories from the organization at this moment
+        self.assertEqual(
+            2, len(update_procedure_response_data["steps"][1]["recipients"])
+        )
+        # There should still be 2 steps of signature
+        self.assertEqual(2, len(update_procedure_response_data["steps"]))
+
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_backend_lex_persona_update_signatories_with_student_and_organization(self):
+        """
+        When update an existing signature procedure to add new signatories to existing workflows,
+        it should return, if it succeeds, the signature backend reference that has been updated.
+        """
+        # Create learner and the order
+        user = factories.UserFactory(
+            email="johndoe@example.fr",
+            first_name="John Doe",
+            last_name=".",
+        )
+        order = factories.OrderFactory(
+            owner=user,
+            state=enums.ORDER_STATE_VALIDATED,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
+        factories.ContractFactory(
+            order=order,
+            definition=order.product.contract_definition,
+            definition_checksum="1234",
+            context="context",
+            signature_backend_reference="wfl_id_fake",
+            submitted_for_signature_on=timezone.now(),
+            student_signed_on=None,
+            organization_signed_on=None,
+        )
+        # Create organization user with owner access on the organization
+        org_user_1 = factories.UserFactory(email="org_user_1@example.fr")
+        factories.UserOrganizationAccessFactory(
+            organization=order.organization, role=enums.OWNER, user=org_user_1
+        )
+        # Create a new organization owner linked to the order
+        org_user_2 = factories.UserFactory(email="org_user_2@example.fr")
+        factories.UserOrganizationAccessFactory(
+            organization=order.organization, role=enums.OWNER, user=org_user_2
+        )
+        all_organizaiton_accesses_owners = models.OrganizationAccess.objects.filter(
+            organization=order.organization, role=enums.OWNER
+        )
+
+        # Prepare data for workflow
+        validity_period_ms = settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS * 1000
+        preferred_locale = order.owner.language
+        country = order.main_invoice.recipient_address.country.code
+        workflow_id = "wfl_id_fake"
+        title = "Contract Definition"
+
+        # Update signature procedure signatories
+        update_signatories_procedure_api_url = (
+            f"https://lex_persona.test01.com/api/workflows/{workflow_id}/"
+        )
+        # Pretend that no one has signed the file yet
+        update_procedure_response_data = {
+            "allowedCoManagerUsers": [],
+            "coManagerNotifiedEvents": [],
+            "created": 1712739490564,
+            "currentRecipientEmails": [
+                "johndoe@example.fr",
+            ],
+            "currentRecipientUsers": [],
+            "description": title,
+            "email": "user@example.fr",
+            "firstName": order.owner.first_name,
+            "groupId": "grp_id_fake",
+            "id": "wfl_id_fake",
+            "jobOperation": "processWorkflow",
+            "lastName": ".",
+            "logs": [],
+            "name": title,
+            "notifiedEvents": [
+                "recipientRefused",
+                "recipientFinished",
+                "workflowFinished",
+            ],
+            "progress": 0,
+            "started": 1712739520954,
+            "steps": [
+                {
+                    "allowComments": False,
+                    "hideAttachments": False,
+                    "hideWorkflowRecipients": False,
+                    "id": "stp_id_fake",
+                    "invitePeriod": None,
+                    "isFinished": True,
+                    "isStarted": True,
+                    "logs": [],
+                    "maxInvites": 0,
+                    "recipients": [
+                        {
+                            "email": "johndoe@example.fr",
+                            "firstName": "John Doe",
+                            "lastName": ".",
+                            "country": country.upper(),
+                            "preferredLocale": preferred_locale.lower(),
+                            "consentPageId": "cop_id_fake",
+                        }
+                    ],
+                    "requiredRecipients": 1,
+                    "sendDownloadLink": True,
+                    "stepType": "signature",
+                    "validityPeriod": validity_period_ms,
+                },
+                {
+                    "allowComments": False,
+                    "hideAttachments": False,
+                    "hideWorkflowRecipients": False,
+                    "id": "stp_id_fake",
+                    "invitePeriod": None,
+                    "isFinished": False,
+                    "isStarted": False,
+                    "logs": [],
+                    "maxInvites": 0,
+                    "recipients": [
+                        {
+                            "email": access.user.email,
+                            "firstName": access.user.first_name,
+                            "lastName": ".",
+                            "country": order.organization.country.code.upper(),
+                            "preferred_locale": access.user.language.lower(),
+                            "consentPageId": "cop_id_fake",
+                        }
+                        for access in reversed(all_organizaiton_accesses_owners)
+                    ],
+                    "requiredRecipients": 1,
+                    "sendDownloadLink": True,
+                    "stepType": "signature",
+                    "validityPeriod": validity_period_ms,
+                },
+            ],
+            "tenantId": "ten_id_fake",
+            "updated": 1712739615424,
+            "userId": "usr_id_fake",
+            "viewAuthorizedGroups": ["grp_id_fake"],
+            "viewAuthorizedUsers": [],
+            "watchers": [],
+            "workflowStatus": "started",
+        }
+        responses.add(
+            responses.PATCH,
+            update_signatories_procedure_api_url,
+            status=HTTPStatus.OK,
+            json=update_procedure_response_data,
+            match=[
+                responses.matchers.header_matcher(
+                    {
+                        "Authorization": "Bearer token_id_fake",
+                    },
+                ),
+                responses.matchers.json_params_matcher(
+                    {
+                        "steps": [
+                            {
+                                "allowComments": False,
+                                "hideAttachments": False,
+                                "hideWorkflowRecipients": False,
+                                "invitePeriod": None,
+                                "maxInvites": 0,
+                                "recipients": [
+                                    {
+                                        "consentPageId": "cop_id_fake",
+                                        "email": "johndoe@example.fr",
+                                        "firstName": "John Doe",
+                                        "lastName": ".",
+                                        "country": country.upper(),
+                                        "preferred_locale": preferred_locale.lower(),
+                                    }
+                                ],
+                                "requiredRecipients": 1,
+                                "sendDownloadLink": True,
+                                "stepType": "signature",
+                                "validityPeriod": validity_period_ms,
+                            },
+                            {
+                                "steps": [
+                                    {
+                                        "allowComments": False,
+                                        "hideAttachments": False,
+                                        "hideWorkflowRecipients": False,
+                                        "invitePeriod": None,
+                                        "maxInvites": 0,
+                                        "recipients": [
+                                            {
+                                                "email": org_user_2.email,
+                                                "firstName": org_user_2.first_name,
+                                                "lastName": ".",
+                                                "country": order.organization.country.code.upper(),
+                                                "preferred_locale": org_user_2.language.lower(),
+                                                "consentPageId": "cop_id_fake",
+                                            },
+                                            {
+                                                "email": org_user_1.email,
+                                                "firstName": org_user_1.first_name,
+                                                "lastName": ".",
+                                                "country": order.organization.country.code.upper(),
+                                                "preferred_locale": org_user_1.language.lower(),
+                                                "consentPageId": "cop_id_fake",
+                                            },
+                                        ],
+                                        "requiredRecipients": 1,
+                                        "sendDownloadLink": True,
+                                        "stepType": "signature",
+                                        "validityPeriod": validity_period_ms,
+                                    }
+                                ]
+                            },
+                        ]
+                    }
+                ),
+            ],
+        )
+
+        lex_persona_backend = get_signature_backend()
+        reference_id = lex_persona_backend.update_signatories(
+            reference_id=workflow_id,
+            all_signatories=True,
+        )
+
+        self.assertEqual(workflow_id, reference_id)
+        self.assertEqual("started", update_procedure_response_data["workflowStatus"])
+        # There should be only 1 student in the first step of signatories
+        self.assertEqual(
+            1, len(update_procedure_response_data["steps"][0]["recipients"])
+        )
+        # There should be only 2 signatories from the organization at this moment
+        self.assertEqual(
+            2, len(update_procedure_response_data["steps"][1]["recipients"])
+        )
+        # There should still be 2 steps of signature
+        self.assertEqual(2, len(update_procedure_response_data["steps"]))
+
+    @responses.activate
+    def test_backend_lex_persona_update_signatories_with_wrong_reference_id(
+        self,
+    ):
+        """
+        If we pass a reference id that is not registered at the signature provider, it should
+        raise an error and not let us update the signatories of the given 'reference_id'.
+        """
+        workflow_id = "fake_wfl_id_fake"
+        validity_period_ms = settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS * 1000
+
+        user = factories.UserFactory(email="johndoe@example.fr")
+        order = factories.OrderFactory(
+            owner=user,
+            state=enums.ORDER_STATE_VALIDATED,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+        )
+        factories.ContractFactory(
+            order=order,
+            definition=order.product.contract_definition,
+            definition_checksum="1234",
+            context="context",
+            signature_backend_reference="fake_wfl_id_fake",
+            submitted_for_signature_on=timezone.now(),
+            student_signed_on=timezone.now(),
+            organization_signed_on=None,
+        )
+
+        # Create organization user with owner access on the organization
+        org_user_1 = factories.UserFactory(email="org_user_1@example.fr")
+        factories.UserOrganizationAccessFactory(
+            organization=order.organization, role=enums.OWNER, user=org_user_1
+        )
+        # Create a new organization owner linked to the order
+        org_user_2 = factories.UserFactory(email="org_user_2@example.fr")
+        factories.UserOrganizationAccessFactory(
+            organization=order.organization, role=enums.OWNER, user=org_user_2
+        )
+
+        # Update signature procedure signatories
+        update_signatories_procedure_api_url = (
+            f"https://lex_persona.test01.com/api/workflows/{workflow_id}/"
+        )
+        responses.add(
+            responses.PATCH,
+            update_signatories_procedure_api_url,
+            status=HTTPStatus.NOT_FOUND,
+            json={
+                "status": 404,
+                "error": "Not Found",
+                "message": "The specified workflow can not be found.",
+                "requestId": "32205c11-122154",
+                "code": "WorkflowNotFound",
+                "logId": "log_id_fake",
+            },
+            match=[
+                responses.matchers.header_matcher(
+                    {
+                        "Authorization": "Bearer token_id_fake",
+                    },
+                ),
+                responses.matchers.json_params_matcher(
+                    {
+                        "steps": [
+                            {
+                                "stepType": "signature",
+                                "recipients": [
+                                    {
+                                        "email": org_user_2.email,
+                                        "firstName": org_user_2.first_name,
+                                        "lastName": ".",
+                                        "country": order.organization.country.code.upper(),
+                                        "preferred_locale": org_user_2.language.lower(),
+                                        "consentPageId": "cop_id_fake",
+                                    },
+                                    {
+                                        "email": org_user_1.email,
+                                        "firstName": org_user_1.first_name,
+                                        "lastName": ".",
+                                        "country": order.organization.country.code.upper(),
+                                        "preferred_locale": org_user_1.language.lower(),
+                                        "consentPageId": "cop_id_fake",
+                                    },
+                                ],
+                                "requiredRecipients": 1,
+                                "validityPeriod": validity_period_ms,
+                                "invitePeriod": None,
+                                "maxInvites": 0,
+                                "sendDownloadLink": True,
+                                "allowComments": False,
+                                "hideAttachments": False,
+                                "hideWorkflowRecipients": False,
+                            },
+                        ],
+                    }
+                ),
+            ],
+        )
+
+        lex_persona_backend = get_signature_backend()
+        with self.assertRaises(ValidationError) as context:
+            lex_persona_backend.update_signatories(
+                reference_id=workflow_id,
+                all_signatories=False,
+            )
+
+        self.assertEqual(
+            str(context.exception.message),
+            "Lex Persona: Unable to update the signatories for signature procedure with "
+            f"the reference {workflow_id}",
+        )
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(
+            responses.calls[0].request.url, update_signatories_procedure_api_url
+        )
+        self.assertEqual(responses.calls[0].request.method, "PATCH")


### PR DESCRIPTION
New organization owners should be able to sign the contract. Actually, the invitation link received by the signature backend will only return the link if the user has been registered into the signature procedure. Actually, a new organization owner will never be able to sign existing contracts that were initiated before his arrival. 

We need to be able to catch every update, deletion or creation of **organization access** with the role 'owner' to update the list of signatories for an organization for ongoing signature procedures.

## Purpose

Allow new organization owners to be able to sign existing contract that were initiated before their arrival.
Owners who are deleted should be taken of the signature procedures as well.
The goal is to have only users who are eligible to date to sign contracts in order to get a valid contract once signed by both parties.

## Proposal
- [x] Add endpoint for signature backend to update existing workflow (base, dummy, lex_persona)
- [x] Create utility methods for contracts to retrieve orders that are concerned by the organization access organization.
- [x] Celery task to update the signatories in background.
- [x] Declare `create()`, `update()`, and `delete()` methods for the API admin Endpoints of `OrganizationAccessViewSet`
- [x]  Add tests