### PR TITLE
♻️(backend) use same serializer for product and course relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Use generic AdminCourseProductRelationSerializer
+
 ## [2.0.1] - 2024-04-16
 
 ### Fixed

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -471,8 +471,8 @@ class AdminCourseProductRelationsSerializer(serializers.ModelSerializer):
     Serialize all information about a course relation nested in a product.
     """
 
-    course = AdminCourseNestedSerializer(read_only=True)
-    product = AdminProductSerializer(read_only=True)
+    course = AdminCourseLightSerializer(read_only=True)
+    product = AdminProductLightSerializer(read_only=True)
     organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
     order_groups = AdminOrderGroupSerializer(many=True, read_only=True)
 
@@ -551,32 +551,6 @@ class AdminCourseProductRelationsSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class AdminCourseRelationsSerializer(AdminCourseProductRelationsSerializer):
-    """
-    Serialize all information about a course relation nested in a product.
-    """
-
-    class Meta(AdminCourseProductRelationsSerializer.Meta):
-        fields = [
-            field
-            for field in AdminCourseProductRelationsSerializer.Meta.fields
-            if field != "product"
-        ]
-        read_only_fields = fields
-
-
-class AdminProductRelationSerializer(AdminCourseProductRelationsSerializer):
-    """Serializer for CourseProductRelation model."""
-
-    class Meta(AdminCourseProductRelationsSerializer.Meta):
-        fields = [
-            field
-            for field in AdminCourseProductRelationsSerializer.Meta.fields
-            if field != "course"
-        ]
-        read_only_fields = ["id", "can_edit", "order_groups"]
-
-
 class AdminCourseAccessSerializer(serializers.ModelSerializer):
     """Serializer for CourseAccess model."""
 
@@ -629,7 +603,7 @@ class AdminCourseSerializer(serializers.ModelSerializer):
     title = serializers.CharField()
     cover = ThumbnailDetailField(required=False)
     organizations = AdminOrganizationLightSerializer(many=True, read_only=True)
-    product_relations = AdminProductRelationSerializer(many=True, read_only=True)
+    product_relations = AdminCourseProductRelationsSerializer(many=True, read_only=True)
     accesses = AdminCourseAccessSerializer(many=True, read_only=True)
     course_runs = AdminCourseRunLightSerializer(many=True, read_only=True)
     effort = ISO8601DurationField(allow_null=True, required=False)
@@ -932,7 +906,7 @@ class AdminProductDetailSerializer(serializers.ModelSerializer):
     price = serializers.DecimalField(
         coerce_to_string=False, decimal_places=2, max_digits=9, min_value=0
     )
-    course_relations = AdminCourseRelationsSerializer(read_only=True, many=True)
+    course_relations = AdminCourseProductRelationsSerializer(read_only=True, many=True)
     price_currency = serializers.SerializerMethodField(read_only=True)
 
     class Meta:

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_create.py
@@ -5,13 +5,11 @@ Test suite for CourseProductRelation create Admin API.
 
 import uuid
 from http import HTTPStatus
-from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase
 
 from joanie.core import enums, factories, models
-from joanie.core.serializers import fields
 
 
 class CourseProductRelationCreateAdminApiTest(TestCase):
@@ -68,12 +66,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             {"detail": "You do not have permission to perform this action."},
         )
 
-    @mock.patch.object(
-        fields.ThumbnailDetailField,
-        "to_representation",
-        return_value="_this_field_is_mocked",
-    )
-    def test_admin_api_course_products_relation_create_superuser(self, _):
+    def test_admin_api_course_products_relation_create_superuser(self):
         """
         Super admin user should be able to create a course product relation.
         """
@@ -106,9 +99,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                 "course": {
                     "code": course.code,
                     "id": str(course.id),
-                    "cover": "_this_field_is_mocked",
                     "title": course.title,
-                    "organizations": [],
                     "state": {
                         "priority": course.state["priority"],
                         "datetime": course.state["datetime"]
@@ -122,105 +113,21 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                 },
                 "order_groups": [],
                 "product": {
+                    "price": float(product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
                     "id": str(product.id),
                     "title": product.title,
                     "description": product.description,
                     "call_to_action": product.call_to_action,
-                    "price": float(product.price),
-                    "price_currency": settings.DEFAULT_CURRENCY,
                     "type": product.type,
-                    "certificate_definition": {
-                        "id": str(product.certificate_definition.id),
-                        "description": product.certificate_definition.description,
-                        "name": product.certificate_definition.name,
-                        "title": product.certificate_definition.title,
-                        "template": product.certificate_definition.template,
-                    },
+                    "certificate_definition": str(product.certificate_definition.id),
                     "contract_definition": None,
                     "target_courses": [
-                        {
-                            "code": target_course.code,
-                            "course_runs": [
-                                {
-                                    "id": course_run.id,
-                                    "title": course_run.title,
-                                    "resource_link": course_run.resource_link,
-                                    "state": {
-                                        "priority": course_run.state["priority"],
-                                        "datetime": course_run.state["datetime"]
-                                        .isoformat()
-                                        .replace("+00:00", "Z"),
-                                        "call_to_action": course_run.state[
-                                            "call_to_action"
-                                        ],
-                                        "text": course_run.state["text"],
-                                    },
-                                    "start": course_run.start.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "end": course_run.end.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "enrollment_start": (
-                                        course_run.enrollment_start.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                    "enrollment_end": (
-                                        course_run.enrollment_end.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                }
-                                for course_run in target_course.course_runs.all().order_by(
-                                    "start"
-                                )
-                            ],
-                            "position": target_course.product_relations.get(
-                                product=product
-                            ).position,
-                            "is_graded": target_course.product_relations.get(
-                                product=product
-                            ).is_graded,
-                            "title": target_course.title,
-                        }
+                        str(target_course.id)
                         for target_course in product.target_courses.all().order_by(
                             "product_target_relations__position"
                         )
                     ],
-                    "course_relations": [
-                        {
-                            "can_edit": True,
-                            "course": {
-                                "code": course.code,
-                                "cover": "_this_field_is_mocked",
-                                "id": str(course.id),
-                                "organizations": [],
-                                "state": {
-                                    "priority": course.state["priority"],
-                                    "datetime": course.state["datetime"]
-                                    .isoformat()
-                                    .replace("+00:00", "Z")
-                                    if course.state["datetime"]
-                                    else None,
-                                    "call_to_action": course.state["call_to_action"],
-                                    "text": course.state["text"],
-                                },
-                                "title": course.title,
-                            },
-                            "id": str(relation.id),
-                            "uri": relation.uri,
-                            "order_groups": [],
-                            "organizations": [
-                                {
-                                    "code": organization.code,
-                                    "id": str(organization.id),
-                                    "title": organization.title,
-                                }
-                            ],
-                        }
-                    ],
-                    "instructions": "",
                 },
                 "organizations": [
                     {
@@ -282,12 +189,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
             {"product_id": "This field is required."},
         )
 
-    @mock.patch.object(
-        fields.ThumbnailDetailField,
-        "to_representation",
-        return_value="_this_field_is_mocked",
-    )
-    def test_admin_api_course_products_relation_create_no_organization_id(self, _):
+    def test_admin_api_course_products_relation_create_no_organization_id(self):
         """
         Super admin user should be able to create a course product relation
         without organization id.
@@ -319,9 +221,7 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                 "course": {
                     "code": course.code,
                     "id": str(course.id),
-                    "cover": "_this_field_is_mocked",
                     "title": course.title,
-                    "organizations": [],
                     "state": {
                         "priority": course.state["priority"],
                         "datetime": course.state["datetime"]
@@ -335,99 +235,21 @@ class CourseProductRelationCreateAdminApiTest(TestCase):
                 },
                 "order_groups": [],
                 "product": {
+                    "price": float(product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
                     "id": str(product.id),
                     "title": product.title,
                     "description": product.description,
                     "call_to_action": product.call_to_action,
-                    "price": float(product.price),
-                    "price_currency": settings.DEFAULT_CURRENCY,
                     "type": product.type,
-                    "certificate_definition": {
-                        "id": str(product.certificate_definition.id),
-                        "description": product.certificate_definition.description,
-                        "name": product.certificate_definition.name,
-                        "title": product.certificate_definition.title,
-                        "template": product.certificate_definition.template,
-                    },
+                    "certificate_definition": str(product.certificate_definition.id),
                     "contract_definition": None,
                     "target_courses": [
-                        {
-                            "code": target_course.code,
-                            "course_runs": [
-                                {
-                                    "id": course_run.id,
-                                    "title": course_run.title,
-                                    "resource_link": course_run.resource_link,
-                                    "state": {
-                                        "priority": course_run.state["priority"],
-                                        "datetime": course_run.state["datetime"]
-                                        .isoformat()
-                                        .replace("+00:00", "Z"),
-                                        "call_to_action": course_run.state[
-                                            "call_to_action"
-                                        ],
-                                        "text": course_run.state["text"],
-                                    },
-                                    "start": course_run.start.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "end": course_run.end.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "enrollment_start": (
-                                        course_run.enrollment_start.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                    "enrollment_end": (
-                                        course_run.enrollment_end.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                }
-                                for course_run in target_course.course_runs.all().order_by(
-                                    "start"
-                                )
-                            ],
-                            "position": target_course.product_relations.get(
-                                product=product
-                            ).position,
-                            "is_graded": target_course.product_relations.get(
-                                product=product
-                            ).is_graded,
-                            "title": target_course.title,
-                        }
+                        str(target_course.id)
                         for target_course in product.target_courses.all().order_by(
                             "product_target_relations__position"
                         )
                     ],
-                    "course_relations": [
-                        {
-                            "can_edit": True,
-                            "course": {
-                                "code": course.code,
-                                "cover": "_this_field_is_mocked",
-                                "id": str(course.id),
-                                "organizations": [],
-                                "state": {
-                                    "priority": course.state["priority"],
-                                    "datetime": course.state["datetime"]
-                                    .isoformat()
-                                    .replace("+00:00", "Z")
-                                    if course.state["datetime"]
-                                    else None,
-                                    "call_to_action": course.state["call_to_action"],
-                                    "text": course.state["text"],
-                                },
-                                "title": course.title,
-                            },
-                            "id": str(relation.id),
-                            "uri": relation.uri,
-                            "order_groups": [],
-                            "organizations": [],
-                        }
-                    ],
-                    "instructions": "",
                 },
                 "organizations": [],
             },

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_list.py
@@ -4,13 +4,11 @@ Test suite for CourseProductRelation list Admin API.
 """
 
 from http import HTTPStatus
-from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase
 
 from joanie.core import enums, factories
-from joanie.core.serializers import fields
 
 
 class CourseProductRelationListAdminApiTest(TestCase):
@@ -51,12 +49,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
             {"detail": "You do not have permission to perform this action."},
         )
 
-    @mock.patch.object(
-        fields.ThumbnailDetailField,
-        "to_representation",
-        return_value="_this_field_is_mocked",
-    )
-    def test_admin_api_course_products_relation_list_superuser(self, _):
+    def test_admin_api_course_products_relation_list_superuser(self):
         """
         Super admin user should be able to list a course product relation.
         """
@@ -87,9 +80,7 @@ class CourseProductRelationListAdminApiTest(TestCase):
                         "course": {
                             "code": relation.course.code,
                             "id": str(relation.course.id),
-                            "cover": "_this_field_is_mocked",
                             "title": relation.course.title,
-                            "organizations": [],
                             "state": {
                                 "priority": relation.course.state["priority"],
                                 "datetime": relation.course.state["datetime"]
@@ -105,116 +96,23 @@ class CourseProductRelationListAdminApiTest(TestCase):
                         },
                         "order_groups": [],
                         "product": {
+                            "price": float(relation.product.price),
+                            "price_currency": settings.DEFAULT_CURRENCY,
                             "id": str(relation.product.id),
                             "title": relation.product.title,
                             "description": relation.product.description,
                             "call_to_action": relation.product.call_to_action,
-                            "price": float(relation.product.price),
-                            "price_currency": settings.DEFAULT_CURRENCY,
                             "type": relation.product.type,
-                            "certificate_definition": {
-                                "id": str(relation.product.certificate_definition.id),
-                                "description": relation.product.certificate_definition.description,
-                                "name": relation.product.certificate_definition.name,
-                                "title": relation.product.certificate_definition.title,
-                                "template": relation.product.certificate_definition.template,
-                            },
+                            "certificate_definition": str(
+                                relation.product.certificate_definition.id
+                            ),
                             "contract_definition": None,
                             "target_courses": [
-                                {
-                                    "code": target_course.code,
-                                    "course_runs": [
-                                        {
-                                            "id": course_run.id,
-                                            "title": course_run.title,
-                                            "resource_link": course_run.resource_link,
-                                            "state": {
-                                                "priority": course_run.state[
-                                                    "priority"
-                                                ],
-                                                "datetime": course_run.state["datetime"]
-                                                .isoformat()
-                                                .replace("+00:00", "Z"),
-                                                "call_to_action": course_run.state[
-                                                    "call_to_action"
-                                                ],
-                                                "text": course_run.state["text"],
-                                            },
-                                            "start": course_run.start.isoformat().replace(
-                                                "+00:00", "Z"
-                                            ),
-                                            "end": course_run.end.isoformat().replace(
-                                                "+00:00", "Z"
-                                            ),
-                                            "enrollment_start": (
-                                                course_run.enrollment_start.isoformat().replace(
-                                                    "+00:00", "Z"
-                                                )
-                                            ),
-                                            "enrollment_end": (
-                                                course_run.enrollment_end.isoformat().replace(
-                                                    "+00:00", "Z"
-                                                )
-                                            ),
-                                        }
-                                        for course_run in target_course.course_runs.all().order_by(
-                                            "start"
-                                        )
-                                    ],
-                                    "position": target_course.product_relations.get(
-                                        product=relation.product
-                                    ).position,
-                                    "is_graded": target_course.product_relations.get(
-                                        product=relation.product
-                                    ).is_graded,
-                                    "title": target_course.title,
-                                }
-                                for target_course in (
-                                    relation.product.target_courses.all().order_by(
-                                        "product_target_relations__position"
-                                    )
+                                str(target_course.id)
+                                for target_course in relation.product.target_courses.all().order_by(
+                                    "product_target_relations__position"
                                 )
                             ],
-                            "course_relations": [
-                                {
-                                    "can_edit": True,
-                                    "course": {
-                                        "code": relation.course.code,
-                                        "cover": "_this_field_is_mocked",
-                                        "id": str(relation.course.id),
-                                        "organizations": [],
-                                        "state": {
-                                            "priority": relation.course.state[
-                                                "priority"
-                                            ],
-                                            "datetime": relation.course.state[
-                                                "datetime"
-                                            ]
-                                            .isoformat()
-                                            .replace("+00:00", "Z")
-                                            if relation.course.state["datetime"]
-                                            else None,
-                                            "call_to_action": relation.course.state[
-                                                "call_to_action"
-                                            ],
-                                            "text": relation.course.state["text"],
-                                        },
-                                        "title": relation.course.title,
-                                    },
-                                    "id": str(relation.id),
-                                    "uri": relation.uri,
-                                    "order_groups": [],
-                                    "organizations": [
-                                        {
-                                            "code": organization.code,
-                                            "id": str(organization.id),
-                                            "title": organization.title,
-                                        }
-                                        for organization in relation.organizations.all()
-                                    ],
-                                }
-                            ],
-                            "instructions": "",
                         },
                         "organizations": [
                             {

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_retrieve.py
@@ -4,13 +4,11 @@ Test suite for CourseProductRelation retrieve Admin API.
 """
 
 from http import HTTPStatus
-from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase
 
 from joanie.core import enums, factories
-from joanie.core.serializers import fields
 
 
 class CourseProductRelationRetrieveAdminApiTest(TestCase):
@@ -51,12 +49,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
             {"detail": "You do not have permission to perform this action."},
         )
 
-    @mock.patch.object(
-        fields.ThumbnailDetailField,
-        "to_representation",
-        return_value="_this_field_is_mocked",
-    )
-    def test_admin_api_course_products_relation_retrieve_superuser(self, _):
+    def test_admin_api_course_products_relation_retrieve_superuser(self):
         """
         Super admin user should be able to retrieve a course product relation.
         """
@@ -81,9 +74,7 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
                 "course": {
                     "code": relation.course.code,
                     "id": str(relation.course.id),
-                    "cover": "_this_field_is_mocked",
                     "title": relation.course.title,
-                    "organizations": [],
                     "state": {
                         "priority": relation.course.state["priority"],
                         "datetime": relation.course.state["datetime"]
@@ -97,110 +88,23 @@ class CourseProductRelationRetrieveAdminApiTest(TestCase):
                 },
                 "order_groups": [],
                 "product": {
+                    "price": float(relation.product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
                     "id": str(relation.product.id),
                     "title": relation.product.title,
                     "description": relation.product.description,
                     "call_to_action": relation.product.call_to_action,
-                    "price": float(relation.product.price),
-                    "price_currency": settings.DEFAULT_CURRENCY,
                     "type": relation.product.type,
-                    "certificate_definition": {
-                        "id": str(relation.product.certificate_definition.id),
-                        "description": relation.product.certificate_definition.description,
-                        "name": relation.product.certificate_definition.name,
-                        "title": relation.product.certificate_definition.title,
-                        "template": relation.product.certificate_definition.template,
-                    },
+                    "certificate_definition": str(
+                        relation.product.certificate_definition.id
+                    ),
                     "contract_definition": None,
                     "target_courses": [
-                        {
-                            "code": target_course.code,
-                            "course_runs": [
-                                {
-                                    "id": course_run.id,
-                                    "title": course_run.title,
-                                    "resource_link": course_run.resource_link,
-                                    "state": {
-                                        "priority": course_run.state["priority"],
-                                        "datetime": course_run.state["datetime"]
-                                        .isoformat()
-                                        .replace("+00:00", "Z"),
-                                        "call_to_action": course_run.state[
-                                            "call_to_action"
-                                        ],
-                                        "text": course_run.state["text"],
-                                    },
-                                    "start": course_run.start.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "end": course_run.end.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "enrollment_start": (
-                                        course_run.enrollment_start.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                    "enrollment_end": (
-                                        course_run.enrollment_end.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                }
-                                for course_run in target_course.course_runs.all().order_by(
-                                    "start"
-                                )
-                            ],
-                            "position": target_course.product_relations.get(
-                                product=relation.product
-                            ).position,
-                            "is_graded": target_course.product_relations.get(
-                                product=relation.product
-                            ).is_graded,
-                            "title": target_course.title,
-                        }
-                        for target_course in (
-                            relation.product.target_courses.all().order_by(
-                                "product_target_relations__position"
-                            )
+                        str(target_course.id)
+                        for target_course in relation.product.target_courses.all().order_by(
+                            "product_target_relations__position"
                         )
                     ],
-                    "course_relations": [
-                        {
-                            "can_edit": True,
-                            "course": {
-                                "code": relation.course.code,
-                                "cover": "_this_field_is_mocked",
-                                "id": str(relation.course.id),
-                                "organizations": [],
-                                "state": {
-                                    "priority": relation.course.state["priority"],
-                                    "datetime": relation.course.state["datetime"]
-                                    .isoformat()
-                                    .replace("+00:00", "Z")
-                                    if relation.course.state["datetime"]
-                                    else None,
-                                    "call_to_action": relation.course.state[
-                                        "call_to_action"
-                                    ],
-                                    "text": relation.course.state["text"],
-                                },
-                                "title": relation.course.title,
-                            },
-                            "id": str(relation.id),
-                            "uri": relation.uri,
-                            "order_groups": [],
-                            "organizations": [
-                                {
-                                    "code": organization.code,
-                                    "id": str(organization.id),
-                                    "title": organization.title,
-                                }
-                                for organization in relation.organizations.all()
-                            ],
-                        }
-                    ],
-                    "instructions": "",
                 },
                 "organizations": [
                     {

--- a/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
+++ b/src/backend/joanie/tests/core/api/admin/course_product_relations/test_update.py
@@ -5,13 +5,11 @@ Test suite for CourseProductRelation update Admin API.
 
 import uuid
 from http import HTTPStatus
-from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase
 
 from joanie.core import enums, factories
-from joanie.core.serializers import fields
 
 
 class CourseProductRelationUpdateAdminApiTest(TestCase):
@@ -70,12 +68,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             {"detail": "You do not have permission to perform this action."},
         )
 
-    @mock.patch.object(
-        fields.ThumbnailDetailField,
-        "to_representation",
-        return_value="_this_field_is_mocked",
-    )
-    def test_admin_api_course_products_relation_update_superuser(self, _):
+    def test_admin_api_course_products_relation_update_superuser(self):
         """
         Super admin user should be able to update a course product relation.
         """
@@ -110,9 +103,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                 "course": {
                     "code": course.code,
                     "id": str(course.id),
-                    "cover": "_this_field_is_mocked",
                     "title": course.title,
-                    "organizations": [],
                     "state": {
                         "priority": course.state["priority"],
                         "datetime": course.state["datetime"]
@@ -126,108 +117,23 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                 },
                 "order_groups": [],
                 "product": {
-                    "id": str(product.id),
-                    "title": product.title,
-                    "description": product.description,
-                    "call_to_action": product.call_to_action,
-                    "price": float(product.price),
+                    "price": float(relation.product.price),
                     "price_currency": settings.DEFAULT_CURRENCY,
-                    "type": product.type,
-                    "certificate_definition": {
-                        "id": str(product.certificate_definition.id),
-                        "description": product.certificate_definition.description,
-                        "name": product.certificate_definition.name,
-                        "title": product.certificate_definition.title,
-                        "template": product.certificate_definition.template,
-                    },
+                    "id": str(relation.product.id),
+                    "title": relation.product.title,
+                    "description": relation.product.description,
+                    "call_to_action": relation.product.call_to_action,
+                    "type": relation.product.type,
+                    "certificate_definition": str(
+                        relation.product.certificate_definition.id
+                    ),
                     "contract_definition": None,
                     "target_courses": [
-                        {
-                            "code": target_course.code,
-                            "course_runs": [
-                                {
-                                    "id": course_run.id,
-                                    "title": course_run.title,
-                                    "resource_link": course_run.resource_link,
-                                    "state": {
-                                        "priority": course_run.state["priority"],
-                                        "datetime": course_run.state["datetime"]
-                                        .isoformat()
-                                        .replace("+00:00", "Z"),
-                                        "call_to_action": course_run.state[
-                                            "call_to_action"
-                                        ],
-                                        "text": course_run.state["text"],
-                                    },
-                                    "start": course_run.start.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "end": course_run.end.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "enrollment_start": (
-                                        course_run.enrollment_start.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                    "enrollment_end": (
-                                        course_run.enrollment_end.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                }
-                                for course_run in target_course.course_runs.all().order_by(
-                                    "start"
-                                )
-                            ],
-                            "position": target_course.product_relations.get(
-                                product=product
-                            ).position,
-                            "is_graded": target_course.product_relations.get(
-                                product=product
-                            ).is_graded,
-                            "title": target_course.title,
-                        }
-                        for target_course in (
-                            product.target_courses.all().order_by(
-                                "product_target_relations__position"
-                            )
+                        str(target_course.id)
+                        for target_course in relation.product.target_courses.all().order_by(
+                            "product_target_relations__position"
                         )
                     ],
-                    "course_relations": [
-                        {
-                            "can_edit": True,
-                            "course": {
-                                "code": course.code,
-                                "cover": "_this_field_is_mocked",
-                                "id": str(course.id),
-                                "organizations": [],
-                                "state": {
-                                    "priority": course.state["priority"],
-                                    "datetime": course.state["datetime"]
-                                    .isoformat()
-                                    .replace("+00:00", "Z")
-                                    if course.state["datetime"]
-                                    else None,
-                                    "call_to_action": course.state["call_to_action"],
-                                    "text": course.state["text"],
-                                },
-                                "title": course.title,
-                            },
-                            "id": str(relation.id),
-                            "uri": relation.uri,
-                            "order_groups": [],
-                            "organizations": [
-                                {
-                                    "code": organization.code,
-                                    "id": str(organization.id),
-                                    "title": organization.title,
-                                }
-                                for organization in relation.organizations.all()
-                            ],
-                        }
-                    ],
-                    "instructions": "",
                 },
                 "organizations": [
                     {
@@ -283,12 +189,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             {"detail": "You do not have permission to perform this action."},
         )
 
-    @mock.patch.object(
-        fields.ThumbnailDetailField,
-        "to_representation",
-        return_value="_this_field_is_mocked",
-    )
-    def test_admin_api_course_products_relation_partially_update_superuser(self, _):
+    def test_admin_api_course_products_relation_partially_update_superuser(self):
         """
         Super admin user should be able to partially update a course product relation.
         """
@@ -318,9 +219,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                 "course": {
                     "code": course.code,
                     "id": str(course.id),
-                    "cover": "_this_field_is_mocked",
                     "title": course.title,
-                    "organizations": [],
                     "state": {
                         "priority": course.state["priority"],
                         "datetime": course.state["datetime"]
@@ -334,108 +233,23 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
                 },
                 "order_groups": [],
                 "product": {
+                    "price": float(relation.product.price),
+                    "price_currency": settings.DEFAULT_CURRENCY,
                     "id": str(relation.product.id),
                     "title": relation.product.title,
                     "description": relation.product.description,
                     "call_to_action": relation.product.call_to_action,
-                    "price": float(relation.product.price),
-                    "price_currency": settings.DEFAULT_CURRENCY,
                     "type": relation.product.type,
-                    "certificate_definition": {
-                        "id": str(relation.product.certificate_definition.id),
-                        "description": relation.product.certificate_definition.description,
-                        "name": relation.product.certificate_definition.name,
-                        "title": relation.product.certificate_definition.title,
-                        "template": relation.product.certificate_definition.template,
-                    },
+                    "certificate_definition": str(
+                        relation.product.certificate_definition.id
+                    ),
                     "contract_definition": None,
                     "target_courses": [
-                        {
-                            "code": target_course.code,
-                            "course_runs": [
-                                {
-                                    "id": course_run.id,
-                                    "title": course_run.title,
-                                    "resource_link": course_run.resource_link,
-                                    "state": {
-                                        "priority": course_run.state["priority"],
-                                        "datetime": course_run.state["datetime"]
-                                        .isoformat()
-                                        .replace("+00:00", "Z"),
-                                        "call_to_action": course_run.state[
-                                            "call_to_action"
-                                        ],
-                                        "text": course_run.state["text"],
-                                    },
-                                    "start": course_run.start.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "end": course_run.end.isoformat().replace(
-                                        "+00:00", "Z"
-                                    ),
-                                    "enrollment_start": (
-                                        course_run.enrollment_start.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                    "enrollment_end": (
-                                        course_run.enrollment_end.isoformat().replace(
-                                            "+00:00", "Z"
-                                        )
-                                    ),
-                                }
-                                for course_run in target_course.course_runs.all().order_by(
-                                    "start"
-                                )
-                            ],
-                            "position": target_course.product_relations.get(
-                                product=relation.product
-                            ).position,
-                            "is_graded": target_course.product_relations.get(
-                                product=relation.product
-                            ).is_graded,
-                            "title": target_course.title,
-                        }
-                        for target_course in (
-                            relation.product.target_courses.all().order_by(
-                                "product_target_relations__position"
-                            )
+                        str(target_course.id)
+                        for target_course in relation.product.target_courses.all().order_by(
+                            "product_target_relations__position"
                         )
                     ],
-                    "course_relations": [
-                        {
-                            "can_edit": True,
-                            "course": {
-                                "code": course.code,
-                                "cover": "_this_field_is_mocked",
-                                "id": str(course.id),
-                                "organizations": [],
-                                "state": {
-                                    "priority": course.state["priority"],
-                                    "datetime": course.state["datetime"]
-                                    .isoformat()
-                                    .replace("+00:00", "Z")
-                                    if course.state["datetime"]
-                                    else None,
-                                    "call_to_action": course.state["call_to_action"],
-                                    "text": course.state["text"],
-                                },
-                                "title": course.title,
-                            },
-                            "id": str(relation.id),
-                            "uri": relation.uri,
-                            "order_groups": [],
-                            "organizations": [
-                                {
-                                    "code": organization.code,
-                                    "id": str(organization.id),
-                                    "title": organization.title,
-                                }
-                                for organization in relation.organizations.all()
-                            ],
-                        }
-                    ],
-                    "instructions": "",
                 },
                 "organizations": [
                     {
@@ -450,12 +264,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
         )
 
-    @mock.patch.object(
-        fields.ThumbnailDetailField,
-        "to_representation",
-        return_value="_this_field_is_mocked",
-    )
-    def test_admin_api_course_products_relation_partially_update_organizations(self, _):
+    def test_admin_api_course_products_relation_partially_update_organizations(self):
         """
         Super admin user should be able to partially update a course product relation.
         """
@@ -487,9 +296,7 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             "course": {
                 "code": relation.course.code,
                 "id": str(relation.course.id),
-                "cover": "_this_field_is_mocked",
                 "title": relation.course.title,
-                "organizations": [],
                 "state": {
                     "priority": relation.course.state["priority"],
                     "datetime": relation.course.state["datetime"]
@@ -503,110 +310,23 @@ class CourseProductRelationUpdateAdminApiTest(TestCase):
             },
             "order_groups": [],
             "product": {
+                "price": float(relation.product.price),
+                "price_currency": settings.DEFAULT_CURRENCY,
                 "id": str(relation.product.id),
                 "title": relation.product.title,
                 "description": relation.product.description,
                 "call_to_action": relation.product.call_to_action,
-                "price": float(relation.product.price),
-                "price_currency": settings.DEFAULT_CURRENCY,
                 "type": relation.product.type,
-                "certificate_definition": {
-                    "id": str(relation.product.certificate_definition.id),
-                    "description": relation.product.certificate_definition.description,
-                    "name": relation.product.certificate_definition.name,
-                    "title": relation.product.certificate_definition.title,
-                    "template": relation.product.certificate_definition.template,
-                },
+                "certificate_definition": str(
+                    relation.product.certificate_definition.id
+                ),
                 "contract_definition": None,
                 "target_courses": [
-                    {
-                        "code": target_course.code,
-                        "course_runs": [
-                            {
-                                "id": course_run.id,
-                                "title": course_run.title,
-                                "resource_link": course_run.resource_link,
-                                "state": {
-                                    "priority": course_run.state["priority"],
-                                    "datetime": course_run.state["datetime"]
-                                    .isoformat()
-                                    .replace("+00:00", "Z"),
-                                    "call_to_action": course_run.state[
-                                        "call_to_action"
-                                    ],
-                                    "text": course_run.state["text"],
-                                },
-                                "start": course_run.start.isoformat().replace(
-                                    "+00:00", "Z"
-                                ),
-                                "end": course_run.end.isoformat().replace(
-                                    "+00:00", "Z"
-                                ),
-                                "enrollment_start": (
-                                    course_run.enrollment_start.isoformat().replace(
-                                        "+00:00", "Z"
-                                    )
-                                ),
-                                "enrollment_end": (
-                                    course_run.enrollment_end.isoformat().replace(
-                                        "+00:00", "Z"
-                                    )
-                                ),
-                            }
-                            for course_run in target_course.course_runs.all().order_by(
-                                "start"
-                            )
-                        ],
-                        "position": target_course.product_relations.get(
-                            product=relation.product
-                        ).position,
-                        "is_graded": target_course.product_relations.get(
-                            product=relation.product
-                        ).is_graded,
-                        "title": target_course.title,
-                    }
-                    for target_course in (
-                        relation.product.target_courses.all().order_by(
-                            "product_target_relations__position"
-                        )
+                    str(target_course.id)
+                    for target_course in relation.product.target_courses.all().order_by(
+                        "product_target_relations__position"
                     )
                 ],
-                "course_relations": [
-                    {
-                        "can_edit": True,
-                        "course": {
-                            "code": relation.course.code,
-                            "cover": "_this_field_is_mocked",
-                            "id": str(relation.course.id),
-                            "organizations": [],
-                            "state": {
-                                "priority": relation.course.state["priority"],
-                                "datetime": relation.course.state["datetime"]
-                                .isoformat()
-                                .replace("+00:00", "Z")
-                                if relation.course.state["datetime"]
-                                else None,
-                                "call_to_action": relation.course.state[
-                                    "call_to_action"
-                                ],
-                                "text": relation.course.state["text"],
-                            },
-                            "title": relation.course.title,
-                        },
-                        "id": str(relation.id),
-                        "uri": relation.uri,
-                        "order_groups": [],
-                        "organizations": [
-                            {
-                                "code": organization.code,
-                                "id": str(organization.id),
-                                "title": organization.title,
-                            }
-                            for organization in relation.organizations.all()
-                        ],
-                    }
-                ],
-                "instructions": "",
             },
             "organizations": [
                 {

--- a/src/backend/joanie/tests/core/test_api_admin_products.py
+++ b/src/backend/joanie/tests/core/test_api_admin_products.py
@@ -5,6 +5,7 @@ Test suite for Product Admin API.
 import random
 from http import HTTPStatus
 
+from django.conf import settings
 from django.test import TestCase
 
 from joanie.core import enums, factories, models
@@ -14,6 +15,8 @@ class ProductAdminApiTest(TestCase):
     """
     Test suite for Product Admin API.
     """
+
+    maxDiff = None
 
     def test_admin_api_product_request_without_authentication(self):
         """
@@ -245,27 +248,33 @@ class ProductAdminApiTest(TestCase):
                     "course": {
                         "id": str(relation.course.id),
                         "code": relation.course.code,
-                        "cover": {
-                            "filename": relation.course.cover.name,
-                            "height": relation.course.cover.height,
-                            "width": relation.course.cover.width,
-                            "src": f"{relation.course.cover.url}.1x1_q85.webp",
-                            "size": relation.course.cover.size,
-                            "srcset": (
-                                f"{relation.course.cover.url}.1920x1080_q85_crop-scale_upscale.webp 1920w, "  # pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.1280x720_q85_crop-scale_upscale.webp 1280w, "  # pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.768x432_q85_crop-scale_upscale.webp 768w, "  # pylint: disable=line-too-long
-                                f"{relation.course.cover.url}.384x216_q85_crop-scale_upscale.webp 384w"  # pylint: disable=line-too-long
-                            ),
-                        },
                         "title": relation.course.title,
-                        "organizations": [],
                         "state": {
                             "priority": relation.course.state["priority"],
                             "datetime": relation.course.state["datetime"],
                             "call_to_action": relation.course.state["call_to_action"],
                             "text": relation.course.state["text"],
                         },
+                    },
+                    "product": {
+                        "price": float(relation.product.price),
+                        "price_currency": settings.DEFAULT_CURRENCY,
+                        "id": str(relation.product.id),
+                        "title": relation.product.title,
+                        "description": relation.product.description,
+                        "call_to_action": relation.product.call_to_action,
+                        "type": relation.product.type,
+                        "certificate_definition": str(
+                            relation.product.certificate_definition.id
+                        ),
+                        "contract_definition": str(
+                            relation.product.contract_definition.id
+                        ),
+                        "target_courses": [
+                            str(relations[0].course.id),
+                            str(relations[1].course.id),
+                            str(relations[2].course.id),
+                        ],
                     },
                     "organizations": [
                         {

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -4675,7 +4675,7 @@
                     "product_relations": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/AdminProductRelation"
+                            "$ref": "#/components/schemas/AdminCourseProductRelations"
                         },
                         "readOnly": true
                     },
@@ -4781,71 +4781,6 @@
                     "title"
                 ]
             },
-            "AdminCourseNested": {
-                "type": "object",
-                "description": "Serializer for Course model nested in product.",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "readOnly": true,
-                        "description": "primary key for the record as UUID"
-                    },
-                    "code": {
-                        "type": "string",
-                        "maxLength": 100
-                    },
-                    "cover": {
-                        "type": "string",
-                        "format": "uri"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "organizations": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AdminOrganizationLight"
-                        },
-                        "readOnly": true
-                    },
-                    "state": {
-                        "type": "string",
-                        "description": "The state of the course carrying information on what to display on a course glimpse.\n\nThe game is to find the highest priority state for this course among\nits course runs and its products.",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "code",
-                    "id",
-                    "organizations",
-                    "state",
-                    "title"
-                ]
-            },
-            "AdminCourseNestedRequest": {
-                "type": "object",
-                "description": "Serializer for Course model nested in product.",
-                "properties": {
-                    "code": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": 100
-                    },
-                    "cover": {
-                        "type": "string",
-                        "format": "binary"
-                    },
-                    "title": {
-                        "type": "string",
-                        "minLength": 1
-                    }
-                },
-                "required": [
-                    "code",
-                    "title"
-                ]
-            },
             "AdminCourseProductRelations": {
                 "type": "object",
                 "description": "Serialize all information about a course relation nested in a product.",
@@ -4863,7 +4798,7 @@
                     "course": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/AdminCourseNested"
+                                "$ref": "#/components/schemas/AdminCourseLight"
                             }
                         ],
                         "readOnly": true
@@ -4885,7 +4820,7 @@
                     "product": {
                         "allOf": [
                             {
-                                "$ref": "#/components/schemas/AdminProduct"
+                                "$ref": "#/components/schemas/AdminProductLight"
                             }
                         ],
                         "readOnly": true
@@ -6373,56 +6308,6 @@
                     "target_courses",
                     "title",
                     "type"
-                ]
-            },
-            "AdminProductRelation": {
-                "type": "object",
-                "description": "Serializer for CourseProductRelation model.",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "format": "uuid",
-                        "readOnly": true,
-                        "description": "primary key for the record as UUID"
-                    },
-                    "can_edit": {
-                        "type": "string",
-                        "readOnly": true
-                    },
-                    "organizations": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AdminOrganizationLight"
-                        },
-                        "readOnly": true
-                    },
-                    "order_groups": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/AdminOrderGroup"
-                        },
-                        "readOnly": true
-                    },
-                    "product": {
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/AdminProduct"
-                            }
-                        ],
-                        "readOnly": true
-                    },
-                    "uri": {
-                        "type": "string",
-                        "readOnly": true
-                    }
-                },
-                "required": [
-                    "can_edit",
-                    "id",
-                    "order_groups",
-                    "organizations",
-                    "product",
-                    "uri"
                 ]
             },
             "AdminProductRequest": {


### PR DESCRIPTION
## Purpose

Previously, we were using specific serializers to bind course relations and product relations in respective serializers. Now, we would like to be able to create/update product's course relations but the route in charge to create those relations is a nested one under course resource so currently course information are not returned in the response but we need those information from product detail view. That's why we decided to share the same serializer to return relation of Course or Product.

## Proposal

- [x] Update admin serializers
- [x] Update tests
