### PR TITLE
🐛(user) prevent newsletter subscription created twice on user creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to
 
 ### Fixed
 
+- Prevent newsletter subscription on user save failure
 - Query string search for enrollment in django admin backoffice
 - Encrypt sentry additional data (may contain sensitive data)
 


### PR DESCRIPTION
## Purpose

As we are creating user on the fly during api requests, sometimes we can try to create a user twice. In this case `save` method raise an IntegrityError but as the subscription logic is put before the model save, this one is executed even if the save fails that is weird.

## Proposal

- [x] Create a single task even if we are trying to create a user twice
- [x] Write a working test
