### PR TITLE
🐛(backend) prevent automatic enrollment failure to raise error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Add settings configuration for the contract's country calendar to
   manage the payment schedule and the withdrawal period in days
 
+### Changed
+
+- Catch all exceptions raised by enroll_user_to_course_run method
+
 ### Fixed
 
 - Fix enrollment mode update on order validation

--- a/src/backend/joanie/core/flows/order.py
+++ b/src/backend/joanie/core/flows/order.py
@@ -3,6 +3,7 @@
 from django.apps import apps
 from django.utils import timezone
 
+from sentry_sdk import capture_exception
 from viewflow import fsm
 
 from joanie.core import enums
@@ -220,7 +221,12 @@ class OrderFlow:
             target == enums.ORDER_STATE_VALIDATED
             and self.instance.product.contract_definition is None
         ):
-            self.instance.enroll_user_to_course_run()
+            try:
+                # ruff : noqa : BLE001
+                # pylint: disable=broad-exception-caught
+                self.instance.enroll_user_to_course_run()
+            except Exception as error:
+                capture_exception(error)
 
         if target == enums.ORDER_STATE_CANCELED:
             self.instance.unenroll_user_from_course_runs()

--- a/src/backend/joanie/signature/backends/base.py
+++ b/src/backend/joanie/signature/backends/base.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils import timezone as django_timezone
 
+from sentry_sdk import capture_exception
+
 from joanie.core import models
 
 logger = getLogger(__name__)
@@ -66,7 +68,12 @@ class BaseSignatureBackend:
 
         # The student has signed the contract, we can now try to automatically enroll
         # it to single course runs opened for enrollment.
-        contract.order.enroll_user_to_course_run()
+        try:
+            # ruff : noqa : BLE001
+            # pylint: disable=broad-exception-caught
+            contract.order.enroll_user_to_course_run()
+        except Exception as error:
+            capture_exception(error)
 
         logger.info("Student signed the contract '%s'", contract.id)
 

--- a/src/backend/joanie/tests/signature/test_backend_signature_base.py
+++ b/src/backend/joanie/tests/signature/test_backend_signature_base.py
@@ -118,6 +118,41 @@ class BaseSignatureBackendTestCase(TestCase):
         # contract.order.enroll_user_to_course should have been called once
         _mock_enroll_user.assert_called_once()
 
+    @mock.patch(
+        "joanie.core.models.Order.enroll_user_to_course_run", side_effect=Exception
+    )
+    def test_backend_signature_base_backend_confirm_student_signature_with_auto_enroll_failure(
+        self, mock_enroll_user
+    ):
+        """
+        If the automatic enrollment fails, the `confirm_student_signature` method
+        should log an error and continue the process.
+        """
+        user = factories.UserFactory()
+        order = factories.OrderFactory(
+            owner=user,
+            product__contract_definition=factories.ContractDefinitionFactory(),
+            state=enums.ORDER_STATE_VALIDATED,
+        )
+        contract = factories.ContractFactory(
+            order=order,
+            definition=order.product.contract_definition,
+            signature_backend_reference="wfl_fake_dummy_id",
+            definition_checksum="fake_test_file_hash",
+            context="content",
+            submitted_for_signature_on=django_timezone.now(),
+        )
+        backend = get_signature_backend()
+
+        backend.confirm_student_signature(reference="wfl_fake_dummy_id")
+
+        contract.refresh_from_db()
+        self.assertIsNotNone(contract.submitted_for_signature_on)
+        self.assertIsNotNone(contract.student_signed_on)
+
+        # contract.order.enroll_user_to_course should have been called once
+        mock_enroll_user.assert_called_once()
+
     @override_settings(
         JOANIE_SIGNATURE_BACKEND=random.choice(
             [


### PR DESCRIPTION
## Purpose

On order validation, the `enroll_user_to_course_run` is triggered and sometimes this one can raise exception. In atomic transition context, this is weird as it causes the rollback of database changes and from api point of view the endpoint returns an internal server error... As this method can be considered of a side effect it should impact nothing if it fails. In order to fix that, we catch all exception raised by this method and just send an error log to Sentry.