### PR TITLE
🐛(backend) fix certificate template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to
   `create_zero_click_payment`
 - Improve error management of `set_enrollment` method of 
   MoodleBackend.
+- Bind properly organizations in a certificate template sentence
 
 ## [2.2.0] - 2024-05-22
 

--- a/src/backend/joanie/core/templates/issuers/certificate.html
+++ b/src/backend/joanie/core/templates/issuers/certificate.html
@@ -51,9 +51,9 @@
                 <p><sup>*</sup>{% translate "MOOC: Massive Open Online Course" %}</p>
                 <p>
                     <strong>
-                    {% blocktranslate trimmed with organization=organization.name %}
+                    {% blocktranslate trimmed with organizations=organizations|list_key:'name'|join_and %}
                     The current document is not a degree or diploma and does not award credits (ECTS).
-                    <br />It does not certify that the learner was registered with {{ organization }}.
+                    <br />It does not certify that the learner was registered with {{ organizations }}.
                     <br />The learner's identity has not been verified.
                     {% endblocktranslate %}
                     </strong>


### PR DESCRIPTION
## Purpose

In a sentence, organization was not bound properly.

<img width="540" alt="Capture d’écran 2024-06-11 à 16 31 03" src="https://github.com/openfun/joanie/assets/9265241/8610291f-0f58-4e3e-9c79-28a3b0770f90">
