### PR TITLE
🔇(moodle) remove error logs when user is not found

### DIFF
--- a/src/backend/joanie/lms_handler/backends/moodle.py
+++ b/src/backend/joanie/lms_handler/backends/moodle.py
@@ -115,7 +115,7 @@ class MoodleLMSBackend(BaseLMSBackend):
             # username is unique in Moodle
             user_id = res.get("users", [])[0].get("id")
         except IndexError as e:
-            logger.error("User %s not found in Moodle", username)
+            logger.info("User %s not found in Moodle", username)
             raise MoodleUserException() from e
         return user_id
 

--- a/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
+++ b/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
@@ -2,7 +2,7 @@
 
 import random
 from http import HTTPStatus
-from logging import ERROR
+from logging import ERROR, INFO
 
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -884,7 +884,7 @@ class MoodleLMSBackendTestCase(TestCase):
 
         with (
             self.assertLogs(
-                "joanie.lms_handler.backends.moodle", level=ERROR
+                "joanie.lms_handler.backends.moodle", level=INFO
             ) as error_logs,
             self.assertRaises(EnrollmentError),
         ):
@@ -893,7 +893,7 @@ class MoodleLMSBackendTestCase(TestCase):
         self.assertEqual(
             error_logs.output,
             [
-                "ERROR:joanie.lms_handler.backends.moodle:User student not found in Moodle"
+                "INFO:joanie.lms_handler.backends.moodle:User student not found in Moodle"
             ],
         )
 
@@ -1537,7 +1537,7 @@ class MoodleLMSBackendTestCase(TestCase):
 
         with (
             self.assertLogs(
-                "joanie.lms_handler.backends.moodle", level=ERROR
+                "joanie.lms_handler.backends.moodle", level=INFO
             ) as error_logs,
             self.assertRaises(GradeError),
         ):
@@ -1546,7 +1546,7 @@ class MoodleLMSBackendTestCase(TestCase):
         self.assertEqual(
             error_logs.output,
             [
-                "ERROR:joanie.lms_handler.backends.moodle:User student not found in Moodle"
+                "INFO:joanie.lms_handler.backends.moodle:User student not found in Moodle"
             ],
         )
 


### PR DESCRIPTION
## Purpose

Each time a user is not found on Moodle, a logger.error message is sent. That means that for all new users, an event will be sent that is weird. In order to fix that, we decrease the log level to info. In this way, this log will be bound
 to an error event if needed.
