### PR TITLE
Ease installment identification and propage installment in payment backend

### DIFF
--- a/src/backend/joanie/core/tasks/payment_schedule.py
+++ b/src/backend/joanie/core/tasks/payment_schedule.py
@@ -32,12 +32,9 @@ def process_today_installment(order_id):
             except CreditCard.DoesNotExist:
                 order.set_installment_refused(installment["id"])
                 continue
-            payment_succeeded = payment_backend.create_zero_click_payment(
+
+            payment_backend.create_zero_click_payment(
                 order=order,
                 credit_card_token=credit_card.token,
-                amount=installment["amount"],
+                installment=installment,
             )
-            if payment_succeeded:
-                order.set_installment_paid(installment["id"])
-            else:
-                order.set_installment_refused(installment["id"])

--- a/src/backend/joanie/core/tasks/payment_schedule.py
+++ b/src/backend/joanie/core/tasks/payment_schedule.py
@@ -30,7 +30,7 @@ def process_today_installment(order_id):
             try:
                 credit_card = CreditCard.objects.get(owner=order.owner, is_main=True)
             except CreditCard.DoesNotExist:
-                order.set_installment_refused(installment["due_date"])
+                order.set_installment_refused(installment["id"])
                 continue
             payment_succeeded = payment_backend.create_zero_click_payment(
                 order=order,
@@ -38,6 +38,6 @@ def process_today_installment(order_id):
                 amount=installment["amount"],
             )
             if payment_succeeded:
-                order.set_installment_paid(installment["due_date"])
+                order.set_installment_paid(installment["id"])
             else:
-                order.set_installment_refused(installment["due_date"])
+                order.set_installment_refused(installment["id"])

--- a/src/backend/joanie/core/utils/payment_schedule.py
+++ b/src/backend/joanie/core/utils/payment_schedule.py
@@ -3,6 +3,7 @@ Payment schedule utility functions.
 """
 
 import logging
+import uuid
 from datetime import timedelta
 
 from django.conf import settings
@@ -85,6 +86,7 @@ def _calculate_installments(total, due_dates, percentages):
             amount = total_amount - amount_sum
         installments.append(
             {
+                "id": uuid.uuid4(),
                 "due_date": due_date,
                 "amount": amount,
                 "state": enums.PAYMENT_STATE_PENDING,

--- a/src/backend/joanie/tests/core/models/order/test_schedule.py
+++ b/src/backend/joanie/tests/core/models/order/test_schedule.py
@@ -314,30 +314,34 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         order = factories.OrderFactory(
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
-                    "state": PAYMENT_STATE_PENDING,
+                    "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
-            ]
+            ],
         )
 
         is_first, is_last = order._set_installment_state(
-            due_date="2024-01-17",
+            installment_id="d9356dd7-19a6-4695-b18e-ad93af41424a",
             state=PAYMENT_STATE_PAID,
         )
 
@@ -346,21 +350,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -371,7 +379,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         self.assertFalse(is_last)
 
         is_first, is_last = order._set_installment_state(
-            due_date="2024-04-17",
+            installment_id="9fcff723-7be4-4b77-87c6-2865e000f879",
             state=PAYMENT_STATE_REFUSED,
         )
 
@@ -380,21 +388,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_REFUSED,
@@ -406,7 +418,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
 
         with self.assertRaises(ValueError):
             order._set_installment_state(
-                due_date="2024-03-18",
+                installment_id="eb402e70-53da-4d67-81a9-b50dd04f571b",
                 state=PAYMENT_STATE_REFUSED,
             )
 
@@ -420,21 +432,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -443,7 +459,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_paid(
-            due_date="2024-02-17",
+            installment_id="1932fbc5-d971-48aa-8fee-6d637c3154a5",
         )
 
         order.refresh_from_db()
@@ -451,21 +467,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -485,21 +505,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
-                    "state": PAYMENT_STATE_PENDING,
+                    "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -508,7 +532,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_paid(
-            due_date="2024-01-17",
+            installment_id="d9356dd7-19a6-4695-b18e-ad93af41424a",
         )
 
         order.refresh_from_db()
@@ -516,21 +540,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -550,21 +578,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -573,7 +605,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_paid(
-            due_date="2024-04-17",
+            installment_id="9fcff723-7be4-4b77-87c6-2865e000f879",
         )
 
         order.refresh_from_db()
@@ -581,21 +613,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PAID,
@@ -615,6 +651,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -623,7 +660,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_paid(
-            due_date="2024-01-17",
+            installment_id="d9356dd7-19a6-4695-b18e-ad93af41424a",
         )
 
         order.refresh_from_db()
@@ -631,6 +668,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
@@ -650,21 +688,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING_PAYMENT,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -673,7 +715,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_refused(
-            due_date="2024-02-17",
+            installment_id="1932fbc5-d971-48aa-8fee-6d637c3154a5"
         )
 
         order.refresh_from_db()
@@ -681,21 +723,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_REFUSED,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -715,21 +761,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -738,7 +788,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_refused(
-            due_date="2024-01-17",
+            installment_id="d9356dd7-19a6-4695-b18e-ad93af41424a",
         )
 
         order.refresh_from_db()
@@ -746,21 +796,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_REFUSED,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -780,21 +834,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING_PAYMENT,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -803,7 +861,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_refused(
-            due_date="2024-04-17",
+            installment_id="9fcff723-7be4-4b77-87c6-2865e000f879",
         )
 
         order.refresh_from_db()
@@ -811,21 +869,25 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_REFUSED,
@@ -845,6 +907,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             state=ORDER_STATE_PENDING,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -853,7 +916,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         order.set_installment_refused(
-            due_date="2024-01-17",
+            installment_id="d9356dd7-19a6-4695-b18e-ad93af41424a",
         )
 
         order.refresh_from_db()
@@ -861,6 +924,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_REFUSED,
@@ -875,11 +939,13 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         order = factories.OrderFactory(
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -908,11 +974,13 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         order = factories.OrderFactory(
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,

--- a/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
+++ b/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
@@ -37,21 +37,25 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             owner=credit_card.owner,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -68,21 +72,25 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -97,21 +105,25 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             state=ORDER_STATE_PENDING,
             payment_schedule=[
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
@@ -128,21 +140,25 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             order.payment_schedule,
             [
                 {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
                     "amount": "200.00",
                     "due_date": "2024-01-17",
                     "state": PAYMENT_STATE_REFUSED,
                 },
                 {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
                     "amount": "300.00",
                     "due_date": "2024-02-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
                     "amount": "300.00",
                     "due_date": "2024-03-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
                     "amount": "199.99",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,

--- a/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
+++ b/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
@@ -11,13 +11,12 @@ from django.test import TestCase
 from joanie.core.enums import (
     ORDER_STATE_NO_PAYMENT,
     ORDER_STATE_PENDING,
-    ORDER_STATE_PENDING_PAYMENT,
-    PAYMENT_STATE_PAID,
     PAYMENT_STATE_PENDING,
     PAYMENT_STATE_REFUSED,
 )
 from joanie.core.factories import OrderFactory
 from joanie.core.tasks.payment_schedule import process_today_installment
+from joanie.payment.backends.dummy import DummyPaymentBackend
 from joanie.payment.factories import CreditCardFactory
 from joanie.tests.base import BaseLogMixinTestCase
 
@@ -29,10 +28,18 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
 
     maxDiff = None
 
-    def test_utils_payment_schedule_process_today_installment_succeeded(self):
+    @mock.patch.object(
+        DummyPaymentBackend,
+        "create_zero_click_payment",
+        side_effect=DummyPaymentBackend().create_zero_click_payment,
+    )
+    def test_utils_payment_schedule_process_today_installment_succeeded(
+        self, mock_create_zero_click_payment
+    ):
         """Check today's installment is processed"""
         credit_card = CreditCardFactory()
         order = OrderFactory(
+            id="6134df5e-a7eb-4cb3-aceb-d0abfe330af6",
             state=ORDER_STATE_PENDING,
             owner=credit_card.owner,
             payment_schedule=[
@@ -67,37 +74,16 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
         with mock.patch("django.utils.timezone.now", return_value=mocked_now):
             process_today_installment.run(order.id)
 
-        order.refresh_from_db()
-        self.assertEqual(
-            order.payment_schedule,
-            [
-                {
-                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
-                    "state": PAYMENT_STATE_PAID,
-                },
-                {
-                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
-                    "state": PAYMENT_STATE_PENDING,
-                },
-                {
-                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
-                    "state": PAYMENT_STATE_PENDING,
-                },
-                {
-                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
-                    "state": PAYMENT_STATE_PENDING,
-                },
-            ],
+        mock_create_zero_click_payment.assert_called_once_with(
+            order=order,
+            credit_card_token=credit_card.token,
+            installment={
+                "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+                "amount": "200.00",
+                "due_date": "2024-01-17",
+                "state": PAYMENT_STATE_PENDING,
+            },
         )
-        self.assertEqual(order.state, ORDER_STATE_PENDING_PAYMENT)
 
     def test_utils_payment_schedule_process_today_installment_no_card(self):
         """Check today's installment is processed"""


### PR DESCRIPTION
## Purpose

In order to identify every installments in an order schedule, we add a
unique id that can be use to find it later.

When an installment is paid, we can now use it in the
payment backend for all existing payment method (create_payment,
create_one_click_payment and create_zero_click_payment). Doing this, the
`_do_on_payment_success` and `_do_on_payment_failure` methods are able
to manage an installment lifecycle. There is no more need to manage it
in the payment schedule task.

## Proposal

- [x] add a unique id to each installments in an order schedule
- [x] use installment id to change installment state
- [x] when an installment is paid, propagate it in the payment backend