### PR TITLE
👔(backend) certificate order filter return enrollment degrees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 - Add `currency` field to `OrderPaymentSerializer` serializer
 - Allow an order with `no_payment` state to pay for failed installment
   on a payment schedule
+- Order certificate filter now returns also legacy degree certificates
+  linked to an enrollment
 
 ### Fixed
 


### PR DESCRIPTION
## Purpose

With the data migration, we imported degrees and attestation of achievement. To prevent to have to create all the data structure (product, product course relation, orders), for degrees, we simply linked them to their enrollment and we used a "degree" certificate template. But there is one drawback to do that, the api allows to filter certificates according to their relation to order and enrollment models. In short, imported degrees are currently returned with legacy attestation of achievement. In order to fix that, we propose to tweak the certificate filter to include those specific degrees with order certificates