### PR TITLE
🧑‍💻(backend) complete no payment order

### DIFF
--- a/src/backend/joanie/core/flows/order.py
+++ b/src/backend/joanie/core/flows/order.py
@@ -151,7 +151,11 @@ class OrderFlow:
         )
 
     @state.transition(
-        source=[enums.ORDER_STATE_PENDING, enums.ORDER_STATE_PENDING_PAYMENT],
+        source=[
+            enums.ORDER_STATE_PENDING_PAYMENT,
+            enums.ORDER_STATE_FAILED_PAYMENT,
+            enums.ORDER_STATE_PENDING,
+        ],
         target=enums.ORDER_STATE_COMPLETED,
         conditions=[_can_be_state_completed],
     )
@@ -161,7 +165,12 @@ class OrderFlow:
         """
 
     @state.transition(
-        source=[enums.ORDER_STATE_PENDING, enums.ORDER_STATE_PENDING_PAYMENT],
+        source=[
+            enums.ORDER_STATE_PENDING_PAYMENT,
+            enums.ORDER_STATE_FAILED_PAYMENT,
+            enums.ORDER_STATE_NO_PAYMENT,
+            enums.ORDER_STATE_PENDING,
+        ],
         target=enums.ORDER_STATE_PENDING_PAYMENT,
         conditions=[_can_be_state_pending_payment],
     )

--- a/src/backend/joanie/demo/management/commands/create_dev_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_dev_demo.py
@@ -253,6 +253,10 @@ class Command(BaseCommand):
             student_signed_on=django_timezone.now(),
         )
 
+        payment_factories.InvoiceFactory(
+            order=order, recipient_address__owner=order.owner, total=order.total
+        )
+
         order.generate_schedule()
         installment = order.payment_schedule[0]
         order.set_installment_refused(installment["id"])

--- a/src/backend/joanie/tests/core/test_flows_order.py
+++ b/src/backend/joanie/tests/core/test_flows_order.py
@@ -788,6 +788,41 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
 
         self.assertEqual(order.state, enums.ORDER_STATE_COMPLETED)
 
+    def test_flows_order_failed_payment_to_complete(self):
+        """
+        Test that the complete transition sets complete state
+        when all installments are paid and source state is "failed payment".
+        """
+        order = factories.OrderFactory(
+            state=enums.ORDER_STATE_FAILED_PAYMENT,
+            payment_schedule=[
+                {
+                    "amount": "200.00",
+                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PAID,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PAID,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PAID,
+                },
+                {
+                    "amount": "199.99",
+                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PAID,
+                },
+            ],
+        )
+
+        order.flow.complete()
+
+        self.assertEqual(order.state, enums.ORDER_STATE_COMPLETED)
+
     def test_flows_order_complete_first_paid(self):
         """
         Test that the complete transition sets pending_payment state
@@ -927,3 +962,73 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
         order.flow.failed_payment()
 
         self.assertEqual(order.state, enums.ORDER_STATE_FAILED_PAYMENT)
+
+    def test_flows_order_no_payment_to_pending_payment(self):
+        """
+        Test that the pending payment transition sets pending payment state
+        when the first installment is paid and source state is "no payment".
+        """
+        order = factories.OrderFactory(
+            state=enums.ORDER_STATE_NO_PAYMENT,
+            payment_schedule=[
+                {
+                    "amount": "200.00",
+                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PAID,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+                {
+                    "amount": "199.99",
+                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        order.flow.pending_payment()
+
+        self.assertEqual(order.state, enums.ORDER_STATE_PENDING_PAYMENT)
+
+    def test_flows_order_failed_payment_to_pending_payment(self):
+        """
+        Test that the pending payment transition sets pending payment state
+        when an installment is paid and source state is "failed payment".
+        """
+        order = factories.OrderFactory(
+            state=enums.ORDER_STATE_FAILED_PAYMENT,
+            payment_schedule=[
+                {
+                    "amount": "200.00",
+                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PAID,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PAID,
+                },
+                {
+                    "amount": "300.00",
+                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+                {
+                    "amount": "199.99",
+                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        order.flow.pending_payment()
+
+        self.assertEqual(order.state, enums.ORDER_STATE_PENDING_PAYMENT)


### PR DESCRIPTION
## Purpose

Some state source were missing for `complete` and `pending_payment` transition. We fix that.
Furthermore, we recently create a failed installment payment order but we forgot to link an invoice to this order, so it leads to issues when trying to use this order for development.


## Proposal

Description...

- [x] Update order flow to add missing source transition
- [x] Update demo_dev script to work as expected
