### PR TITLE
🐛(frontend) fix order view when organization is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to
 - Accesses list layout
 - Product target course layout
 - Update DatePicker with keyboard
-
+- Order view when organization is not defined
 
 ## [2.1.0] - 2024-05-02
 

--- a/src/frontend/admin/src/components/templates/orders/view/OrderView.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/OrderView.tsx
@@ -89,12 +89,16 @@ export function OrderView({ order }: Props) {
                 fullWidth={true}
                 disabled={true}
                 InputProps={{
-                  endAdornment: getViewIcon(
-                    PATH_ADMIN.organizations.edit(order.organization.id),
-                  ),
+                  ...(order.organization
+                    ? {
+                        endAdornment: getViewIcon(
+                          PATH_ADMIN.organizations.edit(order.organization.id),
+                        ),
+                      }
+                    : {}),
                 }}
                 label={intl.formatMessage(orderViewMessages.organization)}
-                value={order.organization.title}
+                value={order.organization?.title ?? ""}
               />
             </Grid>
             <Grid xs={12} sm={6}>
@@ -116,9 +120,13 @@ export function OrderView({ order }: Props) {
                   fullWidth={true}
                   disabled={true}
                   InputProps={{
-                    endAdornment: getViewIcon(
-                      PATH_ADMIN.courses.edit(order.course.id),
-                    ),
+                    ...(order.course
+                      ? {
+                          endAdornment: getViewIcon(
+                            PATH_ADMIN.courses.edit(order.course.id),
+                          ),
+                        }
+                      : {}),
                   }}
                   label={intl.formatMessage(orderViewMessages.course)}
                   value={order.course.title}

--- a/src/frontend/admin/src/services/api/models/Order.ts
+++ b/src/frontend/admin/src/services/api/models/Order.ts
@@ -27,7 +27,7 @@ export type OrderListItem = AbstractOrder & {
 export type Order = AbstractOrder & {
   owner: User;
   product: ProductSimple;
-  organization: Organization;
+  organization?: Organization;
   order_group?: OrderGroup;
   course: Nullable<Course>;
   enrollment: Nullable<Enrollment>;
@@ -101,7 +101,7 @@ export const transformOrderToOrderListItem = (order: Order): OrderListItem => {
     course_code: order.course?.code ?? null,
     created_on: order.created_on,
     enrollment_id: order.enrollment?.id ?? null,
-    organization_title: order.organization.title,
+    organization_title: order.organization?.title ?? "",
     owner_name: order.owner.full_name ?? order.owner.username,
     product_title: order.product.title,
     state: order.state,

--- a/src/frontend/admin/src/tests/orders/OrderTestScenario.ts
+++ b/src/frontend/admin/src/tests/orders/OrderTestScenario.ts
@@ -14,7 +14,9 @@ export const getOrdersScenarioStore = (itemsNumber: number = 30) => {
   list.forEach((order) => {
     products.push(order.product);
     users.push(order.owner);
-    organizations.push(order.organization);
+    if (order.organization) {
+      organizations.push(order.organization);
+    }
     if (order.course) {
       courses.push(order.course);
     }


### PR DESCRIPTION
## Purpose

When an order is in draft without organization for example, a fatal error occurs

Close #784

