### PR TITLE
🚑(backend) fix enrollment mode update on order validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Add settings configuration for the contract's country calendar to
   manage the payment schedule and the withdrawal period in days
 
+### Fixed
+
+- Fix enrollment mode update on order validation
+
 ## [2.3.0] - 2024-06-18
 
 ### Added

--- a/src/backend/joanie/core/flows/order.py
+++ b/src/backend/joanie/core/flows/order.py
@@ -209,9 +209,8 @@ class OrderFlow:
         # course runs targeted by the purchased product, we should change their enrollment mode on
         # these course runs to "verified".
         if target in [enums.ORDER_STATE_VALIDATED, enums.ORDER_STATE_CANCELED]:
-            Enrollment = apps.get_model("core", "Enrollment")  # pylint: disable=invalid-name
-            for enrollment in Enrollment.objects.filter(
-                course_run__course__target_orders=self.instance, is_active=True
+            for enrollment in self.instance.get_target_enrollments(
+                is_active=True
             ).select_related("course_run", "user"):
                 enrollment.set()
 

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -702,7 +702,7 @@ class Order(BaseModel):
         Retrieve owner's enrollments related to the ordered target courses.
         """
         filters = {
-            "course_run__course__in": self.target_courses.all(),
+            "course_run__in": self.target_course_runs,
             "user": self.owner,
         }
         if is_active is not None:


### PR DESCRIPTION
## Purpose

Currently, when an order is canceled or validated, we update the enrollment mode . (e.g: For OpenEdx, from honor to verified on order validation). Currently the queryset to retrieve enrollments is wrong. Instead of retrieving user enrollment for the related order, it retrieves all active enrollments related to the course to which the order is linked...
