### PR TITLE
:sparkles: (backend) Mail when installment debit has succeed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Send an email to the user when an installment is successfully
+  paid
 - Support of payment_schedule for certificate products
 
 ### Changed

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -57,7 +57,7 @@ DJANGO_EMAIL_PORT=1025
 # Richie
 JOANIE_CATALOG_BASE_URL=http://richie:8070
 JOANIE_CATALOG_NAME=richie
-JOANIE_CONTRACT_CONTEXT_PROCESSORS = 
+JOANIE_CONTRACT_CONTEXT_PROCESSORS =
 
 # Backoffice
 JOANIE_BACKOFFICE_BASE_URL="http://localhost:8072"
@@ -75,3 +75,6 @@ DEVELOPER_EMAIL="developer@example.com"
 
 # Security for remote endpoints API
 JOANIE_AUTHORIZED_API_TOKENS = "secretTokenForRemoteAPIConsumer"
+
+# Add here the dashboard link of orders for email sent when an installment is paid
+JOANIE_DASHBOARD_ORDER_LINK = "http://localhost:8070/dashboard/courses/orders/:orderId/"

--- a/src/backend/joanie/debug/urls.py
+++ b/src/backend/joanie/debug/urls.py
@@ -10,6 +10,8 @@ from joanie.debug.views import (
     DebugContractTemplateView,
     DebugDegreeTemplateView,
     DebugInvoiceTemplateView,
+    DebugMailAllInstallmentPaidViewHtml,
+    DebugMailAllInstallmentPaidViewTxt,
     DebugMailSuccessInstallmentPaidViewHtml,
     DebugMailSuccessInstallmentPaidViewTxt,
     DebugMailSuccessPaymentViewHtml,
@@ -62,5 +64,15 @@ urlpatterns = [
         "__debug__/mail/installment-paid-txt",
         DebugMailSuccessInstallmentPaidViewTxt.as_view(),
         name="debug.mail.installment_paid_txt",
+    ),
+    path(
+        "__debug__/mail/installments-fully-paid-html",
+        DebugMailAllInstallmentPaidViewHtml.as_view(),
+        name="debug.mail.installments_fully_paid_html",
+    ),
+    path(
+        "__debug__/mail/installments-fully-paid-txt",
+        DebugMailAllInstallmentPaidViewTxt.as_view(),
+        name="debug.mail.installments_fully_paid_txt",
     ),
 ]

--- a/src/backend/joanie/debug/urls.py
+++ b/src/backend/joanie/debug/urls.py
@@ -10,6 +10,8 @@ from joanie.debug.views import (
     DebugContractTemplateView,
     DebugDegreeTemplateView,
     DebugInvoiceTemplateView,
+    DebugMailSuccessInstallmentPaidViewHtml,
+    DebugMailSuccessInstallmentPaidViewTxt,
     DebugMailSuccessPaymentViewHtml,
     DebugMailSuccessPaymentViewTxt,
     DebugPaymentTemplateView,
@@ -50,5 +52,15 @@ urlpatterns = [
         "__debug__/payment",
         DebugPaymentTemplateView.as_view(),
         name="debug.payment_template",
+    ),
+    path(
+        "__debug__/mail/installment-paid-html",
+        DebugMailSuccessInstallmentPaidViewHtml.as_view(),
+        name="debug.mail.installment_paid_html",
+    ),
+    path(
+        "__debug__/mail/installment-paid-txt",
+        DebugMailSuccessInstallmentPaidViewTxt.as_view(),
+        name="debug.mail.installment_paid_txt",
     ),
 ]

--- a/src/backend/joanie/debug/views.py
+++ b/src/backend/joanie/debug/views.py
@@ -158,6 +158,39 @@ class DebugMailSuccessInstallmentPaidViewTxt(DebugMailInstallmentPayment):
     template_name = "mail/text/installment_paid.txt"
 
 
+class DebugMailAllInstallmentPaid(DebugMailInstallmentPayment):
+    """Debug View to check the layout of when all installments are paid by email"""
+
+    def get_context_data(self, **kwargs):
+        """
+        Base method to prepare the document context to render in the email for the debug view.
+        """
+        context = super().get_context_data()
+        order = context.get("order")
+        for payment in order.payment_schedule:
+            payment["state"] = PAYMENT_STATE_PAID
+        context["installment_amount"] = Money(order.payment_schedule[-1]["amount"])
+        context["targeted_installment_index"] = order.get_index_of_last_installment(
+            state=PAYMENT_STATE_PAID
+        )
+
+        return context
+
+
+class DebugMailAllInstallmentPaidViewHtml(DebugMailAllInstallmentPaid):
+    """Debug View to check the layout of when all installments are paid by email
+    in html format."""
+
+    template_name = "mail/html/installments_fully_paid.html"
+
+
+class DebugMailAllInstallmentPaidViewTxt(DebugMailAllInstallmentPaid):
+    """Debug View to check the layout of when all installments are paid by email
+    in txt format."""
+
+    template_name = "mail/text/installments_fully_paid.txt"
+
+
 class DebugPdfTemplateView(TemplateView):
     """
     Simple class to render the PDF template in bytes format of a document to preview.

--- a/src/backend/joanie/payment/backends/base.py
+++ b/src/backend/joanie/payment/backends/base.py
@@ -11,6 +11,9 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django.utils.translation import override
 
+from stockholm import Money
+
+from joanie.core.enums import ORDER_STATE_COMPLETED, PAYMENT_STATE_PAID
 from joanie.payment.enums import INVOICE_STATE_REFUNDED
 from joanie.payment.models import Invoice, Transaction
 
@@ -53,16 +56,49 @@ class BasePaymentBackend:
 
         order.set_installment_paid(payment["installment_id"])
 
-        # send mail
-        cls._send_mail_payment_success(order)
+        upcoming_installment = order.state == ORDER_STATE_COMPLETED
+        # Because with Lyra Payment Provider, we get the value in cents
+        cls._send_mail_payment_installment_success(
+            order=order,
+            amount=payment["amount"]
+            if "." in str(payment["amount"])
+            else payment["amount"] / 100,
+            upcoming_installment=not upcoming_installment,
+        )
 
     @classmethod
-    def _send_mail_payment_success(cls, order):
+    def _send_mail(cls, subject, template_vars, template_name, to_user_email):
         """Send mail with the current language of the user"""
         try:
-            with override(order.owner.language):
-                template_vars = {
-                    "title": _("Purchase order confirmed!"),
+            msg_html = render_to_string(
+                f"mail/html/{template_name}.html", template_vars
+            )
+            msg_plain = render_to_string(
+                f"mail/text/{template_name}.txt", template_vars
+            )
+            send_mail(
+                subject,
+                msg_plain,
+                settings.EMAIL_FROM,
+                [to_user_email],
+                html_message=msg_html,
+                fail_silently=False,
+            )
+        except smtplib.SMTPException as exception:
+            # no exception raised as user can't sometimes change his mail,
+            logger.error("%s purchase order mail %s not send", to_user_email, exception)
+
+    @classmethod
+    def _send_mail_subscription_success(cls, order):
+        """
+        Send mail with the current language of the user when an order subscription is
+        confirmed
+        """
+        with override(order.owner.language):
+            cls._send_mail(
+                subject=_("Subscription confirmed!"),
+                template_vars={
+                    "title": _("Subscription confirmed!"),
                     "email": order.owner.email,
                     "fullname": order.owner.get_full_name() or order.owner.username,
                     "product": order.product,
@@ -70,25 +106,64 @@ class BasePaymentBackend:
                         "name": settings.JOANIE_CATALOG_NAME,
                         "url": settings.JOANIE_CATALOG_BASE_URL,
                     },
-                }
-                msg_html = render_to_string(
-                    "mail/html/order_validated.html", template_vars
+                },
+                template_name="order_validated",
+                to_user_email=order.owner.email,
+            )
+
+    @classmethod
+    def _send_mail_payment_installment_success(
+        cls, order, amount, upcoming_installment
+    ):
+        """
+        Send mail using the current language of the user when an installment is successfully paid
+        and also when all the installments are paid.
+        """
+        with override(order.owner.language):
+            product_title = order.product.safe_translation_getter(
+                "title", language_code=order.owner.language
+            )
+            base_subject = _(f"{settings.JOANIE_CATALOG_NAME} - {product_title} - ")
+            installment_amount = Money(amount)
+            currency = settings.DEFAULT_CURRENCY
+            if upcoming_installment:
+                variable_subject_part = _(
+                    f"An installment has been successfully paid of {installment_amount} {currency}"
                 )
-                msg_plain = render_to_string(
-                    "mail/text/order_validated.txt", template_vars
+            else:
+                variable_subject_part = _(
+                    f"Order completed ! The last installment of {installment_amount} {currency} "
+                    "has been debited"
                 )
-                send_mail(
-                    _("Purchase order confirmed!"),
-                    msg_plain,
-                    settings.EMAIL_FROM,
-                    [order.owner.email],
-                    html_message=msg_html,
-                    fail_silently=False,
-                )
-        except smtplib.SMTPException as exception:
-            # no exception raised as user can't sometimes change his mail,
-            logger.error(
-                "%s purchase order mail %s not send", order.owner.email, exception
+            cls._send_mail(
+                subject=f"{base_subject}{variable_subject_part}",
+                template_vars={
+                    "fullname": order.owner.get_full_name() or order.owner.username,
+                    "email": order.owner.email,
+                    "product_title": product_title,
+                    "installment_amount": installment_amount,
+                    "product_price": Money(order.product.price),
+                    "credit_card_last_numbers": order.credit_card.last_numbers,
+                    "remaining_balance_to_pay": order.get_remaining_balance_to_pay(),
+                    "date_next_installment_to_pay": order.get_date_next_installment_to_pay(),
+                    "targeted_installment_index": order.get_index_of_last_installment(
+                        state=PAYMENT_STATE_PAID
+                    ),
+                    "order_payment_schedule": order.payment_schedule,
+                    "dashboard_order_link": (
+                        settings.JOANIE_DASHBOARD_ORDER_LINK.replace(
+                            ":orderId", str(order.id)
+                        )
+                    ),
+                    "site": {
+                        "name": settings.JOANIE_CATALOG_NAME,
+                        "url": settings.JOANIE_CATALOG_BASE_URL,
+                    },
+                },
+                template_name="installment_paid"
+                if upcoming_installment
+                else "installments_fully_paid",
+                to_user_email=order.owner.email,
             )
 
     @staticmethod

--- a/src/backend/joanie/payment/backends/dummy.py
+++ b/src/backend/joanie/payment/backends/dummy.py
@@ -115,9 +115,18 @@ class DummyPaymentBackend(BasePaymentBackend):
         )
 
     @classmethod
-    def _send_mail_payment_success(cls, order):
+    def _send_mail_subscription_success(cls, order):
         logger.info("Mail is sent to %s from dummy payment", order.owner.email)
-        super()._send_mail_payment_success(order)
+        super()._send_mail_subscription_success(order)
+
+    @classmethod
+    def _send_mail_payment_installment_success(
+        cls, order, amount, upcoming_installment
+    ):
+        logger.info("Mail is sent to %s from dummy payment", order.owner.email)
+        super()._send_mail_payment_installment_success(
+            order=order, amount=amount, upcoming_installment=upcoming_installment
+        )
 
     def _get_payment_data(
         self,

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -205,6 +205,7 @@ class Base(Configuration):
         "django.contrib.sites",
         "django.contrib.messages",
         "django.contrib.staticfiles",
+        "django.contrib.humanize",
         # Third party apps
         "admin_auto_filters",
         "django_object_actions",
@@ -437,9 +438,15 @@ class Base(Configuration):
         environ_name="JOANIE_WITHDRAWAL_PERIOD_DAYS",
         environ_prefix=None,
     )
+    # Email for installment payment
+    # Add here the dashboard link of orders
+    JOANIE_DASHBOARD_ORDER_LINK = values.Value(
+        None,
+        environ_name="JOANIE_DASHBOARD_ORDER_LINK",
+        environ_prefix=None,
+    )
 
     # CORS
-
     CORS_ALLOW_CREDENTIALS = True
     CORS_ALLOW_ALL_ORIGINS = values.BooleanValue(False)
     CORS_ALLOWED_ORIGINS = values.ListValue([])
@@ -742,6 +749,10 @@ class Test(Base):
         {0: (30, 70)},
         environ_name="JOANIE_PAYMENT_SCHEDULE_LIMITS",
         environ_prefix=None,
+    )
+
+    JOANIE_DASHBOARD_ORDER_LINK = (
+        "http://localhost:8070/dashboard/courses/orders/:orderId/"
     )
 
     LOGGING = values.DictValue(

--- a/src/backend/joanie/tests/payment/base_payment.py
+++ b/src/backend/joanie/tests/payment/base_payment.py
@@ -3,37 +3,41 @@
 from django.core import mail
 from django.test import TestCase
 
+from joanie.core.enums import ORDER_STATE_COMPLETED
+
 
 class BasePaymentTestCase(TestCase):
     """Common method to test the Payment Backend"""
 
     maxDiff = None
 
-    def _check_order_validated_email_sent(self, email, username, order):
-        """Shortcut to check order validated email has been sent"""
-        # check email has been sent
-        self.assertEqual(len(mail.outbox), 1)
-
+    def _check_installment_paid_email_sent(self, email, order):
+        """Shortcut to check over installment paid email has been sent"""
         # check we send it to the right email
         self.assertEqual(mail.outbox[0].to[0], email)
 
-        email_content = " ".join(mail.outbox[0].body.split())
-        self.assertIn("Your order has been confirmed.", email_content)
-        self.assertIn("Thank you very much for your purchase!", email_content)
-        self.assertIn(order.product.title, email_content)
-
         # check it's the right object
-        self.assertEqual(mail.outbox[0].subject, "Purchase order confirmed!")
-
-        if username:
-            self.assertIn(f"Hello {username}", email_content)
+        if order.state == ORDER_STATE_COMPLETED:
+            self.assertIn(
+                "Order completed ! The last installment of",
+                mail.outbox[0].subject,
+            )
         else:
-            self.assertIn("Hello", email_content)
-            self.assertNotIn("None", email_content)
+            self.assertIn(
+                "An installment has been successfully paid",
+                mail.outbox[0].subject,
+            )
+
+        # Check body
+        email_content = " ".join(mail.outbox[0].body.split())
+        fullname = order.owner.get_full_name()
+        self.assertIn(f"Hello {fullname}", email_content)
+        self.assertIn("has been debited on the credit card", email_content)
+        self.assertIn("See order details on your dashboard", email_content)
+        self.assertIn(order.product.title, email_content)
 
         # emails are generated from mjml format, test rendering of email doesn't
         # contain any trans tag, it might happen if \n are generated
         self.assertNotIn("trans ", email_content)
-
         # catalog url is included in the email
         self.assertIn("https://richie.education", email_content)

--- a/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
+++ b/src/backend/joanie/tests/payment/test_backend_dummy_payment.py
@@ -210,9 +210,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):  # pylint: disable=too-m
         order.refresh_from_db()
         self.assertEqual(order.state, ORDER_STATE_COMPLETED)
         # check email has been sent
-        self._check_order_validated_email_sent(
-            order.owner.email, order.owner.username, order
-        )
+        self._check_installment_paid_email_sent(order.owner.email, order)
 
         mock_logger.assert_called_with(
             "Mail is sent to %s from dummy payment", order.owner.email
@@ -291,9 +289,7 @@ class DummyPaymentBackendTestCase(BasePaymentTestCase):  # pylint: disable=too-m
                 self.assertEqual(installment["state"], PAYMENT_STATE_PENDING)
 
         # check email has been sent
-        self._check_order_validated_email_sent(
-            order.owner.email, order.owner.username, order
-        )
+        self._check_installment_paid_email_sent(order.owner.email, order)
 
         mock_logger.assert_called_with(
             "Mail is sent to %s from dummy payment", order.owner.email

--- a/src/backend/joanie/tests/payment/test_backend_payplug.py
+++ b/src/backend/joanie/tests/payment/test_backend_payplug.py
@@ -727,6 +727,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
             owner=owner,
             credit_card__is_main=True,
             credit_card__initial_issuer_transaction_identifier="1",
+            product__price=D("123.45"),
         )
         # Force the first installment id to match the stored request
         first_installment = order.payment_schedule[0]
@@ -755,9 +756,7 @@ class PayplugBackendTestCase(BasePaymentTestCase):
         backend.handle_notification(request)
 
         # Email has been sent
-        self._check_order_validated_email_sent(
-            order.owner.email, order.owner.get_full_name(), order
-        )
+        self._check_installment_paid_email_sent(order.owner.email, order)
 
     @mock.patch.object(BasePaymentBackend, "_do_on_payment_success")
     @mock.patch.object(payplug.notifications, "treat")

--- a/src/mail/mjml/installment_paid.mjml
+++ b/src/mail/mjml/installment_paid.mjml
@@ -1,0 +1,64 @@
+<mjml>
+  <mj-include path="./partial/header.mjml" />
+  <mj-body mj-class="bg--blue-100">
+    <mj-wrapper css-class="wrapper" padding="20px 40px 40px 40px">
+      <mj-section>
+        <mj-column>
+          <mj-image src="{% base64_static 'joanie/images/logo_fun.png' %}" width="200px" align="left" alt="{%trans 'Company logo' %}" />
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="30px 50px 10px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% if fullname %}
+              <p>
+              {% blocktranslate with name=fullname%}
+                Hello {{ name }},
+              {% endblocktranslate %}
+              </p>
+            {% else %}
+              {% trans "Hello," %}
+            {% endif %}<br />
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate with targeted_installment_index=targeted_installment_index|add:1|ordinal title=product_title %}
+            For the course <strong>{{ title }}</strong>, the {{ targeted_installment_index }}
+            installment has been successfully paid.
+            <br />
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% with installment_amount=installment_amount|format_currency_with_symbol remaining_balance_to_pay=remaining_balance_to_pay|format_currency_with_symbol date_next_installment_to_pay=date_next_installment_to_pay|date:"SHORT_DATE_FORMAT" %}
+            {% blocktranslate %}
+            An amount of <strong>{{ installment_amount }}</strong> has been debited on
+            the credit card •••• •••• •••• {{ credit_card_last_numbers }}.
+            <br />
+            Currently, it remains <strong>{{ remaining_balance_to_pay }}</strong> to be paid.
+            The next installment will be debited on <strong>{{ date_next_installment_to_pay }}</strong>.
+            {% endblocktranslate %}
+            {% endwith %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-include path="./partial/installment_table.mjml" />
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate %}
+            See order details on your <a href="{{ dashboard_order_link }}">dashboard</a>
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-include path="./partial/footer.mjml" />
+  </mj-body>
+</mjml>

--- a/src/mail/mjml/installments_fully_paid.mjml
+++ b/src/mail/mjml/installments_fully_paid.mjml
@@ -1,0 +1,61 @@
+<mjml>
+  <mj-include path="./partial/header.mjml" />
+  <mj-body mj-class="bg--blue-100">
+    <mj-wrapper css-class="wrapper" padding="20px 40px 40px 40px">
+      <mj-section>
+        <mj-column>
+          <mj-image src="{% base64_static 'joanie/images/logo_fun.png' %}" width="200px" align="left" alt="{%trans 'Company logo' %}" />
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="30px 50px 10px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% if fullname %}
+              <p>
+              {% blocktranslate with name=fullname%}
+                Hello {{ name }},
+              {% endblocktranslate %}
+              </p>
+            {% else %}
+              {% trans "Hello," %}
+            {% endif %}<br />
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate with title=product_title %}
+              For the course <strong>{{ title }}</strong>, we have just debited the last installment.
+              Your order is now fully paid!
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>s
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% with installment_amount=installment_amount|format_currency_with_symbol %}
+            {% blocktranslate %}
+            An amount of <strong>{{ installment_amount }}</strong> has been debited on
+            the credit card •••• •••• •••• {{ credit_card_last_numbers }}.
+            <br />
+            {% endblocktranslate %}
+            {% endwith %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-include path="./partial/installment_table.mjml" />
+      <mj-section mj-class="bg--blue-100" padding="0 50px 30px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate %}
+            See order details on your <a href="{{ dashboard_order_link }}">dashboard</a>
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-include path="./partial/footer.mjml" />
+  </mj-body>
+</mjml>

--- a/src/mail/mjml/partial/header.mjml
+++ b/src/mail/mjml/partial/header.mjml
@@ -5,7 +5,7 @@
             We load django tags here, in this way there are put within the body in html output
             so the html-to-text command includes it within its output
         -->
-        {% load i18n static extra_tags %}
+        {% load i18n humanize static extra_tags %}
         {{ title }}
     </mj-preview>
     <mj-attributes>

--- a/src/mail/mjml/partial/installment_table.mjml
+++ b/src/mail/mjml/partial/installment_table.mjml
@@ -1,0 +1,63 @@
+<mj-section mj-class="bg--blue-100" padding="0 50px 0 50px">
+  <mj-column>
+    <mj-text padding="0" font-size="16px">
+      <strong>{% trans "Payment schedule" %}</strong>
+    </mj-text>
+  </mj-column>
+</mj-section>
+<mj-section mj-class="bg--blue-100">
+  <mj-column>
+    <mj-text padding="0 50px 0 50px">
+      <div style="background-color:#ffffff; border: 1px solid #B8C7E3; border-radius: 8px; overflow: hidden;">
+        <table style="font-size: 14px; width: 100%; border-collapse: collapse; overflow: hidden;">
+          {% for installment in order_payment_schedule %}
+          {% with amount=installment.amount|format_currency_with_symbol installment_date=installment.due_date|date:"SHORT_DATE_FORMAT" %}
+          <tr style="{% if not forloop.last %}border-bottom: 1px solid #B8C7E3;{% endif %} {% if targeted_installment_index == forloop.counter0 %}background-color: #EDF5FA; {% endif %}">
+            <td style="padding: 10px 10px 10px 20px;">
+              <mj-text>{{ forloop.counter }}</mj-text>
+            </td>
+            <td style="padding:10px;">
+              <mj-text><strong>{{ amount }}</strong></mj-text>
+            </td>
+            <td style="padding:10px;">
+              <p>
+              {% blocktranslate with installment_date=installment_date %}
+                Withdrawn on {{ installment_date }}
+              {% endblocktranslate %}
+              </p>
+            </td>
+            <td style="padding:10px;">
+              <div style="display: inline-block; width: 100%;">
+                {% if installment.state == "paid" %}
+                <p style="font-size: 14px; background-color: #B9E49E; color: #507838; text-decoration: none; text-align: center; padding: 2px 2px; border-radius: 20px;">
+                  <strong>{% blocktranslate with state=installment.state.capitalize %}{{ state }}{% endblocktranslate %}</strong>
+                </p>
+                {% elif installment.state == "pending" %}
+                <p style="font-size: 14px; background-color: #B8C7E3; color: #4A5A7B; text-decoration: none; text-align: center; padding: 2px 2px; border-radius: 20px;">
+                  <strong>{% blocktranslate with state=installment.state.capitalize %}{{ state }}</strong>{% endblocktranslate %}
+                </p>
+                {% elif installment.state == "refused" %}
+                <p style="font-size: 14px; background-color: #F3D4AF; color: #7C5D3A; text-decoration: none; text-align: center; padding: 2px 2px; border-radius: 20px;">
+                  <strong>{% blocktranslate with state=installment.state.capitalize %}{{ state }}{% endblocktranslate %}</strong>
+                </p>
+                {% endif %}
+              </div>
+            </td>
+          </tr>
+          {% endwith %}
+          {% endfor %}
+        </table>
+      </div>
+    </mj-text>
+    <mj-text>
+      <div style="padding:5px 50px 5px 38px;">
+        <mj-text mj-class="bg--blue-100">
+          <div style="display: flex; justify-content: space-between; align-items: center;">
+            <strong>Total</strong>
+            <strong>{{ product_price|format_currency_with_symbol }}</strong>
+          </div>
+        </mj-text>
+      </div>
+    </mj-text>
+  </mj-column>
+</mj-section>


### PR DESCRIPTION
## Purpose
This PR will solve this [issue](https://github.com/openfun/joanie/issues/862) 

Actually, we only send an email confirming that the order is validated. This behaviour is useful when a user purchases a certificate for example.

But since we have added payment schedules for all order in a near future, we should trigger an email each time the user has paid successfully an installment. We must preserve the first email that is initially sent once the order is validated. We now also send a different email when the user has paid all the installments on the payment schedule.

## Proposal
- [x] Create one MJML template when a new installment is paid with the table of the payment schedule included.
- [x] Create one MJML template when all the installments are paid on the payment schedule.
- [x] Create a debug view to preview the layout when 1 installment is paid.
- [x] Create a debug view to preview the layout when all installments are paid. 
- [x] Add new email logic into the base payment backend class.
