### PR TITLE
🐛(backend) moodle user creation must raise EnrollmentError exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 - Ensure when API requests fails with payment provider, it raises
   an error for `create_payment`, `create_one_click_payment` and
   `create_zero_click_payment`
+- Improve error management of `set_enrollment` method of 
+  MoodleBackend.
 
 ## [2.2.0] - 2024-05-22
 

--- a/src/backend/joanie/lms_handler/backends/moodle.py
+++ b/src/backend/joanie/lms_handler/backends/moodle.py
@@ -135,6 +135,8 @@ class MoodleLMSBackend(BaseLMSBackend):
             logger.error("Moodle error while creating user %s: %s", user.username, e)
             raise MoodleUserCreateException() from e
 
+    # pylint: disable=too-many-branches
+    # ruff: noqa: PLR0912
     def set_enrollment(self, enrollment):
         """Activate/deactivate an enrollment."""
         try:
@@ -143,12 +145,18 @@ class MoodleLMSBackend(BaseLMSBackend):
             logger.error("Moodle error while retrieving student role: %s", e)
             raise EnrollmentError() from e
 
+        user_id = None
         try:
             user_id = self.get_user_id(enrollment.user.username)
         except MoodleUserException as e:
             if not enrollment.is_active:
                 raise EnrollmentError() from e
-            user_created = self.create_user(enrollment.user)
+
+        if user_id is None:
+            try:
+                user_created = self.create_user(enrollment.user)
+            except MoodleUserCreateException as e:
+                raise EnrollmentError() from e
             user_id = user_created.get("id")
 
         course_id = self.extract_course_id(enrollment.course_run.resource_link)

--- a/src/backend/joanie/tests/core/test_flows_order.py
+++ b/src/backend/joanie/tests/core/test_flows_order.py
@@ -352,6 +352,131 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             }
         ]
     )
+    def test_flows_order_validate_auto_enroll(self):
+        """
+        When an order is validated, if one target course contains only one course run
+        and this one is opened for enrollment, the user should be automatically enrolled
+        """
+        course = factories.CourseFactory()
+        resource_link = (
+            "http://openedx.test/courses/course-v1:edx+000001+Demo_Course/course"
+        )
+        factories.CourseRunFactory(
+            course=course,
+            resource_link=resource_link,
+            state=CourseState.ONGOING_OPEN,
+            is_listed=False,
+        )
+        product = factories.ProductFactory(target_courses=[course], price="0.00")
+
+        url = "http://openedx.test/api/enrollment/v1/enrollment"
+        responses.add(
+            responses.POST,
+            url,
+            status=HTTPStatus.OK,
+            json={"is_active": True},
+        )
+
+        # Create an order
+        order = factories.OrderFactory(product=product)
+        order.submit()
+
+        self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, url)
+        self.assertEqual(
+            responses.calls[0].request.headers["X-Edx-Api-Key"], "a_secure_api_token"
+        )
+        enrollment = Enrollment.objects.get(
+            user=order.owner, course_run__resource_link=resource_link
+        )
+        self.assertEqual(enrollment.state, "set")
+        self.assertEqual(
+            json.loads(responses.calls[0].request.body),
+            {
+                "is_active": enrollment.is_active,
+                "mode": "verified",
+                "user": enrollment.user.username,
+                "course_details": {"course_id": "course-v1:edx+000001+Demo_Course"},
+            },
+        )
+
+    @responses.activate
+    @override_settings(
+        JOANIE_LMS_BACKENDS=[
+            {
+                "API_TOKEN": "a_secure_api_token",
+                "BACKEND": "joanie.lms_handler.backends.openedx.OpenEdXLMSBackend",
+                "BASE_URL": "http://openedx.test",
+                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
+                "SELECTOR_REGEX": r".*",
+            }
+        ]
+    )
+    def test_flows_order_validate_auto_enroll_failure(self):
+        """
+        When an order is validated, if one target course contains only one course run
+        and this one is opened for enrollment, the user should be automatically enrolled
+        If the enrollment request fails, the order should be validated.
+        """
+        course = factories.CourseFactory()
+        resource_link = (
+            "http://openedx.test/courses/course-v1:edx+000001+Demo_Course/course"
+        )
+        factories.CourseRunFactory(
+            course=course,
+            resource_link=resource_link,
+            state=CourseState.ONGOING_OPEN,
+            is_listed=False,
+        )
+        product = factories.ProductFactory(target_courses=[course], price="0.00")
+
+        url = "http://openedx.test/api/enrollment/v1/enrollment"
+        responses.add(
+            responses.POST,
+            url,
+            status=HTTPStatus.BAD_REQUEST,
+            json=None,
+        )
+
+        # Create an order
+        order = factories.OrderFactory(product=product)
+        order.submit()
+
+        self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, url)
+        self.assertEqual(
+            responses.calls[0].request.headers["X-Edx-Api-Key"], "a_secure_api_token"
+        )
+        enrollment = Enrollment.objects.get(
+            user=order.owner, course_run__resource_link=resource_link
+        )
+        self.assertEqual(enrollment.state, "failed")
+        self.assertEqual(
+            json.loads(responses.calls[0].request.body),
+            {
+                "is_active": enrollment.is_active,
+                "mode": "verified",
+                "user": enrollment.user.username,
+                "course_details": {"course_id": "course-v1:edx+000001+Demo_Course"},
+            },
+        )
+
+    @responses.activate
+    @override_settings(
+        JOANIE_LMS_BACKENDS=[
+            {
+                "API_TOKEN": "a_secure_api_token",
+                "BACKEND": "joanie.lms_handler.backends.openedx.OpenEdXLMSBackend",
+                "BASE_URL": "http://openedx.test",
+                "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
+                "SELECTOR_REGEX": r".*",
+            }
+        ]
+    )
     def test_flows_order_validate_preexisting_enrollments_targeted(self):
         """
         When an order is validated, if the user was previously enrolled for free in any of the
@@ -522,6 +647,95 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
         self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
 
         self.assertEqual(len(responses.calls), 6)
+
+    @responses.activate
+    @override_settings(
+        JOANIE_LMS_BACKENDS=[
+            {
+                "API_TOKEN": "a_secure_api_token",
+                "BACKEND": "joanie.lms_handler.backends.moodle.MoodleLMSBackend",
+                "BASE_URL": "http://moodle.test/webservice/rest/server.php",
+                "COURSE_REGEX": r"^.*/course/view.php\?id=.*$",
+                "SELECTOR_REGEX": r"^.*/course/view.php\?id=.*$",
+            }
+        ]
+    )
+    def test_flows_order_validate_auto_enroll_moodle_failure(self):
+        """
+        When an order is validated, if one target course contains only one course run
+        and this one is opened for enrollment, the user should be automatically enrolled
+        If the enrollment request fails, the order should be validated.
+        """
+        course = factories.CourseFactory()
+        resource_link = "http://moodle.test/course/view.php?id=2"
+        factories.CourseRunFactory(
+            course=course,
+            resource_link=resource_link,
+            state=CourseState.ONGOING_OPEN,
+            is_listed=False,
+        )
+        product = factories.ProductFactory(target_courses=[course], price="0.00")
+        backend = LMSHandler.select_lms(resource_link)
+
+        responses.add(
+            responses.POST,
+            backend.build_url("local_wsgetroles_get_roles"),
+            status=HTTPStatus.OK,
+            json=[
+                {
+                    "id": 5,
+                    "name": "",
+                    "shortname": "student",
+                    "description": "",
+                    "sortorder": 5,
+                    "archetype": "student",
+                },
+            ],
+        )
+
+        responses.add(
+            responses.POST,
+            backend.build_url("core_user_get_users"),
+            match=[
+                responses.matchers.urlencoded_params_matcher(
+                    {
+                        "criteria[0][key]": "username",
+                        "criteria[0][value]": "student",
+                    }
+                )
+            ],
+            status=HTTPStatus.NOT_FOUND,
+        )
+
+        responses.add(
+            responses.POST,
+            backend.build_url("core_user_create_user"),
+            status=HTTPStatus.BAD_REQUEST,
+        )
+
+        responses.add(
+            responses.POST,
+            backend.build_url("enrol_manual_enrol_users"),
+            match=[
+                responses.matchers.urlencoded_params_matcher(
+                    {
+                        "enrolments[0][courseid]": "2",
+                        "enrolments[0][userid]": "5",
+                        "enrolments[0][roleid]": "5",
+                    }
+                )
+            ],
+            status=HTTPStatus.OK,
+        )
+
+        # - Submit the order to trigger the validation as it is free
+        order = factories.OrderFactory(product=product)
+        order.submit()
+
+        order.refresh_from_db()
+        self.assertEqual(order.state, enums.ORDER_STATE_VALIDATED)
+
+        self.assertEqual(len(responses.calls), 3)
 
     def test_flows_order_cancel_success(self):
         """Test that the cancel transition is successful from any state"""


### PR DESCRIPTION
## Purpose

Currently, in MoodleBackend,  if during a `set_enrollment`, a user must be created and this task failed, a MoodleUserCreateException is raised. This exception is not caught by the method `set` of the Enrollment model and it should not be manage as this is too specific exception. But currently, if this error is raised when we try to auto enroll a user during an order validation, the order validation can be rollback. That's why we have to
 improve this error management and raise an EnrollmentError instead.

https://gip-fun-mooc.sentry.io/issues/5141416829/?environment=preproduction&project=6599941&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D&statsPeriod=90d&stream_index=7&utc=true
