### PR TITLE
✨(api) add `amount_currency` field to `OrderPaymentSerializer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Add `currency` field to `OrderPaymentSerializer` serializer
+
 ## [2.2.0] - 2024-05-22
 
 ### Added

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -1041,6 +1041,7 @@ class OrderPaymentSerializer(serializers.Serializer):
         min_value=D(0.00),
         required=True,
     )
+    currency = serializers.SerializerMethodField(read_only=True)
     due_date = serializers.DateField(required=True)
     state = serializers.ChoiceField(
         choices=enums.PAYMENT_STATE_CHOICES,
@@ -1056,6 +1057,10 @@ class OrderPaymentSerializer(serializers.Serializer):
                 "state": data.get("state"),
             }
         )
+
+    def get_currency(self, *args, **kwargs) -> str:
+        """Return the code of currency used by the instance"""
+        return settings.DEFAULT_CURRENCY
 
     def create(self, validated_data):
         """Only there to avoid a NotImplementedError"""

--- a/src/backend/joanie/tests/core/api/order/test_read_detail.py
+++ b/src/backend/joanie/tests/core/api/order/test_read_detail.py
@@ -94,6 +94,7 @@ class OrderReadApiTest(BaseAPITestCase):
                 "payment_schedule": [
                     {
                         "amount": float(installment["amount"]),
+                        "currency": settings.DEFAULT_CURRENCY,
                         "due_date": format_date(installment["due_date"]),
                         "state": installment["state"],
                     }

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -1481,11 +1481,13 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 "payment_schedule": [
                     {
                         "amount": 0.90,
+                        "currency": settings.DEFAULT_CURRENCY,
                         "due_date": "2024-01-17",
                         "state": enums.PAYMENT_STATE_PENDING,
                     },
                     {
                         "amount": 2.10,
+                        "currency": settings.DEFAULT_CURRENCY,
                         "due_date": "2024-02-17",
                         "state": enums.PAYMENT_STATE_PENDING,
                     },

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -6106,6 +6106,11 @@
                         "minimum": 0.0,
                         "exclusiveMaximum": true
                     },
+                    "currency": {
+                        "type": "string",
+                        "description": "Return the code of currency used by the instance",
+                        "readOnly": true
+                    },
                     "due_date": {
                         "type": "string",
                         "format": "date"
@@ -6116,6 +6121,7 @@
                 },
                 "required": [
                     "amount",
+                    "currency",
                     "due_date",
                     "state"
                 ]


### PR DESCRIPTION
## Purpose

When retrieving payment schedule, our API consumer needs to know what is the currency used. So we add a field `amount_currency` to pass this information.
