### PR TITLE
🐛(frontend) fix bug update DatePicker with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 - Manage invalid logging secret key
 - Accesses list layout
 - Product target course layout
+- Update DatePicker with keyboard
 
 
 ## [2.1.0] - 2024-05-02

--- a/src/frontend/admin/src/components/presentational/hook-form/RHFDateTimePicker.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFDateTimePicker.tsx
@@ -43,7 +43,6 @@ export function RHFDateTimePicker({ label, name, ...props }: Props) {
               },
             }}
             onChange={(newValue: Date | null) => {
-              console.log(newValue);
               if (newValue === null) {
                 setValue(name, undefined);
               } else {

--- a/src/frontend/admin/src/components/presentational/hook-form/RHFDateTimePicker.tsx
+++ b/src/frontend/admin/src/components/presentational/hook-form/RHFDateTimePicker.tsx
@@ -1,6 +1,15 @@
 import { Controller, useFormContext } from "react-hook-form";
 import { DateTimePicker, DateTimePickerProps } from "@mui/x-date-pickers";
 import FormHelperText from "@mui/material/FormHelperText";
+import { defineMessages, useIntl } from "react-intl";
+
+const messages = defineMessages({
+  invalidDate: {
+    id: "components.presentational.hookForm.RHFDateTimePicker.invalidDate",
+    defaultMessage: "Invalid date",
+    description: "Message displayed when a date entered is not a date",
+  },
+});
 
 type Props = DateTimePickerProps<any> & {
   name: string;
@@ -8,7 +17,8 @@ type Props = DateTimePickerProps<any> & {
 };
 
 export function RHFDateTimePicker({ label, name, ...props }: Props) {
-  const { control, getValues, setValue } = useFormContext();
+  const intl = useIntl();
+  const { control, getValues, setValue, setError } = useFormContext();
   const value = getValues(name);
   return (
     <Controller
@@ -33,10 +43,19 @@ export function RHFDateTimePicker({ label, name, ...props }: Props) {
               },
             }}
             onChange={(newValue: Date | null) => {
+              console.log(newValue);
               if (newValue === null) {
                 setValue(name, undefined);
               } else {
-                setValue(name, newValue.toISOString());
+                const isValid = !Number.isNaN(newValue.getTime());
+                if (isValid) {
+                  setValue(name, newValue.toISOString());
+                } else {
+                  setError(name, {
+                    type: "custom",
+                    message: intl.formatMessage(messages.invalidDate),
+                  });
+                }
               }
             }}
             sx={{ width: "100%" }}

--- a/src/frontend/admin/src/components/testing/presentational/hook-form/RHFDateTimePicker/RHFDateTimePicker.spec.e2e.tsx
+++ b/src/frontend/admin/src/components/testing/presentational/hook-form/RHFDateTimePicker/RHFDateTimePicker.spec.e2e.tsx
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { RHFDateTimePickerTestWrapper } from "@/components/testing/presentational/hook-form/RHFDateTimePicker/RHFDateTimePickerTestWrapper";
+
+test.describe("<RHFDateTimePicker/>", () => {
+  test("Check the message displayed when you delete part of the date with the keyboard", async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(<RHFDateTimePickerTestWrapper />);
+    await component
+      .locator("div")
+      .filter({ hasText: /^End$/ })
+      .getByLabel("Choose date")
+      .click();
+    await page.getByRole("gridcell", { name: "16" }).click();
+    await page.getByRole("button", { name: "OK" }).click();
+    await component.getByLabel("End", { exact: true }).click();
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("Backspace");
+    await expect(component.getByText("Invalid date")).toBeVisible();
+  });
+});

--- a/src/frontend/admin/src/components/testing/presentational/hook-form/RHFDateTimePicker/RHFDateTimePickerTestWrapper.tsx
+++ b/src/frontend/admin/src/components/testing/presentational/hook-form/RHFDateTimePicker/RHFDateTimePickerTestWrapper.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import Grid from "@mui/material/Grid";
+import {
+  RHFProvider,
+  RHFProviderProps,
+} from "@/components/presentational/hook-form/RHFProvider";
+import { Nullable } from "@/types/utils";
+import { RHFDateTimePicker } from "@/components/presentational/hook-form/RHFDateTimePicker";
+import { TestingWrapper } from "@/components/testing/TestingWrapper";
+
+type Props = Omit<RHFProviderProps<any>, "methods" | "children"> & {};
+export function RHFDateTimePickerTestWrapper(props: Props) {
+  const [date, setDate] = useState<Nullable<Date>>(null);
+  const methods = useForm({
+    defaultValues: { end: null },
+  });
+
+  const onSubmit = (values: any) => {
+    setDate(values.name);
+  };
+
+  return (
+    <TestingWrapper>
+      <Box padding={4}>
+        <Typography data-testid="date-value">
+          Date: {date?.toISOString()}
+        </Typography>
+        <RHFProvider
+          {...props}
+          onSubmit={methods.handleSubmit(onSubmit)}
+          id="rhf-provider-test"
+          methods={methods}
+        >
+          <Grid container spacing={2}>
+            <Grid xs={12}>
+              <RHFDateTimePicker name="end" label="End" />
+            </Grid>
+          </Grid>
+        </RHFProvider>
+      </Box>
+    </TestingWrapper>
+  );
+}


### PR DESCRIPTION
## Purpose

Currently, when you click on a datepicker input and modify the date with the keyboard by deleting the month for example, a fatal error occurs.


<img width="1611" alt="Capture d’écran 2024-05-13 à 14 56 15" src="https://github.com/openfun/joanie/assets/19410531/caedb81e-1881-486a-b325-cd2b66d4acc9">
