### PR TITLE
✨(backend) submit installment payment when order is `no_payment` state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 ### Changed
 
 - Add `currency` field to `OrderPaymentSerializer` serializer
+- Allow an order with `no_payment` state to pay for failed installment
+  on a payment schedule
 
 ## [2.2.0] - 2024-05-22
 

--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -413,7 +413,11 @@ class OrderViewSet(
         """
         Submit a draft order if the conditions are filled
         """
-        billing_address = request.data.get("billing_address")
+        billing_address = (
+            models.Address(**request.data.get("billing_address"))
+            if request.data.get("billing_address")
+            else None
+        )
         credit_card_id = request.data.get("credit_card_id")
         order = self.get_object()
 
@@ -557,7 +561,10 @@ class OrderViewSet(
         Submit a payment for a failed installment that was scheduled for a given order.
         """
         order = self.get_object()
-        if order.state != enums.ORDER_STATE_FAILED_PAYMENT:
+        if order.state not in [
+            enums.ORDER_STATE_NO_PAYMENT,
+            enums.ORDER_STATE_FAILED_PAYMENT,
+        ]:
             return Response(
                 {"detail": "The order is not in failed payment state."},
                 status=HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/src/backend/joanie/payment/backends/lyra/__init__.py
+++ b/src/backend/joanie/payment/backends/lyra/__init__.py
@@ -87,12 +87,12 @@ class LyraBackend(BasePaymentBackend):
 
         if billing_address:
             payload["customer"]["billingDetails"] = {
-                "firstName": billing_address["first_name"],
-                "lastName": billing_address["last_name"],
-                "address": billing_address["address"],
-                "zipCode": billing_address["postcode"],
-                "city": billing_address["city"],
-                "country": billing_address["country"],
+                "firstName": billing_address.first_name,
+                "lastName": billing_address.last_name,
+                "address": billing_address.address,
+                "zipCode": billing_address.postcode,
+                "city": billing_address.city,
+                "country": billing_address.country.code,
                 "language": order.owner.language,
             }
 

--- a/src/backend/joanie/tests/core/api/order/test_submit_installment_payment.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_installment_payment.py
@@ -345,7 +345,7 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
         side_effect=DummyPaymentBackend().create_payment,
     )
     def test_api_order_submit_installment_payment_without_passing_credit_credit_card_id_in_payload(
-        self, mock_create_payment, _mock_create_one_click_payment
+        self, mock_create_payment, mock_create_one_click_payment
     ):
         """
         Authenticated user should be able to pay for a failed installment payment
@@ -405,9 +405,8 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertTrue(mock_create_payment.called)
         self.assertEqual(response.status_code, HTTPStatus.OK)
-        self.assertFalse(_mock_create_one_click_payment.called)
+        self.assertFalse(mock_create_one_click_payment.called)
 
     @mock.patch.object(
         DummyPaymentBackend,
@@ -420,7 +419,7 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
         side_effect=DummyPaymentBackend().create_one_click_payment,
     )
     def test_api_order_submit_installment_payment_with_credit_card_id_payload(
-        self, mock_create_one_click_payment, _mock_create_payment
+        self, mock_create_one_click_payment, mock_create_payment
     ):
         """
         Authenticated user should be able to pay for a failed installment
@@ -486,10 +485,9 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertTrue(mock_create_one_click_payment.called)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertTrue(response.json()["is_paid"])
-        self.assertFalse(_mock_create_payment.called)
+        self.assertFalse(mock_create_payment.called)
 
     def test_api_order_submit_installment_payment_but_no_installment_payment_refused_state_found(
         self,
@@ -616,7 +614,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertTrue(mock_create_one_click_payment.called)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertTrue(response.json()["is_paid"])
 
@@ -684,5 +681,4 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             },
         )
 
-        self.assertTrue(mock_create_payment.called)
         self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/src/backend/joanie/tests/payment/test_backend_lyra.py
+++ b/src/backend/joanie/tests/payment/test_backend_lyra.py
@@ -21,11 +21,16 @@ from joanie.core.enums import (
     PAYMENT_STATE_PAID,
     PAYMENT_STATE_PENDING,
 )
-from joanie.core.factories import OrderFactory, ProductFactory, UserFactory
+from joanie.core.factories import (
+    OrderFactory,
+    ProductFactory,
+    UserAddressFactory,
+    UserFactory,
+)
 from joanie.payment.backends.base import BasePaymentBackend
 from joanie.payment.backends.lyra import LyraBackend
 from joanie.payment.exceptions import ParseNotificationFailed, RegisterPaymentFailed
-from joanie.payment.factories import BillingAddressDictFactory, CreditCardFactory
+from joanie.payment.factories import CreditCardFactory
 from joanie.payment.models import CreditCard, Transaction
 from joanie.tests.base import BaseLogMixinTestCase
 from joanie.tests.payment.base_payment import BasePaymentTestCase
@@ -109,7 +114,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
         owner = UserFactory(email="john.doe@acme.org")
         product = ProductFactory(price=D("123.45"))
         order = OrderFactory(owner=owner, product=product)
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
 
         responses.add(
             responses.POST,
@@ -152,7 +157,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
         owner = UserFactory(email="john.doe@acme.org")
         product = ProductFactory(price=D("123.45"))
         order = OrderFactory(owner=owner, product=product)
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
 
         responses.add(
             responses.POST,
@@ -199,7 +204,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
         owner = UserFactory(email="john.doe@acme.org")
         product = ProductFactory(price=D("123.45"))
         order = OrderFactory(owner=owner, product=product)
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
 
         with self.open("lyra/responses/create_payment_failed.json") as file:
             json_response = json.loads(file.read())
@@ -225,12 +230,12 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                             "email": "john.doe@acme.org",
                             "reference": str(owner.id),
                             "billingDetails": {
-                                "firstName": billing_address["first_name"],
-                                "lastName": billing_address["last_name"],
-                                "address": billing_address["address"],
-                                "zipCode": billing_address["postcode"],
-                                "city": billing_address["city"],
-                                "country": billing_address["country"],
+                                "firstName": billing_address.first_name,
+                                "lastName": billing_address.last_name,
+                                "address": billing_address.address,
+                                "zipCode": billing_address.postcode,
+                                "city": billing_address.city,
+                                "country": billing_address.country.code,
                                 "language": owner.language,
                             },
                             "shippingDetails": {
@@ -285,7 +290,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
         owner = UserFactory(email="john.doe@acme.org")
         product = ProductFactory(price=D("123.45"))
         order = OrderFactory(owner=owner, product=product)
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
 
         with self.open("lyra/responses/create_payment.json") as file:
             json_response = json.loads(file.read())
@@ -311,12 +316,12 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                             "email": "john.doe@acme.org",
                             "reference": str(owner.id),
                             "billingDetails": {
-                                "firstName": billing_address["first_name"],
-                                "lastName": billing_address["last_name"],
-                                "address": billing_address["address"],
-                                "zipCode": billing_address["postcode"],
-                                "city": billing_address["city"],
-                                "country": billing_address["country"],
+                                "firstName": billing_address.first_name,
+                                "lastName": billing_address.last_name,
+                                "address": billing_address.address,
+                                "zipCode": billing_address.postcode,
+                                "city": billing_address.city,
+                                "country": billing_address.country.code,
                                 "language": owner.language,
                             },
                             "shippingDetails": {
@@ -385,7 +390,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                 },
             ],
         )
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
 
         with self.open("lyra/responses/create_payment.json") as file:
             json_response = json.loads(file.read())
@@ -411,12 +416,12 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                             "email": "john.doe@acme.org",
                             "reference": str(owner.id),
                             "billingDetails": {
-                                "firstName": billing_address["first_name"],
-                                "lastName": billing_address["last_name"],
-                                "address": billing_address["address"],
-                                "zipCode": billing_address["postcode"],
-                                "city": billing_address["city"],
-                                "country": billing_address["country"],
+                                "firstName": billing_address.first_name,
+                                "lastName": billing_address.last_name,
+                                "address": billing_address.address,
+                                "zipCode": billing_address.postcode,
+                                "city": billing_address.city,
+                                "country": billing_address.country.code,
                                 "language": owner.language,
                             },
                             "shippingDetails": {
@@ -461,7 +466,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
         owner = UserFactory(email="john.doe@acme.org")
         product = ProductFactory(price=D("123.45"))
         order = OrderFactory(owner=owner, product=product)
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
 
         with self.open("lyra/responses/tokenize_card.json") as file:
             json_response = json.loads(file.read())
@@ -486,12 +491,12 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                             "email": "john.doe@acme.org",
                             "reference": str(owner.id),
                             "billingDetails": {
-                                "firstName": billing_address["first_name"],
-                                "lastName": billing_address["last_name"],
-                                "address": billing_address["address"],
-                                "zipCode": billing_address["postcode"],
-                                "city": billing_address["city"],
-                                "country": billing_address["country"],
+                                "firstName": billing_address.first_name,
+                                "lastName": billing_address.last_name,
+                                "address": billing_address.address,
+                                "zipCode": billing_address.postcode,
+                                "city": billing_address.city,
+                                "country": billing_address.country.code,
                                 "language": owner.language,
                             },
                         },
@@ -529,7 +534,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
         owner = UserFactory(email="john.doe@acme.org")
         product = ProductFactory(price=D("123.45"))
         order = OrderFactory(owner=owner, product=product)
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
         credit_card = CreditCardFactory(
             owner=owner, token="854d630f17f54ee7bce03fb4fcf764e9"
         )
@@ -558,12 +563,12 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                             "email": "john.doe@acme.org",
                             "reference": str(owner.id),
                             "billingDetails": {
-                                "firstName": billing_address["first_name"],
-                                "lastName": billing_address["last_name"],
-                                "address": billing_address["address"],
-                                "zipCode": billing_address["postcode"],
-                                "city": billing_address["city"],
-                                "country": billing_address["country"],
+                                "firstName": billing_address.first_name,
+                                "lastName": billing_address.last_name,
+                                "address": billing_address.address,
+                                "zipCode": billing_address.postcode,
+                                "city": billing_address.city,
+                                "country": billing_address.country.code,
                                 "language": owner.language,
                             },
                             "shippingDetails": {
@@ -635,7 +640,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                 },
             ],
         )
-        billing_address = BillingAddressDictFactory()
+        billing_address = UserAddressFactory(owner=owner)
         credit_card = CreditCardFactory(
             owner=owner, token="854d630f17f54ee7bce03fb4fcf764e9"
         )
@@ -664,12 +669,12 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
                             "email": "john.doe@acme.org",
                             "reference": str(owner.id),
                             "billingDetails": {
-                                "firstName": billing_address["first_name"],
-                                "lastName": billing_address["last_name"],
-                                "address": billing_address["address"],
-                                "zipCode": billing_address["postcode"],
-                                "city": billing_address["city"],
-                                "country": billing_address["country"],
+                                "firstName": billing_address.first_name,
+                                "lastName": billing_address.last_name,
+                                "address": billing_address.address,
+                                "zipCode": billing_address.postcode,
+                                "city": billing_address.city,
+                                "country": billing_address.country.code,
                                 "language": owner.language,
                             },
                             "shippingDetails": {


### PR DESCRIPTION
## Purpose

Allow user to submit installment payment when the order's first installment has not been paid yet. Before the update, only orders with the state `failed_payment` were expected for the endpoint `submit_installment_payment` in the OrderViewSet, now we also allow the state `no_payment` of an order (where the first installment has failed to be paid in the payment schedule).

## Proposal
- [x] update the endpoint with the new accepted state to update a resolve a failed payment installment of an order for a user
- [x] add missing tests
