### PR TITLE
🚑(backend) fix openedx set enrollment mode choice logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix OpenEdX enrollment mode choice logic
+
 ## [2.5.0] - 2024-06-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.5.1] - 2024-06-25
+
 ### Fixed
 
 - Fix OpenEdX enrollment mode choice logic
@@ -377,7 +379,8 @@ and this project adheres to
 - First working version serving sellable micro-credentials for multiple
   organizations synchronized to a remote catalog
 
-[unreleased]: https://github.com/openfun/joanie/compare/v2.5.0...main
+[unreleased]: https://github.com/openfun/joanie/compare/v2.5.1...main
+[2.5.1]: https://github.com/openfun/joanie/compare/v2.5.0...v2.5.1
 [2.5.0]: https://github.com/openfun/joanie/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/openfun/joanie/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/openfun/joanie/compare/v2.2.0...v2.3.0

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,6 +1,6 @@
 # arnold.yml
 metadata:
   name: joanie
-  version: 2.5.0
+  version: 2.5.1
 source:
   path: src/tray

--- a/src/backend/joanie/lms_handler/backends/openedx.py
+++ b/src/backend/joanie/lms_handler/backends/openedx.py
@@ -132,6 +132,7 @@ class OpenEdXLMSBackend(BaseLMSBackend):
                 Q(target_courses=enrollment.course_run.course)
                 | Q(enrollment=enrollment),
                 state=enums.ORDER_STATE_VALIDATED,
+                owner=enrollment.user,
             ).exists()
             else OPENEDX_MODE_HONOR
         )

--- a/src/backend/joanie/tests/lms_handler/test_backend_openedx.py
+++ b/src/backend/joanie/tests/lms_handler/test_backend_openedx.py
@@ -269,7 +269,7 @@ class OpenEdXLMSBackendTestCase(TestCase):
             json.loads(responses.calls[1].request.body),
             {
                 "is_active": True,
-                "mode": "honor",
+                "mode": OPENEDX_MODE_HONOR,
                 "user": user.username,
                 "course_details": {"course_id": "course-v1:edx+000001+Demo_Course"},
             },
@@ -289,7 +289,29 @@ class OpenEdXLMSBackendTestCase(TestCase):
             json.loads(responses.calls[1].request.body),
             {
                 "is_active": True,
-                "mode": "verified",
+                "mode": OPENEDX_MODE_VERIFIED,
+                "user": user.username,
+                "course_details": {"course_id": "course-v1:edx+000001+Demo_Course"},
+            },
+        )
+
+        # However another user without order should be enrolled in honor mode
+        responses.reset()
+        user = factories.UserFactory()
+        url = f"http://openedx.test/api/enrollment/v1/enrollment/{user.username},{course_id}"
+        responses.add(
+            responses.GET,
+            url,
+            status=HTTPStatus.OK,
+            json=None,
+        )
+        factories.EnrollmentFactory(user=user, course_run=course_run, is_active=True)
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(
+            json.loads(responses.calls[1].request.body),
+            {
+                "is_active": True,
+                "mode": OPENEDX_MODE_HONOR,
                 "user": user.username,
                 "course_details": {"course_id": "course-v1:edx+000001+Demo_Course"},
             },

--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8072",

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {

--- a/src/openApiClientJs/package.json
+++ b/src/openApiClientJs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joanie-openapi-client-ts",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "description": "Tool to generate Typescript api client for joanie",
   "scripts": {

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: joanie
-  version: 2.5.0
+  version: 2.5.1

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -21,7 +21,7 @@ joanie_nginx_static_cache_expires: "1M"
 
 # -- admin nginx
 joanie_admin_nginx_image_name: "fundocker/joanie-admin"
-joanie_admin_nginx_image_tag: "2.5.0"
+joanie_admin_nginx_image_tag: "2.5.1"
 joanie_admin_nginx_port: 8061
 joanie_admin_nginx_replicas: 1
 joanie_admin_nginx_healthcheck_port: 5000
@@ -41,7 +41,7 @@ joanie_database_secret_name: "joanie-postgresql-{{ joanie_vault_checksum | defau
 
 # -- joanie
 joanie_image_name: "fundocker/joanie"
-joanie_image_tag: "2.5.0"
+joanie_image_tag: "2.5.1"
 # The image pull secret name should match the name of your secret created to
 # login to your private docker registry
 joanie_image_pull_secret_name: ""


### PR DESCRIPTION
## Purpose

To choose the enrollment mode to use when enrolling a user on OpenEdX course run
 we currently check if a validated order relying on this enrollment exist. But
 to retrieve this order we don't filter order owned by the enrollment user so in
  case of credential product once one validated order exists, all other user
  enrolling to the related course run was enrolled with verified mode...

Then release a patch version