### PR TITLE
✨(backend) add state field to NestedOrderSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Allow to tokenize a card endpoint for a user
+- Add `state` field to NestedOrderSerializer
 
 ### Changed
 

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -380,6 +380,7 @@ class NestedOrderSerializer(serializers.ModelSerializer):
             "organization",
             "owner_name",
             "product_title",
+            "state",
         ]
         read_only_fields = fields
 

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_contract.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_contract.py
@@ -155,6 +155,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
                     },
                     "order": {
                         "id": str(contract.order.id),
+                        "state": contract.order.state,
                         "course": {
                             "code": contract.order.course.code,
                             "cover": "_this_field_is_mocked",
@@ -541,6 +542,7 @@ class OrganizationContractApiTest(BaseAPITestCase):
             },
             "order": {
                 "id": str(contract.order.id),
+                "state": contract.order.state,
                 "course": {
                     "code": contract.order.course.code,
                     "cover": "_this_field_is_mocked",

--- a/src/backend/joanie/tests/core/test_api_certificate.py
+++ b/src/backend/joanie/tests/core/test_api_certificate.py
@@ -100,6 +100,7 @@ class CertificateApiTest(BaseAPITestCase):
                         "enrollment": None,
                         "order": {
                             "id": str(other_order.id),
+                            "state": other_order.state,
                             "course": None,
                             "enrollment": {
                                 "course_run": {
@@ -177,6 +178,7 @@ class CertificateApiTest(BaseAPITestCase):
                         "enrollment": None,
                         "order": {
                             "id": str(order.id),
+                            "state": order.state,
                             "course": {
                                 "id": str(order.course.id),
                                 "code": order.course.code,
@@ -275,6 +277,7 @@ class CertificateApiTest(BaseAPITestCase):
                         "enrollment": None,
                         "order": {
                             "id": str(other_order.id),
+                            "state": other_order.state,
                             "course": None,
                             "enrollment": {
                                 "course_run": {
@@ -352,6 +355,7 @@ class CertificateApiTest(BaseAPITestCase):
                         "enrollment": None,
                         "order": {
                             "id": str(order.id),
+                            "state": order.state,
                             "course": {
                                 "id": str(order.course.id),
                                 "code": order.course.code,
@@ -757,6 +761,7 @@ class CertificateApiTest(BaseAPITestCase):
                 "enrollment": None,
                 "order": {
                     "id": str(certificate.order.id),
+                    "state": certificate.order.state,
                     "course": {
                         "id": str(certificate.order.course.id),
                         "code": certificate.order.course.code,

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -144,6 +144,7 @@ class ContractApiTest(BaseAPITestCase):
                     },
                     "order": {
                         "id": str(contract.order.id),
+                        "state": contract.order.state,
                         "course": {
                             "code": contract.order.course.code,
                             "cover": "_this_field_is_mocked",
@@ -719,7 +720,9 @@ class ContractApiTest(BaseAPITestCase):
         token = self.generate_token_from_user(user)
         organization_signatory = factories.UserFactory()
         contract = factories.ContractFactory(
-            order__owner=user, organization_signatory=organization_signatory
+            order__owner=user,
+            organization_signatory=organization_signatory,
+            order__state=enums.ORDER_STATE_VALIDATED,
         )
 
         with self.assertNumQueries(7):
@@ -769,6 +772,7 @@ class ContractApiTest(BaseAPITestCase):
             },
             "order": {
                 "id": str(contract.order.id),
+                "state": enums.ORDER_STATE_VALIDATED,
                 "course": {
                     "code": contract.order.course.code,
                     "cover": "_this_field_is_mocked",

--- a/src/backend/joanie/tests/core/test_api_courses_contract.py
+++ b/src/backend/joanie/tests/core/test_api_courses_contract.py
@@ -152,6 +152,7 @@ class CourseContractApiTest(BaseAPITestCase):
                     },
                     "order": {
                         "id": str(contract.order.id),
+                        "state": contract.order.state,
                         "course": {
                             "code": contract.order.course.code,
                             "cover": "_this_field_is_mocked",
@@ -520,6 +521,7 @@ class CourseContractApiTest(BaseAPITestCase):
             },
             "order": {
                 "id": str(contract.order.id),
+                "state": contract.order.state,
                 "course": {
                     "code": contract.order.course.code,
                     "cover": "_this_field_is_mocked",

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -5930,6 +5930,14 @@
                     "product_title": {
                         "type": "string",
                         "readOnly": true
+                    },
+                    "state": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OrderStateEnum"
+                            }
+                        ],
+                        "readOnly": true
                     }
                 },
                 "required": [
@@ -5938,7 +5946,8 @@
                     "id",
                     "organization",
                     "owner_name",
-                    "product_title"
+                    "product_title",
+                    "state"
                 ]
             },
             "NestedOrderCourse": {


### PR DESCRIPTION
## Purpose

Frontend consumer needs to use state order field no matter the order is nested within another resource or not.
