### PR TITLE
✨(backend) add payment_schedule field to OrderSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add `payment_schedule` property to `OrderSerializer`
 - Allow to filter enrollment through `is_active` field on the client API
 - Add the possibility to add a syllabus inside the product form
 - Add a command to trigger the daily due payments

--- a/src/backend/joanie/tests/core/api/order/test_abort.py
+++ b/src/backend/joanie/tests/core/api/order/test_abort.py
@@ -99,8 +99,9 @@ class OrderAbortApiTest(BaseAPITestCase):
             content_type="application/json",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
-        order = models.Order.objects.get(id=response.json()["id"])
+
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        order = models.Order.objects.get(id=response.json()["id"])
         response = self.client.patch(
             f"/api/v1.0/orders/{order.id}/submit/",
             data=data,

--- a/src/backend/joanie/tests/core/api/order/test_create.py
+++ b/src/backend/joanie/tests/core/api/order/test_create.py
@@ -82,6 +82,7 @@ class OrderCreateApiTest(BaseAPITestCase):
                 "id": str(order.id),
                 "certificate_id": None,
                 "contract": None,
+                "payment_schedule": None,
                 "course": {
                     "code": course.code,
                     "id": str(course.id),
@@ -240,6 +241,7 @@ class OrderCreateApiTest(BaseAPITestCase):
                 "certificate_id": None,
                 "contract": None,
                 "course": None,
+                "payment_schedule": None,
                 "created_on": order.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 "enrollment": {
                     "course_run": {
@@ -610,6 +612,7 @@ class OrderCreateApiTest(BaseAPITestCase):
                 "id": str(order.id),
                 "certificate_id": None,
                 "contract": None,
+                "payment_schedule": None,
                 "course": {
                     "code": course.code,
                     "id": str(course.id),
@@ -1019,6 +1022,7 @@ class OrderCreateApiTest(BaseAPITestCase):
                 "id": str(order.id),
                 "certificate_id": None,
                 "contract": None,
+                "payment_schedule": None,
                 "course": {
                     "code": course.code,
                     "id": str(course.id),
@@ -1183,6 +1187,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             "id": str(order.id),
             "certificate_id": None,
             "contract": None,
+            "payment_schedule": None,
             "course": {
                 "code": course.code,
                 "id": str(course.id),

--- a/src/backend/joanie/tests/core/api/order/test_read_list.py
+++ b/src/backend/joanie/tests/core/api/order/test_read_list.py
@@ -82,6 +82,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "id": str(order.id),
                         "main_invoice_reference": None,
                         "order_group_id": None,
+                        "payment_schedule": None,
                         "organization": {
                             "id": str(order.organization.id),
                             "code": order.organization.code,
@@ -184,6 +185,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "product_id": str(other_order.product.id),
                         "state": other_order.state,
                         "target_courses": [],
+                        "payment_schedule": None,
                     }
                 ],
             },
@@ -270,6 +272,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "id": str(order.id),
                         "certificate_id": None,
                         "contract": None,
+                        "payment_schedule": None,
                         "course": {
                             "code": order.course.code,
                             "id": str(order.course.id),
@@ -392,6 +395,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "created_on": order.created_on.strftime(
                             "%Y-%m-%dT%H:%M:%S.%fZ"
                         ),
+                        "payment_schedule": None,
                         "enrollment": {
                             "course_run": {
                                 "course": {
@@ -559,6 +563,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "created_on": order.created_on.strftime(
                             "%Y-%m-%dT%H:%M:%S.%fZ"
                         ),
+                        "payment_schedule": None,
                         "enrollment": None,
                         "target_enrollments": [],
                         "main_invoice_reference": None,
@@ -648,6 +653,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "certificate_id": None,
                         "contract": None,
                         "course": None,
+                        "payment_schedule": None,
                         "created_on": order.created_on.strftime(
                             "%Y-%m-%dT%H:%M:%S.%fZ"
                         ),
@@ -904,6 +910,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "id": str(order.id),
                         "certificate_id": None,
                         "contract": None,
+                        "payment_schedule": None,
                         "course": {
                             "code": order.course.code,
                             "id": str(order.course.id),
@@ -990,6 +997,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "id": str(order.id),
                         "certificate_id": None,
                         "contract": None,
+                        "payment_schedule": None,
                         "course": {
                             "code": order.course.code,
                             "id": str(order.course.id),
@@ -1080,6 +1088,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "id": str(order.id),
                         "certificate_id": None,
                         "contract": None,
+                        "payment_schedule": None,
                         "course": {
                             "code": order.course.code,
                             "id": str(order.course.id),

--- a/src/backend/joanie/tests/core/api/order/test_update.py
+++ b/src/backend/joanie/tests/core/api/order/test_update.py
@@ -69,6 +69,7 @@ class OrderUpdateApiTest(BaseAPITestCase):
                 "target_enrollments",
                 "total",
                 "total_currency",
+                "payment_schedule",
             ],
         )
         headers = (

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -6034,6 +6034,13 @@
                         "type": "string",
                         "description": "Return the currency used",
                         "readOnly": true
+                    },
+                    "payment_schedule": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/OrderPayment"
+                        },
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -6046,6 +6053,7 @@
                     "main_invoice_reference",
                     "organization",
                     "owner",
+                    "payment_schedule",
                     "product_id",
                     "state",
                     "target_courses",
@@ -6088,6 +6096,31 @@
                 ]
             },
             "OrderPayment": {
+                "type": "object",
+                "description": "Serializer for the order payment",
+                "properties": {
+                    "amount": {
+                        "type": "number",
+                        "format": "double",
+                        "maximum": 10000000,
+                        "minimum": 0.0,
+                        "exclusiveMaximum": true
+                    },
+                    "due_date": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "state": {
+                        "$ref": "#/components/schemas/OrderPaymentStateEnum"
+                    }
+                },
+                "required": [
+                    "amount",
+                    "due_date",
+                    "state"
+                ]
+            },
+            "OrderPaymentRequest": {
                 "type": "object",
                 "description": "Serializer for the order payment",
                 "properties": {


### PR DESCRIPTION
## Purpose

We want to be able to retrieve order payment schedule if there is one through the order api client.