### PR TITLE
Complete lyra payment payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ src/backend/joanie/static/joanie/
 .vscode/
 *.iml
 /src/frontend/admin/out/
+
+# Payment debug files
+src/backend/answer.json
+src/backend/request.json
+src/backend/response.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 
 ### Fixed
 
+- Lyra backend save card logic
 - Manage invalid logging secret key
 - Accesses list layout
 - Product target course layout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Allow to filter enrollment through `is_active` field on the client API
 - Add the possibility to add a syllabus inside the product form
 
+### Changed
+
+- Complete Lyra payment creation payload
+
 ### Fixed
 
 - Manage invalid logging secret key

--- a/src/backend/joanie/core/templates/debug/payment.html
+++ b/src/backend/joanie/core/templates/debug/payment.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 
     <!-- STEP :
-    1 : load the JS librairy
+    1 : load the JS library
     2 : required public key and the JS parameters as url success -->
 
     <script type="text/javascript"

--- a/src/backend/joanie/payment/backends/lyra/__init__.py
+++ b/src/backend/joanie/payment/backends/lyra/__init__.py
@@ -270,11 +270,14 @@ class LyraBackend(BasePaymentBackend):
         card_token = answer["transactions"][0]["paymentMethodToken"]
         card_details = answer["transactions"][0]["transactionDetails"]["cardDetails"]
         card_pan = card_details["pan"]
+        payment_method_source = card_details["paymentMethodSource"]
+
         # Register card if user has requested it
-        if card_token is not None and card_pan is not None:
-            # In the case of a one click payment, card.id is not None but other
-            # attributes are empty. So to know if a user wants to save its card,
-            # we check if card.id and one other card attribute are not None.
+        if card_token is not None and payment_method_source != "TOKEN":
+            # In the case of a one click payment, card.id is not None and
+            # paymentMethodSource is set to TOKEN. So to know if a user wants to save
+            # its card, we check if card.id is set paymentMethodSource has another value
+            # than TOKEN (e.g: NEW).
             # - User asks to store its card
             CreditCard.objects.create(
                 brand=card_details["effectiveBrand"],

--- a/src/backend/joanie/tests/payment/test_backend_lyra.py
+++ b/src/backend/joanie/tests/payment/test_backend_lyra.py
@@ -658,6 +658,9 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
             },
         )
 
+        # No credit card should have been created
+        self.assertEqual(CreditCard.objects.count(), 0)
+
     @responses.activate(assert_all_requests_are_fired=True)
     def test_payment_backend_lyra_delete_credit_card(self):
         """

--- a/src/backend/joanie/tests/payment/test_backend_lyra.py
+++ b/src/backend/joanie/tests/payment/test_backend_lyra.py
@@ -323,7 +323,17 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
 
         response = backend.create_payment(order, billing_address)
 
-        self.assertEqual(response, json_response.get("answer").get("formToken"))
+        self.assertEqual(
+            response,
+            {
+                "provider_name": "lyra",
+                "form_token": json_response.get("answer").get("formToken"),
+                "configuration": {
+                    "public_key": self.configuration.get("public_key"),
+                    "base_url": self.configuration.get("api_base_url"),
+                },
+            },
+        )
 
     @responses.activate(assert_all_requests_are_fired=True)
     def test_payment_backend_lyra_create_one_click_payment(self):
@@ -390,7 +400,17 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
             order, billing_address, credit_card.token
         )
 
-        self.assertEqual(response, json_response.get("answer").get("formToken"))
+        self.assertEqual(
+            response,
+            {
+                "provider_name": "lyra",
+                "form_token": json_response.get("answer").get("formToken"),
+                "configuration": {
+                    "public_key": self.configuration.get("public_key"),
+                    "base_url": self.configuration.get("api_base_url"),
+                },
+            },
+        )
 
     def test_payment_backend_lyra_handle_notification_unknown_resource(self):
         """


### PR DESCRIPTION
## Purpose

Currently, some information are missing from the payload returned by Lyra backend on payment creation so we add missing information.

Furthermore, currently the logic to check if a credit card looks wrong so on one click payment, a credit card is created and it raises error (duplicated credit card).


## Proposal

- [x] Ignore debug files by git
- [x] Complete Lyra payment creation
- [x] Prevent to save card on one click payment
