### PR TITLE
✨(backend) Template - Update Contract Definition template with new sections (Accessibility and Required Equipment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Add accessibility section from Richie course syllabus
+  in contract definition template through RDF attributes
 - Update signatories for organization owners and student on ongoing
   signature procedures
 - Add enrollments pages

--- a/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
+++ b/src/backend/joanie/core/templates/contract_definition/fragment_appendice_syllabus.html
@@ -79,6 +79,10 @@
             <p>N/A</p>
         {% endif %}
     </section>
+    <section class="syllabus--content">
+        <h5>{% translate "Accessibility" %}</h5>
+        <div>{{ syllabus.accessibility|default:"N/A"|safe|linebreaks }}</div>
+    </section>
     <section class="syllabus--content syllabus--course-plan">
     <h5>{% trans "Course plan" %}</h5>
     {% if syllabus.plan %}

--- a/src/backend/joanie/core/utils/contract_context_processors.py
+++ b/src/backend/joanie/core/utils/contract_context_processors.py
@@ -161,6 +161,9 @@ def parse_richie_syllabus(course_code: str, language_code: str | None) -> dict:
         "assessments": get_object_repr(
             subject=course, predicate=SDO.educationalCredentialAwarded
         ),
+        "accessibility": get_object_repr(
+            subject=course, predicate=SDO.accessibilitySummary
+        ),
         "licenses": [
             {
                 "logo": get_object_repr(subject=l, predicate=SDO.thumbnailUrl),

--- a/src/backend/joanie/tests/core/test_utils_contract_context_processors.py
+++ b/src/backend/joanie/tests/core/test_utils_contract_context_processors.py
@@ -51,6 +51,7 @@ class UtilsContractContextProcessors(TestCase):
                     <p property="description">Course long description</p>
                     <p property="coursePrerequisites">Course prerequisites</p>
                     <p property="educationalCredentialAwarded">Course assessments and awards</p>
+                    <p property="accessibilitySummary">What is the accessibility of this course?</p>
                     <div property="about" typeof="Thing">
                         <h2 property="name">Format</h2>
                         <p property="description">Course format</p>
@@ -58,6 +59,10 @@ class UtilsContractContextProcessors(TestCase):
                     <div property="about" typeof="Thing">
                         <h2 property="name">What you will learn?</h2>
                         <p property="description">Course teaches</p>
+                    </div>
+                    <div property="about" typeof="Thing">
+                        <h2 property="name">Required Equipment</h2>
+                        <p property="description">What are the required equipment to follow this course?</p>
                     </div>
                     <div property="author" typeof="Organization">
                         <img src="//fun-cdn.net/images/2" property="logo" />
@@ -96,7 +101,7 @@ class UtilsContractContextProcessors(TestCase):
                             <meta property="position" content="1" />
                         </li>
                     </ul>
-                </body> 
+                </body>
                 """,
             )
             context = parse_richie_syllabus("178001", "fr-fr")
@@ -113,6 +118,9 @@ class UtilsContractContextProcessors(TestCase):
         self.assertEqual(context["description"], "Course long description")
         self.assertEqual(context["prerequisites"], "Course prerequisites")
         self.assertEqual(context["assessments"], "Course assessments and awards")
+        self.assertEqual(
+            context["accessibility"], "What is the accessibility of this course?"
+        )
         self.assertEqual(context["effort"], "PT3H")
         self.assertEqual(context["languages"], "French")
         self.assertCountEqual(context["categories"], ["Category 1", "Category 2"])
@@ -126,6 +134,10 @@ class UtilsContractContextProcessors(TestCase):
                 {
                     "name": "What you will learn?",
                     "description": "Course teaches",
+                },
+                {
+                    "name": "Required Equipment",
+                    "description": "What are the required equipment to follow this course?",
                 },
             ],
         )
@@ -214,6 +226,7 @@ class UtilsContractContextProcessors(TestCase):
                 "description": "",
                 "prerequisites": "",
                 "assessments": "",
+                "accessibility": "",
                 "effort": "",
                 "languages": "",
                 "categories": [],


### PR DESCRIPTION
There are two new sections in the course syllabus of Richie that we need to extract the information through RDF attributes for our contract_definition context. We've updated the processor context for the accessibility section, and for the required equiment it was already in gathered through the 'about' section.

Fix #764

## Purpose

Add the new section that were added into Richie's course syllabus (Accessibility and Required Equipment). 

## Proposal

- [x] Update extract method through RDF attributes.
- [x] Update template that prepares the data when there is a syllabus
- [x] Update tests of contract processor
