### PR TITLE
Dev /fix lint todo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,14 +161,14 @@ jobs:
       - when:
           condition:
             not:
-                matches: { pattern: "^develop.+$", value: << pipeline.git.branch >> }
+                matches: { pattern: "^dev_/.+$", value: << pipeline.git.branch >> }
           steps:
             - run:
                 name: Lint code with pylint
                 command: ~/.local/bin/pylint joanie
       - when:
           condition:
-            matches: { pattern: "^develop.+$", value: << pipeline.git.branch >> }
+            matches: { pattern: "^dev_/.+$", value: << pipeline.git.branch >> }
           steps:
             - run:
                 name: Lint code with pylint, ignoring TODOs


### PR DESCRIPTION
## Purpose

The pylint CI job dedicated for the development branch is not running.


## Proposal

Update the branch pattern to allow todos in pylint.
