### PR TITLE
🐛(backend) convert validity period in ms for Lex Persona backend

### DIFF
--- a/docs/explanation/signature_backend.md
+++ b/docs/explanation/signature_backend.md
@@ -80,7 +80,7 @@ variables. Here is a list of **all the required configuration** you will need to
 
 Futhermore, here are the common settings that are used for the signature :
 
-* `JOANIE_SIGNATURE_VALIDITY_PERIOD` : This value is declared in seconds. It's the window of time where a file is eligible
+* `JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS` : This value is declared in seconds. It's the window of time where a file is eligible
 to get signed by the signer.
 
 * `JOANIE_SIGNATURE_TIMEOUT` : A timeout refers to the maximum amount of time in seconds for our

--- a/src/backend/joanie/core/models/contracts.py
+++ b/src/backend/joanie/core/models/contracts.py
@@ -252,7 +252,7 @@ class Contract(BaseModel):
             return False
 
         valid_until = self.submitted_for_signature_on + timedelta(
-            seconds=settings.JOANIE_SIGNATURE_VALIDITY_PERIOD
+            seconds=settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS
         )
         is_still_valid = timezone.now() < valid_until
         if not is_still_valid:
@@ -262,7 +262,9 @@ class Contract(BaseModel):
                     "context": {
                         "contract": self.to_dict(),
                         "submitted_for_signature_on": self.submitted_for_signature_on,
-                        "signature_validity_period": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD,
+                        "signature_validity_period": (
+                            settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS
+                        ),
                         "valid_until": valid_until,
                     },
                 },

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -1042,8 +1042,14 @@ class Order(BaseModel):
         #    before expiration of the signature workflow
         # 3- the contract context has changed since it was last submitted for signature
         if should_be_resubmitted or not was_already_submitted:
+            now = timezone.now()
+            course_code = (
+                self.course.code
+                if self.course
+                else self.enrollment.course_run.course.code
+            )
             reference, checksum = backend_signature.submit_for_signature(
-                title=contract_definition.title,
+                title=f'{now.strftime("%Y-%m-%d")}_{course_code}_{self.pk}',
                 file_bytes=file_bytes,
                 order=self,
             )

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -471,7 +471,8 @@ class Base(Configuration):
         environ_prefix=None,
     )
     JOANIE_SIGNATURE_VALIDITY_PERIOD = values.PositiveIntegerValue(
-        60 * 60 * 24 * 15,
+        99 * 60 * 60 * 24,  # Duration in seconds
+        # 99 days is the maximum validity period accepted by Lex Persona
         environ_name="JOANIE_SIGNATURE_VALIDITY_PERIOD",
         environ_prefix=None,
     )

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -470,10 +470,10 @@ class Base(Configuration):
         environ_name="JOANIE_SIGNATURE_BACKEND",
         environ_prefix=None,
     )
-    JOANIE_SIGNATURE_VALIDITY_PERIOD = values.PositiveIntegerValue(
+    JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS = values.PositiveIntegerValue(
         99 * 60 * 60 * 24,  # Duration in seconds
         # 99 days is the maximum validity period accepted by Lex Persona
-        environ_name="JOANIE_SIGNATURE_VALIDITY_PERIOD",
+        environ_name="JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS",
         environ_prefix=None,
     )
 

--- a/src/backend/joanie/signature/backends/lex_persona.py
+++ b/src/backend/joanie/signature/backends/lex_persona.py
@@ -104,7 +104,9 @@ class LexPersonaBackend(BaseSignatureBackend):
         provider.
         """
         timeout = settings.JOANIE_SIGNATURE_TIMEOUT
-        validity_period_in_ms = settings.JOANIE_SIGNATURE_VALIDITY_PERIOD * 1000
+        validity_period_in_ms = (
+            settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS * 1000
+        )
 
         base_url = self.get_setting("BASE_URL")
         session_user_id = self.get_setting("SESSION_USER_ID")

--- a/src/backend/joanie/signature/backends/lex_persona.py
+++ b/src/backend/joanie/signature/backends/lex_persona.py
@@ -104,7 +104,7 @@ class LexPersonaBackend(BaseSignatureBackend):
         provider.
         """
         timeout = settings.JOANIE_SIGNATURE_TIMEOUT
-        validity_period = settings.JOANIE_SIGNATURE_VALIDITY_PERIOD
+        validity_period_in_ms = settings.JOANIE_SIGNATURE_VALIDITY_PERIOD * 1000
 
         base_url = self.get_setting("BASE_URL")
         session_user_id = self.get_setting("SESSION_USER_ID")
@@ -123,7 +123,7 @@ class LexPersonaBackend(BaseSignatureBackend):
                     "stepType": "signature",
                     "recipients": student_recipient_data,
                     "requiredRecipients": 1,
-                    "validityPeriod": validity_period,
+                    "validityPeriod": validity_period_in_ms,
                     "invitePeriod": None,
                     "maxInvites": 0,
                     "sendDownloadLink": True,
@@ -135,7 +135,7 @@ class LexPersonaBackend(BaseSignatureBackend):
                     "stepType": "signature",
                     "recipients": organization_recipient_data,
                     "requiredRecipients": 1,
-                    "validityPeriod": validity_period,
+                    "validityPeriod": validity_period_in_ms,
                     "invitePeriod": None,
                     "maxInvites": 0,
                     "sendDownloadLink": True,

--- a/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
@@ -184,7 +184,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         self.assertIn(expected_substring_invite_url, invitation_url)
 
     @override_settings(
-        JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+        JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     def test_api_order_submit_for_signature_contract_be_resubmitted_with_validity_period_passed(
         self,
@@ -236,7 +236,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         self.assertIn(expected_substring_invite_url, invitation_link)
 
     @override_settings(
-        JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+        JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     def test_api_order_submit_for_signature_contract_context_has_changed_and_still_valid_period(
         self,

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -651,8 +651,6 @@ class EnrollmentApiTest(BaseAPITestCase):
             state=enums.ORDER_STATE_VALIDATED,
         )
 
-        # breakpoint()
-
         enrollment = factories.EnrollmentFactory(
             course_run=target_course_runs[0],
             user=user,

--- a/src/backend/joanie/tests/core/test_models_contract.py
+++ b/src/backend/joanie/tests/core/test_models_contract.py
@@ -539,7 +539,7 @@ class ContractModelTestCase(TestCase):
         self.assertIsNone(contract.definition_checksum)
 
     @override_settings(
-        JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+        JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     def test_model_contract_is_eligible_for_signature_must_be_true(self):
         """
@@ -563,7 +563,7 @@ class ContractModelTestCase(TestCase):
         self.assertEqual(response, True)
 
     @override_settings(
-        JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+        JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     def test_model_contract_is_eligible_for_signature_must_be_false(self):
         """

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -1462,7 +1462,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         self.assertIsNotNone(contract.student_signed_on)
 
     @override_settings(
-        JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+        JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     def test_models_order_submit_for_signature_contract_same_context_but_passed_validity_period(
         self,

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_delete_signing_procedure.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_delete_signing_procedure.py
@@ -20,7 +20,7 @@ from . import get_expected_workflow_payload
     JOANIE_SIGNATURE_LEXPERSONA_SESSION_USER_ID="usr_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_PROFILE_ID="sip_profile_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_TOKEN="token_id_fake",
-    JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+    JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     JOANIE_SIGNATURE_TIMEOUT=3,
 )
 class LexPersonaBackendTestCase(TestCase):

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signature_invitation_link.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signature_invitation_link.py
@@ -18,7 +18,7 @@ from joanie.signature.backends import get_signature_backend
     JOANIE_SIGNATURE_LEXPERSONA_SESSION_USER_ID="usr_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_PROFILE_ID="sip_profile_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_TOKEN="token_id_fake",
-    JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+    JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     JOANIE_SIGNATURE_TIMEOUT=3,
 )
 class LexPersonaBackendGetSignatureInvitationLinkTestCase(TestCase):

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signed_file.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_get_signed_file.py
@@ -18,7 +18,7 @@ from joanie.signature.backends import get_signature_backend
     JOANIE_SIGNATURE_LEXPERSONA_SESSION_USER_ID="usr_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_PROFILE_ID="sip_profile_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_TOKEN="token_id_fake",
-    JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+    JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     JOANIE_SIGNATURE_TIMEOUT=3,
 )
 class LexPersonaBackendGetSignedFileTestCase(TestCase):

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
@@ -24,7 +24,7 @@ from joanie.tests.base import BaseLogMixinTestCase
     JOANIE_SIGNATURE_LEXPERSONA_SESSION_USER_ID="usr_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_PROFILE_ID="sip_profile_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_TOKEN="token_id_fake",
-    JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+    JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     JOANIE_SIGNATURE_TIMEOUT=3,
 )
 class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase):
@@ -434,7 +434,7 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase
         )
 
     @override_settings(
-        JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+        JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     @responses.activate
     def test_backend_lex_persona_handle_notification_workflow_finished_event_but_signature_expired(

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
@@ -23,7 +23,7 @@ from . import get_expected_workflow_payload
     JOANIE_SIGNATURE_LEXPERSONA_SESSION_USER_ID="usr_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_PROFILE_ID="sip_profile_id_fake",
     JOANIE_SIGNATURE_LEXPERSONA_TOKEN="token_id_fake",
-    JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+    JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     JOANIE_SIGNATURE_TIMEOUT=3,
 )
 class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
@@ -129,8 +129,10 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
                                     }
                                 ],
                                 "requiredRecipients": 1,
-                                "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD
-                                * 1000,
+                                "validityPeriod": (
+                                    settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS
+                                    * 1000
+                                ),
                                 "invitePeriod": None,
                                 "maxInvites": 0,
                                 "sendDownloadLink": True,
@@ -152,8 +154,10 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
                                     for access in reversed(accesses)
                                 ],
                                 "requiredRecipients": 1,
-                                "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD
-                                * 1000,
+                                "validityPeriod": (
+                                    settings.JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS
+                                    * 1000
+                                ),
                                 "invitePeriod": None,
                                 "maxInvites": 0,
                                 "sendDownloadLink": True,

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
@@ -129,7 +129,8 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
                                     }
                                 ],
                                 "requiredRecipients": 1,
-                                "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD,
+                                "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD
+                                * 1000,
                                 "invitePeriod": None,
                                 "maxInvites": 0,
                                 "sendDownloadLink": True,
@@ -151,7 +152,8 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
                                     for access in reversed(accesses)
                                 ],
                                 "requiredRecipients": 1,
-                                "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD,
+                                "validityPeriod": settings.JOANIE_SIGNATURE_VALIDITY_PERIOD
+                                * 1000,
                                 "invitePeriod": None,
                                 "maxInvites": 0,
                                 "sendDownloadLink": True,

--- a/src/backend/joanie/tests/signature/test_backend_signature_base.py
+++ b/src/backend/joanie/tests/signature/test_backend_signature_base.py
@@ -125,7 +125,7 @@ class BaseSignatureBackendTestCase(TestCase):
                 "joanie.signature.backends.dummy.DummySignatureBackend",
             ],
         ),
-        JOANIE_SIGNATURE_VALIDITY_PERIOD=60 * 60 * 24 * 15,
+        JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     def test_backend_signature_base_backend_confirm_student_signature_but_validity_period_is_passed(
         self,


### PR DESCRIPTION
## Purpose

Currently the document uploaded on the signature provider has the contract definition title as title. This is weird as for a course, all contracts will have the same name. In order to improve that we decide to built a specific title according to the current date, the related course and the order primary key.

`YYYY-MM-DD_COURSE_CODE_ORDER_PK`


On Lex Persona, each workflow steps have a validity period. We sets this one according to the settings `JOANIE_SIGNATURE_VALIDITY_PERIOD` but this setting is expressed in seconds and it appears Lex Persona expects a duration in ms. So as effect, the minimum validity period of Lex persona is used (which is 24h). Once this delay is reached, Lex Persona stops the related workflow and recipients are not able to sign until we restart the worfklow.
    
Furthermore, we decide to update the default `JOANIE_SIGNATURE_VALIDITY_PERIOD` to the max value accepted by Lex Persona which is 99 days.


## Proposal

- [x] Improve document title to sign
- [x] Use ms as unit to set validity period in Lex Persona backend
- [x] Use the max validity period accepted by Lex Persona as default value for the setting `JOANIE_SIGNATURE_VALIDITY_PERIOD`
