### PR TITLE
🐛(backend) manage invalid logging secret key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Manage invalid logging secret key
+
 ## [2.1.0] - 2024-05-02
 
 ### Added

--- a/src/backend/joanie/core/utils/sentry.py
+++ b/src/backend/joanie/core/utils/sentry.py
@@ -77,7 +77,11 @@ def encrypt_data(data):
     except TypeError:
         return data
 
-    cipher_suite = Fernet(key)
+    try:
+        cipher_suite = Fernet(key)
+    except ValueError:
+        return {"error": "Log context encryption failed. The secret key is invalid."}
+
     cipher_text = cipher_suite.encrypt(data)
     return cipher_text.decode()
 

--- a/src/backend/joanie/tests/core/utils/test_sentry.py
+++ b/src/backend/joanie/tests/core/utils/test_sentry.py
@@ -70,6 +70,19 @@ class UtilsSentryTestCase(TestCase):
                         continue
                     self.assertEqual(decrypted_data, obj)
 
+    @override_settings(LOGGING_SECRET_KEY="invalid_secret_key")
+    def test_encrypt_data_with_invalid_secret_key(self):
+        """
+        If the logging secret key is invalid, encrypt_data method should return
+        a dictionary with an error message.
+        """
+        context = encrypt_data({"username": "johndoe"})
+
+        self.assertEqual(
+            context,
+            {"error": "Log context encryption failed. The secret key is invalid."},
+        )
+
     def test_encrypt_organization(self):
         """
         Test the encryption of an organization


### PR DESCRIPTION
## Purpose

If the logging secret key is misconfigured, currently log events are not sent to
 our error tracking platform that is weird. So this setting is misconfigured we
 manage the error and instead of binding encrypted data we bind an error
 dictionary to mention that encryption failed.

