### PR TITLE
🐛(edx_import) ignore conflicts when creating batch of enrollments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
-### Added
-
-### Changed
-
-### Removed
-
 ### Fixed
 
+- Ignore conflicts when creating batch of enrollments
 - Fix translation content logic
 
 ## [2.0.0] - 2024-04-10

--- a/src/backend/joanie/edx_imports/tasks/enrollments.py
+++ b/src/backend/joanie/edx_imports/tasks/enrollments.py
@@ -145,7 +145,7 @@ def import_enrollments_batch(batch_offset, batch_size, total, course_id, dry_run
         enrollment_created_on_field.editable = True
 
         enrollments_created = models.Enrollment.objects.bulk_create(
-            enrollments_to_create
+            enrollments_to_create, ignore_conflicts=True
         )
         report["enrollments"]["created"] += len(enrollments_created)
 

--- a/src/backend/joanie/tests/edx_imports/test_import_enrollments.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_enrollments.py
@@ -330,3 +330,48 @@ class EdxImportEnrollmentsTestCase(TestCase, BaseLogMixinTestCase):
             ("INFO", "1 import enrollments tasks launched"),
         ]
         self.assertLogsEquals(logger.records, expected_logs)
+
+    @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_enrollments_count")
+    @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_enrollments")
+    def test_import_enrollments_create_duplicate_entries(
+        self, mock_get_enrollments, mock_get_enrollments_count
+    ):
+        """
+        Trying to insert duplicate enrollments in the same bulk_create should ignore the duplicates.
+        """
+        edx_enrollments = edx_factories.EdxEnrollmentFactory.create_batch(10)
+
+        for edx_enrollment in edx_enrollments:
+            factories.CourseRunFactory.create(
+                course__code=extract_course_number(edx_enrollment.course_id),
+                resource_link=f"http://openedx.test/courses/{edx_enrollment.course_id}/course/",
+            )
+            factories.UserFactory.create(username=edx_enrollment.user.username)
+
+        edx_enrollments.append(edx_enrollments[0])
+        edx_enrollments.append(edx_enrollments[1])
+        mock_get_enrollments.return_value = edx_enrollments
+        mock_get_enrollments_count.return_value = len(edx_enrollments)
+        self.assertEqual(len(edx_enrollments), 12)
+        self.assertEqual(models.Enrollment.objects.count(), 0)
+
+        import_enrollments()
+
+        self.assertEqual(models.Enrollment.objects.count(), 10)
+        for edx_enrollment in edx_enrollments:
+            enrollment = models.Enrollment.objects.get(
+                user__username=edx_enrollment.user.username,
+                course_run__course__code=extract_course_number(
+                    edx_enrollment.course_id
+                ),
+            )
+            self.assertEqual(enrollment.is_active, edx_enrollment.is_active)
+            self.assertEqual(
+                enrollment.created_on, make_date_aware(edx_enrollment.created)
+            )
+            self.assertEqual(enrollment.user.username, edx_enrollment.user.username)
+            self.assertEqual(
+                enrollment.course_run.course.code,
+                extract_course_number(edx_enrollment.course_id),
+            )
+            self.assertEqual(enrollment.state, ENROLLMENT_STATE_SET)


### PR DESCRIPTION
## Purpose

When importing enrollments, a same insert in the database in a race condition leading to an integrity error. Unfortunately, the whole batch of 1000 enrollments is not inserted at allt. Using the parameter ignore_conflicts fix this issue by ignoring already inserted record but still inserting not existing enrollments.


## Proposal

- [x] ignore conflicts when creating batch of enrollments
