### PR TITLE
✨(backend) endpoint to tokenize a credit card with payment backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Allow to tokenize a card endpoint for a user
+
 ### Changed
 
 - Add `currency` field to `OrderPaymentSerializer` serializer

--- a/src/backend/joanie/payment/api.py
+++ b/src/backend/joanie/payment/api.py
@@ -8,7 +8,7 @@ from http import HTTPStatus
 from django.db import transaction
 
 from rest_framework import mixins, permissions, viewsets
-from rest_framework.decorators import api_view
+from rest_framework.decorators import action, api_view
 from rest_framework.response import Response
 
 from joanie.payment import exceptions, get_payment_backend, models, serializers
@@ -68,3 +68,18 @@ class CreditCardViewSet(
             else self.request.user.username
         )
         return models.CreditCard.objects.filter(owner__username=username)
+
+    @action(
+        methods=["POST"],
+        detail=False,
+        url_path="tokenize-card",
+    )
+    def tokenize_card(self, request):
+        """
+        Tokenize a credit card for a user with payment backend. It returns a form token
+        from the payment backend provider.
+        """
+        payment_backend = get_payment_backend()
+        payment_infos = payment_backend.tokenize_card(user=self.request.user)
+
+        return Response(payment_infos, status=HTTPStatus.OK)

--- a/src/backend/joanie/payment/backends/base.py
+++ b/src/backend/joanie/payment/backends/base.py
@@ -210,3 +210,11 @@ class BasePaymentBackend:
         raise NotImplementedError(
             "subclasses of BasePaymentBackend must provide a abort_payment() method."
         )
+
+    def tokenize_card(self, order=None, billing_address=None, user=None):
+        """
+        Method called to tokenize a credit card.
+        """
+        raise NotImplementedError(
+            "subclasses of BasePaymentBackend must provide a tokenize_card() method."
+        )

--- a/src/backend/joanie/tests/payment/test_api_credit_card.py
+++ b/src/backend/joanie/tests/payment/test_api_credit_card.py
@@ -392,3 +392,97 @@ class CreditCardAPITestCase(BaseAPITestCase):
         )
 
         self.assertEqual(response.status_code, HTTPStatus.NO_CONTENT)
+
+    def test_api_credit_card_tokenize_card_anonymous(self):
+        """
+        Anonymous user should not be able to tokenize a credit card
+        """
+        response = self.client.post("/api/v1.0/credit-cards/tokenize-card/")
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_api_credit_card_tokenize_card_get_method_not_allowed(self):
+        """
+        Authenticated user should not be able to GET method to tokenize his credit card
+        """
+        user = UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.get(
+            "/api/v1.0/credit-cards/tokenize-card/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_api_credit_card_tokenize_card_put_method_not_allowed(self):
+        """
+        Authenticated user should not be able to PUT method to update a tokenize credit card
+        """
+        user = UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.put(
+            "/api/v1.0/credit-cards/tokenize-card/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_api_credit_card_tokenize_card_patch_method_not_allowed(self):
+        """
+        Authenticated user should not be able to PATCH method to partially update tokenized
+        credit card
+        """
+        user = UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.patch(
+            "/api/v1.0/credit-cards/tokenize-card/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    def test_api_credit_card_tokenize_card_delete_method_not_allowed(self):
+        """
+        Authenticated user should not be able to DELETE method to tokenize his credit card
+        """
+        user = UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.delete(
+            "/api/v1.0/credit-cards/tokenize-card/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
+
+    @override_settings(
+        JOANIE_PAYMENT_BACKEND={
+            "backend": "joanie.payment.backends.dummy.DummyPaymentBackend",
+            "configuration": None,
+        }
+    )
+    def test_api_credit_card_tokenize_card(self):
+        """
+        Authenticated user should be able to tokenize a credit card.
+        """
+        user = UserFactory()
+        token = self.get_user_token(user.username)
+
+        response = self.client.post(
+            "/api/v1.0/credit-cards/tokenize-card/",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(
+            response.json(),
+            {
+                "provider": "dummy",
+                "type": "tokenize_card",
+                "customer": str(user.id),
+                "card_token": f"card_{user.id}",
+            },
+        )

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -54,6 +54,9 @@ class TestBasePaymentBackend(BasePaymentBackend):
     def handle_notification(self, request):
         pass
 
+    def tokenize_card(self, order=None, billing_address=None, user=None):
+        pass
+
 
 @override_settings(JOANIE_CATALOG_NAME="Test Catalog")
 @override_settings(JOANIE_CATALOG_BASE_URL="https://richie.education")
@@ -145,6 +148,18 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
         self.assertEqual(
             str(context.exception),
             "subclasses of BasePaymentBackend must provide a abort_payment() method.",
+        )
+
+    def test_payment_backend_base_tokenize_card_not_implemented(self):
+        """Invoke tokenize card should raise a Not ImplementedError"""
+        backend = BasePaymentBackend()
+
+        with self.assertRaises(NotImplementedError) as context:
+            backend.tokenize_card(None)
+
+        self.assertEqual(
+            str(context.exception),
+            "subclasses of BasePaymentBackend must provide a tokenize_card() method.",
         )
 
     def test_payment_backend_base_do_on_payment_success(self):

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -2380,6 +2380,46 @@
                 }
             }
         },
+        "/api/v1.0/credit-cards/tokenize-card/": {
+            "post": {
+                "operationId": "credit_cards_tokenize_card_create",
+                "description": "Tokenize a credit card for a user with payment backend. It returns a form token\nfrom the payment backend provider.",
+                "tags": [
+                    "credit-cards"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreditCardRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreditCardRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "DelegatedJWTAuthentication": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreditCard"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/enrollments/": {
             "get": {
                 "operationId": "enrollments_list",


### PR DESCRIPTION
## Purpose

A user should be allowed to add new credit card by tokenizing his credit card through the payment backend. It allows the user to have multiple credit cards to manage his purchases.

## Proposal
- [x] add new endpoint in CreditCardViewSet to tokenize a credit card.
- [x] add `tokenize_card` method into the dummy payment backend.
- [x] update dummy method `handle_notification` to save the credit card that has been tokenized
- [x] add `tokenize_card` method into the base payment backend.
- [x] add test suite
- [x] complete order tests classes (dummy payment backup, base payment backup)
