### PR TITLE
Encrypt celery additional data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 ### Fixed
 
 - Query string search for enrollment in django admin backoffice
+- Encrypt sentry additional data (may contain sensitive data)
 
 ## [2.0.1] - 2024-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added 
 
 - Add enrollments pages
+- Add admin page to decrypt additional data sent to Sentry
 
 ### Changed
 

--- a/src/backend/joanie/core/templates/admin/base.html
+++ b/src/backend/joanie/core/templates/admin/base.html
@@ -1,0 +1,7 @@
+{% extends "admin/base.html" %}
+{% load i18n %}
+
+{% block userlinks %}
+    <a href={% url "sentry-decrypt" %}>{% trans "Sentry tools" %}</a> /
+  {{block.super}}
+{% endblock %}

--- a/src/backend/joanie/core/templates/debug/sentry_decrypt.html
+++ b/src/backend/joanie/core/templates/debug/sentry_decrypt.html
@@ -1,0 +1,19 @@
+{% extends "admin/index.html" %}
+
+{% block content %}
+  <div id="content-main">
+    <form action="{% url "sentry-decrypt" %}" method="post">
+      {% csrf_token %}
+      <textarea name="encrypted" rows="20" cols="100" >{{ encrypted }}</textarea>
+      <input type="submit" value="Decrypt">
+    </form>
+
+    {% if decrypted %}
+      <h2>Decrypted</h2>
+      <pre>{{ decrypted | pprint }}</pre>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block sidebar %}
+{% endblock %}

--- a/src/backend/joanie/core/utils/newsletter/brevo.py
+++ b/src/backend/joanie/core/utils/newsletter/brevo.py
@@ -40,7 +40,7 @@ class Brevo:
         """Log an info message."""
         logger.info(message, self.user.get("id"), self.list_id)
 
-    def _call_api(self, url, payload=None, query_params=None):
+    def _call_api(self, url, payload=None, query_params=None, log_level=logging.ERROR):
         """
         Call the Brevo API with the given payload.
         """
@@ -51,7 +51,8 @@ class Brevo:
                 url, params=query_params, headers=self.headers, timeout=5
             )
         if not response.ok:
-            logger.error(
+            logger.log(
+                log_level,
                 "Error calling Brevo API %s | %s: %s",
                 url,
                 response.status_code,
@@ -65,9 +66,10 @@ class Brevo:
                     }
                 },
             )
+
         return response
 
-    def create_contact_to_commercial_list(self):
+    def create_contact_to_commercial_list(self, log_level=logging.ERROR):
         """
         Create a contact with the given email, and add it to the commercial newsletter list.
         """
@@ -81,7 +83,7 @@ class Brevo:
             },
             "listIds": [self.list_id],
         }
-        response = self._call_api(self.contact_url, payload)
+        response = self._call_api(self.contact_url, payload, log_level=log_level)
         if not response.ok:
             return None
 
@@ -94,7 +96,9 @@ class Brevo:
         self._log_info("Adding email for user %s to list %s")
 
         payload = {"emails": [self.user.get("email")]}
-        response = self._call_api(self.subscribe_to_list_url, payload)
+        response = self._call_api(
+            self.subscribe_to_list_url, payload, log_level=logging.INFO
+        )
         if not response.ok:
             if (
                 response.status_code == BAD_REQUEST

--- a/src/backend/joanie/core/utils/sentry.py
+++ b/src/backend/joanie/core/utils/sentry.py
@@ -1,0 +1,96 @@
+"""Sentry utilities."""
+
+import json
+
+from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
+
+from cryptography.fernet import Fernet, InvalidToken
+
+RAW_KEYS = ["application", "sys.argv"]
+
+
+class SentryEncoder(DjangoJSONEncoder):
+    """
+    A JSON encoder for sentry context.
+    """
+
+    def default(self, o):
+        if o.__class__.__name__ in ["ImageFieldFile", "ThumbnailerImageFieldFile"]:
+            return o.path
+        if o.__class__.__name__ == "Country":
+            return o.name
+        if o.__class__.__name__ == "Site":
+            return o.domain
+        if o.__class__.__name__ == "Decimal" or isinstance(o, Exception):
+            return str(o)
+
+        return super().default(o)
+
+
+def before_send(event, hint):  # pylint: disable=unused-argument
+    """Encrypt the additional data of the event sent to Sentry."""
+    if extra := event.get("extra"):
+        event["extra"] = encrypt_extra(extra)
+    if breadcrumbs := event.get("breadcrumbs"):
+        for breadcrumb in breadcrumbs.get("values", []):
+            if data := breadcrumb.get("data"):
+                breadcrumb["data"] = encrypt_extra(data)
+    return event
+
+
+def encrypt_extra(extra):
+    """
+    Encrypt extra data.
+
+    Except for the keys in RAW_KEYS, encrypt the extra data at the key "encrypted_context".
+    """
+    key = settings.LOGGING_SECRET_KEY
+    if not key:
+        return extra
+
+    to_encrypt = {}
+    encrypted_extra = {}
+    for key, value in extra.items():
+        if key in RAW_KEYS:
+            encrypted_extra[key] = value
+        else:
+            to_encrypt.update({key: value})
+    if to_encrypt:
+        encrypted_extra["encrypted_context"] = encrypt_data(to_encrypt)
+    return encrypted_extra
+
+
+def serialize_data(data):
+    """Serialize data."""
+    return json.dumps(data, cls=SentryEncoder).encode()
+
+
+def encrypt_data(data):
+    """Encrypt data."""
+    key = settings.LOGGING_SECRET_KEY
+    if not key:
+        return data
+
+    try:
+        data = serialize_data(data)
+    except TypeError:
+        return data
+
+    cipher_suite = Fernet(key)
+    cipher_text = cipher_suite.encrypt(data)
+    return cipher_text.decode()
+
+
+def decrypt_data(encrypted_data):
+    """Decrypt data."""
+    key = settings.LOGGING_SECRET_KEY
+
+    try:
+        cipher_suite = Fernet(key)
+        plain_text = cipher_suite.decrypt(encrypted_data)
+        decrypted_data = json.loads(plain_text.decode())
+    except (json.JSONDecodeError, InvalidToken) as e:
+        decrypted_data = str(e)
+
+    return decrypted_data

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -199,7 +199,6 @@ class Base(Configuration):
 
     # Django applications from the highest priority to the lowest
     INSTALLED_APPS = [
-        "django.contrib.admin",
         "django.contrib.auth",
         "django.contrib.contenttypes",
         "django.contrib.sessions",
@@ -219,6 +218,8 @@ class Base(Configuration):
         "easy_thumbnails",
         # Joanie
         "joanie.core",
+        # contrib admin needs to be after joanie.core to override templates
+        "django.contrib.admin",
         "joanie.payment",
         "joanie.badges",
         "joanie.demo",

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -20,6 +20,7 @@ from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from joanie.core.utils import JSONValue
+from joanie.core.utils.sentry import before_send
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -73,6 +74,7 @@ class Base(Configuration):
     # Security
     ALLOWED_HOSTS = values.ListValue([])
     SECRET_KEY = values.Value(None)
+    LOGGING_SECRET_KEY = values.Value(None)
     # Security - Server to server authorized API keys
     JOANIE_AUTHORIZED_API_TOKENS = values.ListValue([], environ_prefix=None)
 
@@ -616,6 +618,7 @@ class Base(Configuration):
                 environment=cls.__name__.lower(),
                 release=get_release(),
                 integrations=[DjangoIntegration()],
+                before_send=before_send,
             )
             with sentry_sdk.configure_scope() as scope:
                 scope.set_extra("application", "backend")

--- a/src/backend/joanie/tests/base.py
+++ b/src/backend/joanie/tests/base.py
@@ -13,6 +13,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 from joanie.core import enums
 from joanie.core.models import ActivityLog
 from joanie.core.utils.jwt_tokens import generate_jwt_token_from_user
+from joanie.core.utils.sentry import serialize_data
 
 
 class BaseAPITestCase(TestCase):
@@ -149,6 +150,10 @@ class BaseLogMixinTestCase:
                         _type,
                         f"{assert_failed_message} context key {key}",
                     )
+
+                # should not raise
+                # See SentryEncoder in src/backend/joanie/core/utils/sentry.py
+                serialize_data(context)
         except Exception as error:
             raise error
 
@@ -168,6 +173,10 @@ class BaseLogMixinTestCase:
                     pass
             if not is_found:
                 self.fail(f"Expected record {expected_record} not found in {records}")
+
+        for record in logger.records:
+            if hasattr(record, "context"):
+                serialize_data(record.context)
 
 
 class ActivityLogMixingTestCase:

--- a/src/backend/joanie/tests/core/utils/test_sentry.py
+++ b/src/backend/joanie/tests/core/utils/test_sentry.py
@@ -1,0 +1,295 @@
+# ruff: noqa: PLR0912
+# pylint: disable=too-many-branches
+"""Test suite for the sentry utils."""
+
+from unittest import mock
+
+from django.core.serializers.json import DjangoJSONEncoder
+from django.test import TestCase, override_settings
+
+from factory.base import FactoryMetaClass
+
+from joanie.badges import factories as badges_factories
+from joanie.core import factories as core_factories
+from joanie.core.enums import PAYMENT_STATE_PENDING
+from joanie.core.utils.sentry import (
+    before_send,
+    decrypt_data,
+    encrypt_data,
+    encrypt_extra,
+)
+from joanie.payment import factories as payment_factories
+
+factories = []
+factories.extend(core_factories.__dict__.values())
+factories.extend(payment_factories.__dict__.values())
+factories.extend(badges_factories.__dict__.values())
+
+
+@override_settings(LOGGING_SECRET_KEY="9Jg_wqPAr1LF6JCA3iVX6v8lW3fixjW85d0QVsIqXcw=")
+class UtilsSentryTestCase(TestCase):
+    """Test the sentry utils"""
+
+    maxDiff = None
+
+    def test_encrypt_data(self):
+        """
+        Test the encryption of data
+
+        We test the encryption of data and then decrypt it to check if the data is the same
+        All the factories are tested
+        """
+        for factory in factories:
+            if isinstance(factory, FactoryMetaClass):
+                # AddressFactory needs an owner or an organization
+                if "<AddressFactory" in str(factory):
+                    obj = factory(owner=core_factories.UserFactory())
+                else:
+                    obj = factory()
+
+                # Our models have a to_dict method to serialize them
+                if hasattr(obj, "to_dict"):
+                    encrypted_data = encrypt_data(obj.to_dict())
+                # but others don't
+                else:
+                    encrypted_data = encrypt_data(obj)
+
+                decrypted_data = decrypt_data(encrypted_data)
+                if hasattr(obj, "to_dict"):
+                    for key, value in obj.to_dict().items():
+                        try:
+                            self.assertEqual(decrypted_data[key], value)
+                        except AssertionError:
+                            if value is None:
+                                self.assertIsNone(decrypted_data[key])
+                            else:
+                                self.assertIsNotNone(decrypted_data[key])
+                else:
+                    if obj.__class__.__name__ == "Site":
+                        self.assertEqual(decrypted_data, obj.domain)
+                        continue
+                    self.assertEqual(decrypted_data, obj)
+
+    def test_encrypt_organization(self):
+        """
+        Test the encryption of an organization
+
+        Specific test for ImageFieldFile, ThumbnailerImageFieldFile and Country
+        """
+        organization = core_factories.OrganizationFactory()
+
+        encrypted_data = encrypt_data(organization.to_dict())
+
+        decrypted_data = decrypt_data(encrypted_data)
+        self.assertEqual(decrypted_data["signature"], organization.signature.path)
+        self.assertEqual(decrypted_data["logo"], organization.logo.path)
+        self.assertEqual(decrypted_data["country"], organization.country.name)
+
+    def test_encrypt_site(self):
+        """
+        Test the encryption of a site
+
+        Specific test for Site
+        """
+        site = core_factories.SiteFactory()
+
+        encrypted_data = encrypt_data(site)
+
+        decrypted_data = decrypt_data(encrypted_data)
+        self.assertEqual(decrypted_data, site.domain)
+
+    @mock.patch("joanie.core.utils.sentry.SentryEncoder")
+    def test_encrypt_organization_fail(self, mock_sentry_encoder):
+        """
+        If serialization fails, return the data as is, unencrypted
+        """
+        mock_sentry_encoder.side_effect = DjangoJSONEncoder
+        organization = core_factories.OrganizationFactory()
+
+        encrypted_data = encrypt_data(organization.to_dict())
+
+        self.assertEqual(encrypted_data, organization.to_dict())
+
+    def test_encrypt_order_payment_schedule(self):
+        """
+        Test the encryption of an order payment schedule
+        """
+        order = core_factories.OrderFactory(
+            payment_schedule=[
+                {
+                    "amount": "200.00",
+                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ]
+        )
+
+        encrypted_data = encrypt_data(order.to_dict())
+
+        decrypted_data = decrypt_data(encrypted_data)
+        self.assertEqual(decrypted_data["payment_schedule"][0]["amount"], "200.00")
+        self.assertEqual(decrypted_data["payment_schedule"][1]["amount"], "300.00")
+
+    def test_encrypt_extra(self):
+        """
+        Test the encryption of extra data
+
+        We test the encryption of extra data and then decrypt it to check if the data is the same.
+        """
+        encrypted_data = encrypt_extra(
+            {
+                "application": "backend",
+                "sys.argv": ["test", "-c"],
+                "context": {"test": "test"},
+                "payload": {
+                    "test": "test",
+                    "test2": "test",
+                    "test3": "test",
+                },
+            }
+        )
+
+        self.assertEqual(encrypted_data["application"], "backend")
+        self.assertEqual(encrypted_data["sys.argv"], ["test", "-c"])
+
+        decrypted_data = decrypt_data(encrypted_data.get("encrypted_context"))
+
+        self.assertEqual(
+            decrypted_data,
+            {
+                "context": {"test": "test"},
+                "payload": {
+                    "test": "test",
+                    "test2": "test",
+                    "test3": "test",
+                },
+            },
+        )
+
+    @override_settings(LOGGING_SECRET_KEY=None)
+    def test_encrypt_extra_no_logging_secret_key(self):
+        """
+        Test the encryption of extra data
+
+        We test the encryption of extra data and then decrypt it to check if the data is the same.
+        """
+        encrypted_data = encrypt_extra(
+            {
+                "application": "backend",
+                "sys.argv": ["test", "-c"],
+                "context": {"test": "test"},
+                "payload": {
+                    "test": "test",
+                    "test2": "test",
+                    "test3": "test",
+                },
+            }
+        )
+
+        self.assertEqual(
+            encrypted_data,
+            {
+                "application": "backend",
+                "sys.argv": ["test", "-c"],
+                "context": {"test": "test"},
+                "payload": {
+                    "test": "test",
+                    "test2": "test",
+                    "test3": "test",
+                },
+            },
+        )
+
+    def test_encrypt_extra_empty(self):
+        """
+        Test the encryption of extra data
+
+        We test the encryption of extra data and then decrypt it to check if the data is the same.
+        """
+        encrypted_data = encrypt_extra(
+            {
+                "application": "backend",
+                "sys.argv": ["test", "-c"],
+            }
+        )
+
+        self.assertEqual(encrypted_data["application"], "backend")
+        self.assertEqual(encrypted_data["sys.argv"], ["test", "-c"])
+        self.assertIsNone(encrypted_data.get("encrypted_context"))
+
+    def test_before_send(self):
+        """
+        Test the before_send function
+
+        Extra data and breadcrumbs are encrypted.
+        """
+        event = {
+            "extra": {
+                "application": "backend",
+                "sys.argv": ["test", "-c"],
+                "context": {"test": "test"},
+                "payload": {
+                    "test": "test",
+                    "test2": "test",
+                    "test3": "test",
+                },
+            },
+            "breadcrumbs": {
+                "values": [
+                    {
+                        "data": {
+                            "application": "backend",
+                            "sys.argv": ["test", "-c"],
+                            "context": {"test": "test"},
+                            "payload": {
+                                "test": "test",
+                                "test2": "test",
+                                "test3": "test",
+                            },
+                        }
+                    }
+                ]
+            },
+        }
+
+        encrypted_event = before_send(event, None)
+        extra = encrypted_event["extra"]
+        breadcrumb_data = encrypted_event["breadcrumbs"]["values"][0]["data"]
+
+        self.assertEqual(extra["application"], "backend")
+        self.assertEqual(extra["sys.argv"], ["test", "-c"])
+        self.assertEqual(breadcrumb_data["application"], "backend")
+        self.assertEqual(breadcrumb_data["sys.argv"], ["test", "-c"])
+
+        decrypted_extra = decrypt_data(extra.get("encrypted_context"))
+        self.assertEqual(
+            decrypted_extra,
+            {
+                "context": {"test": "test"},
+                "payload": {
+                    "test": "test",
+                    "test2": "test",
+                    "test3": "test",
+                },
+            },
+        )
+
+        decrypted_breadcrumb_data = decrypt_data(
+            breadcrumb_data.get("encrypted_context")
+        )
+        self.assertEqual(
+            decrypted_breadcrumb_data,
+            {
+                "context": {"test": "test"},
+                "payload": {
+                    "test": "test",
+                    "test2": "test",
+                    "test3": "test",
+                },
+            },
+        )

--- a/src/backend/joanie/urls.py
+++ b/src/backend/joanie/urls.py
@@ -33,12 +33,16 @@ from joanie.core.views import (
     CertificateVerificationView,
 )
 from joanie.debug import urls as debug_urls
+from joanie.debug.views import SentryDecryptView
 from joanie.edx_imports import urls as edx_imports_urls
 
 API_VERSION = settings.API_VERSION
 
 urlpatterns = (
     [
+        path(
+            "admin/sentry-decrypt", SentryDecryptView.as_view(), name="sentry-decrypt"
+        ),
         path("admin/", admin.site.urls),
         re_path(
             r"^redirects/backoffice/(?P<path>.*)$",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "boto3==1.34.79",
     "Brotli==1.1.0",
     "celery[redis]==5.3.6",
+    "cryptography==42.0.5",
     "django-admin-sortable2==2.1.10",
     "django-admin-autocomplete-filter==0.7.1",
     "django-configurations==2.5.1",


### PR DESCRIPTION
## Purpose

When analyzing sentry logs, we captured some issues:

- non relevant errors sent during newsletter subscription
- sensitive data sent (celery task arguments)



## Proposal

As those sensitive data were crucial for debugging a real problem, all contexts are encrypted.
An admin page is added to decrypt them


- [x] use logger.info on first call to brevo when subscribing user
- [x] encrypt sentry additional data
- [x] add an admin page to decrypt sentry context
