### PR TITLE
✨(backend) catch up on late payment schedule event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Update the task `process_today_installment` to catch up on late
+  payments of installments that are in the past
+
 ## [2.5.1] - 2024-06-25
 
 ### Fixed
@@ -24,7 +29,6 @@ and this project adheres to
 
 - Do not update OpenEdX enrollment if this one is already
   up-to-date on the remote lms
-- 
 
 ## [2.4.0] - 2024-06-21
 

--- a/src/backend/joanie/core/tasks/payment_schedule.py
+++ b/src/backend/joanie/core/tasks/payment_schedule.py
@@ -22,7 +22,7 @@ def process_today_installment(order_id):
     today = timezone.localdate()
     for installment in order.payment_schedule:
         if (
-            installment["due_date"] == today.isoformat()
+            installment["due_date"] <= today.isoformat()
             and installment["state"] == enums.PAYMENT_STATE_PENDING
         ):
             payment_backend = get_payment_backend()

--- a/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
+++ b/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
@@ -2,21 +2,29 @@
 Test suite for payment schedule tasks
 """
 
+import json
 from datetime import datetime
+from logging import Logger
 from unittest import mock
 from zoneinfo import ZoneInfo
 
 from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework.test import APIRequestFactory
 
 from joanie.core.enums import (
     ORDER_STATE_PENDING,
     ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
+    PAYMENT_STATE_PAID,
     PAYMENT_STATE_PENDING,
     PAYMENT_STATE_REFUSED,
 )
-from joanie.core.factories import OrderFactory
+from joanie.core.factories import OrderFactory, UserAddressFactory, UserFactory
 from joanie.core.tasks.payment_schedule import process_today_installment
+from joanie.payment import get_payment_backend
 from joanie.payment.backends.dummy import DummyPaymentBackend
+from joanie.payment.factories import InvoiceFactory
 from joanie.tests.base import BaseLogMixinTestCase
 
 
@@ -36,9 +44,18 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
         self, mock_create_zero_click_payment
     ):
         """Check today's installment is processed"""
+        owner = UserFactory(
+            email="john.doe@acme.org",
+            first_name="John",
+            last_name="Doe",
+            language="en-us",
+        )
+        UserAddressFactory(owner=owner)
         order = OrderFactory(
             id="6134df5e-a7eb-4cb3-aceb-d0abfe330af6",
+            owner=owner,
             state=ORDER_STATE_PENDING,
+            main_invoice=InvoiceFactory(),
             payment_schedule=[
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
@@ -150,3 +167,154 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             ],
         )
         self.assertEqual(order.state, ORDER_STATE_TO_SAVE_PAYMENT_METHOD)
+
+    @mock.patch.object(Logger, "info")
+    @mock.patch.object(
+        DummyPaymentBackend,
+        "handle_notification",
+        side_effect=DummyPaymentBackend().handle_notification,
+    )
+    @mock.patch.object(
+        DummyPaymentBackend,
+        "create_zero_click_payment",
+        side_effect=DummyPaymentBackend().create_zero_click_payment,
+    )
+    def test_utils_payment_schedule_should_catch_up_late_payments_for_installments_still_unpaid(
+        self, mock_create_zero_click_payment, mock_handle_notification, mock_logger
+    ):
+        """
+        When the due date has come, we should verify that there are no missed previous
+        installments that were not paid, which still require a payment. In the case where a
+        previous installment is found that was not paid, we want our task to handle it and
+        trigger the payment with the method `create_zero_click_payment`. We then verify that
+        the method `handle_notification` updates the order's payment schedule for the installments
+        that were paid.
+        """
+        owner = UserFactory(email="john.doe@acme.org")
+        UserAddressFactory(owner=owner)
+        order = OrderFactory(
+            state=ORDER_STATE_PENDING,
+            owner=owner,
+            main_invoice=InvoiceFactory(),
+            payment_schedule=[
+                {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+                    "amount": "200.00",
+                    "due_date": "2024-01-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "300.00",
+                    "due_date": "2024-02-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+                {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
+                    "amount": "300.00",
+                    "due_date": "2024-03-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+                {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
+                    "amount": "199.99",
+                    "due_date": "2024-04-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        expected_calls = [
+            mock.call(
+                order=order,
+                credit_card_token=order.credit_card.token,
+                installment={
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "300.00",
+                    "due_date": "2024-02-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ),
+            mock.call(
+                order=order,
+                credit_card_token=order.credit_card.token,
+                installment={
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
+                    "amount": "300.00",
+                    "due_date": "2024-03-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ),
+        ]
+
+        mocked_now = datetime(2024, 3, 17, 0, 0, tzinfo=ZoneInfo("UTC"))
+        with mock.patch("django.utils.timezone.now", return_value=mocked_now):
+            process_today_installment.run(order.id)
+        mock_create_zero_click_payment.assert_has_calls(expected_calls, any_order=False)
+
+        backend = get_payment_backend()
+        first_request = APIRequestFactory().post(
+            reverse("payment_webhook"),
+            data={
+                "id": "pay_1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                "type": "payment",
+                "state": "success",
+            },
+            format="json",
+        )
+        first_request.data = json.loads(first_request.body.decode("utf-8"))
+        backend.handle_notification(first_request)
+
+        mock_handle_notification.assert_called_with(first_request)
+        mock_logger.assert_called_with(
+            "Mail is sent to %s from dummy payment", "john.doe@acme.org"
+        )
+        mock_logger.reset_mock()
+
+        second_request = APIRequestFactory().post(
+            reverse("payment_webhook"),
+            data={
+                "id": "pay_168d7e8c-a1a9-4d70-9667-853bf79e502c",
+                "type": "payment",
+                "state": "success",
+            },
+            format="json",
+        )
+        second_request.data = json.loads(second_request.body.decode("utf-8"))
+        backend.handle_notification(second_request)
+
+        mock_handle_notification.assert_called_with(second_request)
+        mock_logger.assert_called_with(
+            "Mail is sent to %s from dummy payment", "john.doe@acme.org"
+        )
+
+        order.refresh_from_db()
+        self.assertEqual(
+            order.payment_schedule,
+            [
+                {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+                    "amount": "200.00",
+                    "due_date": "2024-01-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "300.00",
+                    "due_date": "2024-02-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
+                    "amount": "300.00",
+                    "due_date": "2024-03-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
+                    "amount": "199.99",
+                    "due_date": "2024-04-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ],
+        )

--- a/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
+++ b/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
@@ -69,10 +69,12 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):  # pylint: disable=too-m
         order = OrderGeneratorFactory(state=ORDER_STATE_PENDING)
         billing_address = order.main_invoice.recipient_address.to_dict()
         first_installment = order.payment_schedule[0]
+        installment_id = str(first_installment.get("id"))
+        payment_id = f"pay_{installment_id}"
+
         payment_payload = backend.create_payment(
             order, first_installment, billing_address
         )
-        payment_id = f"pay_{order.id}"
 
         self.assertEqual(
             payment_payload,
@@ -84,6 +86,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):  # pylint: disable=too-m
         )
 
         payment = cache.get(payment_id)
+
         self.assertEqual(
             payment,
             {
@@ -110,7 +113,8 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):  # pylint: disable=too-m
         payment_payload = backend.create_payment(
             order, order.payment_schedule[0], billing_address
         )
-        payment_id = f"pay_{order.id}"
+        installment_id = str(order.payment_schedule[0].get("id"))
+        payment_id = f"pay_{installment_id}"
 
         self.assertEqual(
             payment_payload,
@@ -162,7 +166,8 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):  # pylint: disable=too-m
         owner = UserFactory(language="en-us")
         order = OrderGeneratorFactory(state=ORDER_STATE_PENDING, owner=owner)
         billing_address = order.main_invoice.recipient_address.to_dict()
-        payment_id = f"pay_{order.id}"
+        installment_id = str(order.payment_schedule[0].get("id"))
+        payment_id = f"pay_{installment_id}"
 
         payment_payload = backend.create_one_click_payment(
             order, order.payment_schedule[0], order.credit_card.token, billing_address
@@ -235,7 +240,8 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):  # pylint: disable=too-m
         owner = UserFactory(language="en-us")
         order = OrderGeneratorFactory(state=ORDER_STATE_PENDING, owner=owner)
         billing_address = order.main_invoice.recipient_address.to_dict()
-        payment_id = f"pay_{order.id}"
+        installment_id = str(order.payment_schedule[0].get("id"))
+        payment_id = f"pay_{installment_id}"
 
         payment_payload = backend.create_one_click_payment(
             order, order.payment_schedule[0], order.credit_card.token, billing_address


### PR DESCRIPTION
## Purpose

When the due date has come, the task `process_today_installment` now verifies if there are previous installments on the order that require a payment. Now, the task will trigger a payment for the installments that are in the past that are not yet paid.

## Proposal
- [x] Update the `process_payment_schedule` command to check for installments that were not paid with a status 'pending' and change the logic for the cache key with the dummy backend payment to be able to update each installment states through the method `handle_notification`.
