### PR TITLE
✨(backend) add id field to OrderPaymentSerializer

### DIFF
--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -208,7 +208,8 @@ class CourseProductRelationViewSet(
 
         serializer = self.get_serializer(data={"payment_schedule": payment_schedule})
         serializer.is_valid(raise_exception=True)
-        return Response(serializer.data)
+
+        return Response(serializer.data.get("payment_schedule"))
 
 
 class EnrollmentViewSet(

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -1034,6 +1034,7 @@ class OrderPaymentSerializer(serializers.Serializer):
     Serializer for the order payment
     """
 
+    id = serializers.UUIDField(required=True)
     amount = serializers.DecimalField(
         coerce_to_string=False,
         decimal_places=2,
@@ -1052,6 +1053,7 @@ class OrderPaymentSerializer(serializers.Serializer):
         """Used to format the amount and the due_date before validation."""
         return super().to_internal_value(
             {
+                "id": str(data.get("id")),
                 "amount": data.get("amount").amount_as_string(),
                 "due_date": data.get("due_date").isoformat(),
                 "state": data.get("state"),

--- a/src/backend/joanie/tests/core/api/order/test_read_detail.py
+++ b/src/backend/joanie/tests/core/api/order/test_read_detail.py
@@ -66,7 +66,6 @@ class OrderReadApiTest(BaseAPITestCase):
             state=ORDER_STATE_VALIDATED,
         )
         # Generate payment schedule
-        # breakpoint()
         order.generate_schedule()
 
         organization_address = order.organization.addresses.filter(is_main=True).first()
@@ -93,6 +92,7 @@ class OrderReadApiTest(BaseAPITestCase):
                 },
                 "payment_schedule": [
                     {
+                        "id": str(installment["id"]),
                         "amount": float(installment["amount"]),
                         "currency": settings.DEFAULT_CURRENCY,
                         "due_date": format_date(installment["due_date"]),

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -1462,9 +1462,12 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             organizations=factories.OrganizationFactory.create_batch(2),
         )
 
-        with mock.patch(
-            "django.utils.timezone.now",
-            return_value=datetime(2024, 1, 1, 14, tzinfo=ZoneInfo("UTC")),
+        with (
+            mock.patch("uuid.uuid4", return_value=uuid.UUID(int=1)),
+            mock.patch(
+                "django.utils.timezone.now",
+                return_value=datetime(2024, 1, 1, 14, tzinfo=ZoneInfo("UTC")),
+            ),
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
@@ -1477,22 +1480,22 @@ class CourseProductRelationApiTest(BaseAPITestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(
             response.json(),
-            {
-                "payment_schedule": [
-                    {
-                        "amount": 0.90,
-                        "currency": settings.DEFAULT_CURRENCY,
-                        "due_date": "2024-01-17",
-                        "state": enums.PAYMENT_STATE_PENDING,
-                    },
-                    {
-                        "amount": 2.10,
-                        "currency": settings.DEFAULT_CURRENCY,
-                        "due_date": "2024-02-17",
-                        "state": enums.PAYMENT_STATE_PENDING,
-                    },
-                ]
-            },
+            [
+                {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "amount": 0.90,
+                    "currency": settings.DEFAULT_CURRENCY,
+                    "due_date": "2024-01-17",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+                {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "amount": 2.10,
+                    "currency": settings.DEFAULT_CURRENCY,
+                    "due_date": "2024-02-17",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+            ],
         )
 
         self.assertEqual(response_relation_path.status_code, HTTPStatus.OK)

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -6158,6 +6158,10 @@
                 "type": "object",
                 "description": "Serializer for the order payment",
                 "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
                     "amount": {
                         "type": "number",
                         "format": "double",
@@ -6182,6 +6186,7 @@
                     "amount",
                     "currency",
                     "due_date",
+                    "id",
                     "state"
                 ]
             },
@@ -6189,6 +6194,10 @@
                 "type": "object",
                 "description": "Serializer for the order payment",
                 "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
                     "amount": {
                         "type": "number",
                         "format": "double",
@@ -6207,6 +6216,7 @@
                 "required": [
                     "amount",
                     "due_date",
+                    "id",
                     "state"
                 ]
             },


### PR DESCRIPTION
## Purpose

We recently refactor installment to add an id. We want to add this field into the related serializer.
