### PR TITLE
🐛(backend) contract context for the course section data as strings (price, effort, course start, course end)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to
 ### Changed
 
 - Store certificate images through a new DocumentImage model
-- Migrate to Sentry SDK 2.0 
+- Migrate to Sentry SDK 2.0
 - Add required filter by `Organization` and search through
   query on learner for certificate view in django admin
 - Migrate from `django-fsm` to `viewflow.fsm`
@@ -35,6 +35,8 @@ and this project adheres to
 
 ### Fixed
 
+- Contract's context `course_start`, `course_end`, `course_effort`
+  and `course_price` are strings for template tags formatting
 - Prevent newsletter subscription on user save failure
 - Query string search for enrollment in django admin backoffice
 - Encrypt sentry additional data (may contain sensitive data)

--- a/src/backend/joanie/core/templatetags/extra_tags.py
+++ b/src/backend/joanie/core/templatetags/extra_tags.py
@@ -50,7 +50,7 @@ def iso8601_to_date(value: str, arg: str = None) -> str:
     Custom tag filter to format an ISO 8601 datetime string into
     a formatted date string.
 
-    Paramter:
+    Parameter:
         - `value`: An ISO8601 datetime string
         - `arg`: Date format
                  https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#date

--- a/src/backend/joanie/core/utils/contract_definition.py
+++ b/src/backend/joanie/core/utils/contract_definition.py
@@ -1,7 +1,10 @@
 """Utility to `generate document context` data"""
 
+from datetime import date, timedelta
+
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.utils.duration import duration_iso_string
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext as _
 
@@ -52,7 +55,7 @@ def apply_contract_definition_context_processors(context):
     return context
 
 
-# ruff: noqa: PLR0915
+# ruff: noqa: PLR0912, PLR0915
 # pylint: disable=import-outside-toplevel, too-many-locals, too-many-statements
 def generate_document_context(contract_definition=None, user=None, order=None):
     """
@@ -160,9 +163,17 @@ def generate_document_context(contract_definition=None, user=None, order=None):
         course_start = course_dates["start"]
         course_end = course_dates["end"]
         course_effort = order.course.effort
-        course_price = order.total
-
+        course_price = str(order.total)
         user_address = order.main_invoice.recipient_address
+
+    # Transform duration value to ISO 8601 format
+    if isinstance(course_effort, timedelta):
+        course_effort = duration_iso_string(course_effort)
+    # Transform date value to ISO 8601 format
+    if isinstance(course_start, date):
+        course_start = course_start.isoformat()
+    if isinstance(course_end, date):
+        course_end = course_end.isoformat()
 
     if organization_address:
         organization_address = AddressSerializer(organization_address).data
@@ -209,5 +220,4 @@ def generate_document_context(contract_definition=None, user=None, order=None):
         },
     }
 
-    # Apply context processors
     return apply_contract_definition_context_processors(context)

--- a/src/backend/joanie/tests/core/utils/test_issuers_contract_definition_generate_document.py
+++ b/src/backend/joanie/tests/core/utils/test_issuers_contract_definition_generate_document.py
@@ -1,5 +1,6 @@
 """Test suite for utility method to generate document of Contract Definition in PDF bytes format"""
 
+from datetime import timedelta
 from io import BytesIO
 
 from django.contrib.sites.models import Site
@@ -56,6 +57,7 @@ class UtilsIssuersContractDefinitionGenerateDocument(TestCase):
 
         factories.OrganizationAddressFactory(
             organization=organization,
+            owner=None,
             address="1 Rue de l'Université",
             postcode="87000",
             city="Limoges",
@@ -82,7 +84,7 @@ class UtilsIssuersContractDefinitionGenerateDocument(TestCase):
             ],
         )
 
-        course = factories.CourseFactory(code="UX-00001", effort="PT404H")
+        course = factories.CourseFactory(code="UX-00001", effort=timedelta(hours=404))
 
         relation = factories.CourseProductRelationFactory(
             product=product, course=course, organizations=[organization]


### PR DESCRIPTION
On the contract template, the **hours** and the **dates** were not rendered as expected once it was generated. 

To avoid facing this situation, we now transform those values of **dates** and **duration** into iso 8601 string format before returning the context. We want the value to be prepared at their creation before adding it to the contract.

Overall, we had to update the : `course_start`, `course_end`, `course_effort` and `course_price`.

## Purpose

Make sure that our **template tags** for **date** and **duration** iso 8601 will work as expected into the template rendering. They are both waiting for the incoming input value to be **strings** and not **datetime.datetime**, or **datetime.date**, and not **datetime.timedelta**.

## Proposal

- [x] Adjust `def generate_context_document()` utility method in `contract_definition.py`
- [x] add a model test where we verify how the context is build when calling `submit_for_signature`
- [x] add test on utility method `generate_document_context`

Since we prepare the context that way it should be saved into the `contract.context`, we should also make sure the "order.total" is the string of the Decimal value, else this error comes up if we don't force the `order.price` to string representation in the generation of the context.

```
self = <json.encoder.JSONEncoder object at 0x711ffe726cb0>, o = Decimal('999.99')

    def default(self, o):
        """Implement this method in a subclass such that it returns
        a serializable object for ``o``, or calls the base implementation
        (to raise a ``TypeError``).
    
        For example, to support arbitrary iterators, you could
        implement default like this::
    
            def default(self, o):
                try:
                    iterable = iter(o)
                except TypeError:
                    pass
                else:
                    return list(iterable)
                # Let the base class default method raise the TypeError
                return JSONEncoder.default(self, o)
    
        """
>       raise TypeError(f'Object of type {o.__class__.__name__} '
                        f'is not JSON serializable')
E       TypeError: Object of type Decimal is not JSON serializable

```