### PR TITLE
✨(backend) allow to configure how the withdrawal data is computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add settings configuration for the contract's country calendar to
+  manage the payment schedule and the withdrawal period in days
+
 ## [2.3.0] - 2024-06-18
 
 ### Added

--- a/src/backend/joanie/core/utils/payment_schedule.py
+++ b/src/backend/joanie/core/utils/payment_schedule.py
@@ -10,9 +10,9 @@ from django.conf import settings
 
 from dateutil.relativedelta import relativedelta
 from stockholm import Money, Number
-from workalendar.europe import France
 
 from joanie.core import enums
+from joanie.payment import get_country_calendar
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +47,10 @@ def _withdrawal_limit_date(signed_contract_date, course_start_date):
     The two first rules can be simplified with adding 16 days to the start date.
     So, the withdrawal limit date is the start date + 16 days.
     """
-    calendar = France()
-    withdrawal_date = signed_contract_date + timedelta(days=16)
+    calendar = get_country_calendar()
+    withdrawal_date = signed_contract_date + timedelta(
+        days=settings.JOANIE_WITHDRAWAL_PERIOD_DAYS
+    )
     if not calendar.is_working_day(withdrawal_date):
         return calendar.add_working_days(withdrawal_date, 1, keep_datetime=True)
     return (

--- a/src/backend/joanie/payment/__init__.py
+++ b/src/backend/joanie/payment/__init__.py
@@ -1,6 +1,7 @@
 """Payment"""
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
 
@@ -15,4 +16,19 @@ def get_payment_backend():
             "Cannot instantiate a payment backend. "
             "JOANIE_PAYMENT_BACKEND configuration seems not valid. "
             "Check your settings.py."
+        ) from error
+
+
+def get_country_calendar():
+    """
+    Instantiate the contract's calendar through `JOANIE_CONTRACT_COUNTRY_CALENDAR` setting.
+    """
+    try:
+        calendar_path = settings.JOANIE_CALENDAR
+        return import_string(calendar_path)()
+    except (AttributeError, ImportError) as error:
+        raise ImproperlyConfigured(
+            "Cannot instantiate a calendar. "
+            f'`JOANIE_CONTRACT_COUNTRY_CALENDAR="{calendar_path}"` configuration seems not valid. '
+            "Check your settings.py"
         ) from error

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -424,6 +424,19 @@ class Base(Configuration):
         environ_name="JOANIE_PAYMENT_SCHEDULE_LIMITS",
         environ_prefix=None,
     )
+    # The full list of countries available for use:
+    # https://github.com/workalendar/workalendar#available-calendars
+    JOANIE_CALENDAR = values.Value(
+        "workalendar.europe.France",
+        environ_name="JOANIE_CALENDAR",
+        environ_prefix=None,
+    )
+    # Number of days for the withdrawal period as required by your country's contract legislation
+    JOANIE_WITHDRAWAL_PERIOD_DAYS = values.PositiveIntegerValue(
+        16,
+        environ_name="JOANIE_WITHDRAWAL_PERIOD_DAYS",
+        environ_prefix=None,
+    )
 
     # CORS
 

--- a/src/backend/joanie/tests/payment/test_get_country_calendar.py
+++ b/src/backend/joanie/tests/payment/test_get_country_calendar.py
@@ -1,0 +1,65 @@
+"""get_country_calendar() test suite"""
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from workalendar.europe import France
+
+from joanie.payment import get_country_calendar
+
+
+class GetCountryCalendarTestSuite(TestCase):
+    """Test suite for the get_country_calendar method"""
+
+    @override_settings(
+        JOANIE_CALENDAR=None,
+    )
+    def test_get_country_calendar_when_setting_variable_is_misconfigured(self):
+        """
+        When `JOANIE_CONTRACT_COUNTRY_CALENDAR` is set with None in the settings,
+        it raise a `ImproperlyConfigured` mentioning the issue.
+        """
+        with self.assertRaises(ImproperlyConfigured) as context:
+            get_country_calendar()
+
+        self.assertEqual(
+            str(context.exception),
+            "Cannot instantiate a calendar. "
+            '`JOANIE_CONTRACT_COUNTRY_CALENDAR="None"` configuration seems not valid. '
+            "Check your settings.py",
+        )
+
+    @override_settings(
+        JOANIE_CALENDAR="workalendar.europe.Tothemoon",
+    )
+    def test_get_country_calendar_with_an_error_in_the_path_when_selecting_the_calendar(
+        self,
+    ):
+        """
+        When `JOANIE_CONTRACT_COUNTRY_CALENDAR` is misconfigured with a path
+        that does not exist within the library's list of available calendars,
+        it should raise a `ImproperlyConfigured` error.
+        """
+        with self.assertRaises(ImproperlyConfigured) as context:
+            get_country_calendar()
+
+        self.assertEqual(
+            str(context.exception),
+            "Cannot instantiate a calendar. "
+            '`JOANIE_CONTRACT_COUNTRY_CALENDAR="workalendar.europe.Tothemoon"` '
+            "configuration seems not valid. Check your settings.py",
+        )
+
+    @override_settings(
+        JOANIE_CALENDAR="workalendar.europe.France",
+    )
+    def test_get_country_calendar_get_instantiate_object(self):
+        """
+        When `JOANIE_CONTRACT_COUNTRY_CALENDAR` is well configured,
+        the country calendar should appear and should be the one for France for this test.
+        """
+        calendar = get_country_calendar()
+
+        self.assertIsInstance(calendar, France)
+        self.assertEqual(calendar.name, "France")


### PR DESCRIPTION
This PR will solve the [issue](https://github.com/openfun/joanie/issues/789) 

## Purpose

We have added two new settings to be able to choose the **calendar country** depending on where the application is used geographically. The setting variable is called : `JOANIE_CONTRACT_COUNTRY_CALENDAR`. To get the instance of calendar set in settings, it can be retrieved by using the method : `get_country_calendar()`

The other setting allows (`JOANIE_CONTRACT_COUNTRY_CALENDAR`) to set the period of days a consumer has the right to withdraw from a contract. 

The calendar was set to **France** and the **withdrawal period of days** (16 days for French context) was **hard coded** into the method : 
```python
def _withdrawal_limit_date(signed_contract_date, course_start_date):
...
```

## Proposal

Give more flexibility to set different values for the chosen **calendar** and the **period of days for withdrawal** when signing a contract (which may change depending the country's regulation).

```python
    # settings.py
    
    # The full list of countries available for use:
    # https://github.com/workalendar/workalendar#available-calendars
    JOANIE_CONTRACT_COUNTRY_CALENDAR = values.Value(
        "workalendar.europe.France",
        environ_name="JOANIE_CONTRACT_COUNTRY_CALENDAR",
        environ_prefix=None,
    )
    # Number of days for the withdrawal period as required by your country's contract legislation
    JOANIE_CONTRACT_COUNTRY_CALENDAR = values.PositiveIntegerValue(
        16,
        environ_name="JOANIE_CONTRACT_WITHDRAWAL_PERIOD_DAYS",
        environ_prefix=None,
    )
```

- [x] add 2 setting variables to configure calendar to use and period of withdrawal and add a method to get the an instantiated calendar object through the method `get_country_calendar()`.
