### PR TITLE
✨(frontend) add is graded indicator inside product detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- BO : Highlight graded target courses in product detail view
 - Add `payment_schedule` property to `OrderSerializer`
 - Allow to filter enrollment through `is_active` field on the client API
 - Add the possibility to add a syllabus inside the product form

--- a/src/frontend/admin/src/components/templates/products/form/sections/target-courses/ProductFormTargetCourseRow.tsx
+++ b/src/frontend/admin/src/components/templates/products/form/sections/target-courses/ProductFormTargetCourseRow.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
-import { useIntl } from "react-intl";
+import { defineMessages, useIntl } from "react-intl";
+import SchoolIcon from "@mui/icons-material/School";
+import Tooltip from "@mui/material/Tooltip";
 import {
   ProductTargetCourseRelation,
   ProductTargetCourseRelationOptionalId,
@@ -9,6 +11,14 @@ import { DndDefaultRowProps } from "@/components/presentational/dnd/DndDefaultRo
 import { DefaultRow } from "@/components/presentational/list/DefaultRow";
 import { CustomLink } from "@/components/presentational/link/CustomLink";
 import { PATH_ADMIN } from "@/utils/routes/path";
+
+const messages = defineMessages({
+  isGradedTooltip: {
+    id: "components.templates.products.form.sections.targetCourses.ProductFormTargetCourseRow.isGradedTooltip",
+    description: "Label for the is graded tooltip",
+    defaultMessage: "Taken into account for certification",
+  },
+});
 
 type Props = Omit<DndDefaultRowProps, "mainTitle"> & {
   item: ProductTargetCourseRelation | ProductTargetCourseRelationOptionalId;
@@ -36,6 +46,13 @@ export function ProductFormTargetCourseRow({ item, ...props }: Props) {
         <CustomLink href={PATH_ADMIN.courses.edit(item.course.id)}>
           {item.course.title}
         </CustomLink>
+      }
+      permanentRightActions={
+        item.is_graded ? (
+          <Tooltip title={intl.formatMessage(messages.isGradedTooltip)}>
+            <SchoolIcon />
+          </Tooltip>
+        ) : undefined
       }
       subTitle={intl.formatMessage(
         productFormMessages.targetCourseRowSubTitle,


### PR DESCRIPTION
## Purpose

On product detail target course tab, we should display a visual indicator to distinguish graded target courses from others.

<img width="2548" alt="Capture d’écran 2024-05-16 à 15 31 11" src="https://github.com/openfun/joanie/assets/19410531/23ef21ab-9ee8-4ea9-bd13-dd96d342e1dc">
