### PR TITLE
🐛(backend) certificate template do not render <img> tag if organization has no logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 
 ### Changed
 
+- Update certificate template to render logo of organization if
+  it has a value.
 - Add `currency` field to `OrderPaymentSerializer` serializer
 - Allow an order with `no_payment` state to pay for failed installment
   on a payment schedule
@@ -25,7 +27,7 @@ and this project adheres to
 - Ensure when API requests fails with payment provider, it raises
   an error for `create_payment`, `create_one_click_payment` and
   `create_zero_click_payment`
-- Improve error management of `set_enrollment` method of 
+- Improve error management of `set_enrollment` method of
   MoodleBackend.
 - Bind properly organizations in a certificate template sentence
 

--- a/src/backend/joanie/core/models/certifications.py
+++ b/src/backend/joanie/core/models/certifications.py
@@ -273,6 +273,10 @@ class Certificate(BaseModel):
             if logo_id:
                 if logo := self.images.filter(pk=logo_id).first():
                     logo_file = image_to_base64(logo.file)
+            else:
+                logger.error(
+                    "Organization %s does not have a logo.", self.organization.id
+                )
 
             organization["signature"] = signature_file
             organization["logo"] = logo_file

--- a/src/backend/joanie/core/templates/issuers/certificate.html
+++ b/src/backend/joanie/core/templates/issuers/certificate.html
@@ -17,7 +17,9 @@
                 <img src="{% base64_static "joanie/images/logo_fun.png" %}" />
                 <div class="header__logos-organizations">
                     {% for organization in organizations %}
-                        <img src="{{ organization.logo }}" />
+                        {% if organization.logo %}
+                            <img src="{{ organization.logo }}" />
+                        {% endif %}
                     {% endfor %}
                 </div>
             </div>

--- a/src/backend/joanie/core/templates/issuers/degree.html
+++ b/src/backend/joanie/core/templates/issuers/degree.html
@@ -47,7 +47,9 @@ which is the course provider. So the organization is accessed with organizations
         <div class="signatories__column">
             <div class="signatories__column-content organization">
                 <h2 class="organization__name">{{ organizations.0.name }}</h2>
-                <img class="organization__logo" src="{{ organizations.0.logo }}" />
+                {% if organizations.0.logo %}
+                    <img class="organization__logo" src="{{ organizations.0.logo }}" />
+                {% endif %}
                 <img class="organization__signature" src="{{ organizations.0.signature }}" />
                 <p class="organization__signatory">
                     <em>{{ organizations.0.representative|default:"" }}</em>


### PR DESCRIPTION
## Purpose
When the `organization.logo` is `None`, a `<img>` tag is rendered  `None` actually. We do not want this anymore. We should trigger a message when generating the certificate's context if an organization does not have a logo for itself.

## Proposal

- [x] Update the certificate and degree HTML templates with a condition to verify if `organization.logo` has a value and add a `logger.error` in the `get_document_context` of a certificate if organization logo is `None`.
