### PR TITLE
🩹(backend) check billing address before order assign

### DIFF
--- a/src/backend/joanie/tests/core/api/organizations/test_contracts_signature_link.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_contracts_signature_link.py
@@ -226,10 +226,12 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
         relation = factories.CourseProductRelationFactory(
             organizations=[organization, other_organization],
             product__contract_definition=factories.ContractDefinitionFactory(),
+            product__price=0,
         )
         relation_2 = factories.CourseProductRelationFactory(
             organizations=[organization],
             product__contract_definition=factories.ContractDefinitionFactory(),
+            product__price=0,
         )
         access = factories.UserOrganizationAccessFactory(
             organization=organization, role="owner"
@@ -329,6 +331,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
             2,
             organizations=[organization],
             product__contract_definition=factories.ContractDefinitionFactory(),
+            product__price=0,
         )
         access = factories.UserOrganizationAccessFactory(
             organization=organization, role="owner"

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -1362,6 +1362,7 @@ class ContractApiTest(BaseAPITestCase):
         # Create our Course Product Relation shared by the 2 organizations above
         relation = factories.CourseProductRelationFactory(
             product__contract_definition=factories.ContractDefinitionFactory(),
+            product__price=0,
             organizations=[organizations[0], organizations[1]],
         )
         # Create learners who sign the contract definition
@@ -1452,6 +1453,7 @@ class ContractApiTest(BaseAPITestCase):
         )
         relation = factories.CourseProductRelationFactory(
             product__contract_definition=factories.ContractDefinitionFactory(),
+            product__price=0,
             organizations=[organization],
         )
         learners = factories.UserFactory.create_batch(3)

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -483,7 +483,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
         CreditCardFactory(
             owner=order.owner, is_main=True, initial_issuer_transaction_identifier="1"
         )
-        order.flow.assign()
+        order.flow.assign(billing_address=BillingAddressDictFactory())
 
         backend.call_do_on_payment_failure(
             order, installment_id=order.payment_schedule[0]["id"]


### PR DESCRIPTION


## Purpose

Order assign transition needs a billing address when creating the main invoice. If not present, the transition should fail.


## Proposal

Add a check, and raise TransitionNotAllowed if failed.