### PR TITLE
🐛(backend) fix handle_notification of dummy signature backend

### DIFF
--- a/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
@@ -160,9 +160,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         )
         order.init_flow(billing_address=BillingAddressDictFactory())
         token = self.get_user_token(user.username)
-        expected_substring_invite_url = (
-            "https://dummysignaturebackend.fr/?requestToken="
-        )
+        expected_substring_invite_url = "https://dummysignaturebackend.fr/?reference="
 
         response = self.client.post(
             f"/api/v1.0/orders/{order.id}/submit_for_signature/",
@@ -214,9 +212,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         )
         contract = order.contract
         token = self.get_user_token(order.owner.username)
-        expected_substring_invite_url = (
-            "https://dummysignaturebackend.fr/?requestToken="
-        )
+        expected_substring_invite_url = "https://dummysignaturebackend.fr/?reference="
 
         response = self.client.post(
             f"/api/v1.0/orders/{order.id}/submit_for_signature/",
@@ -258,9 +254,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         contract = order.contract
         token = self.get_user_token(order.owner.username)
         order.contract.definition.body = "a new content"
-        expected_substring_invite_url = (
-            "https://dummysignaturebackend.fr/?requestToken="
-        )
+        expected_substring_invite_url = "https://dummysignaturebackend.fr/?reference="
 
         response = self.client.post(
             f"/api/v1.0/orders/{order.id}/submit_for_signature/",

--- a/src/backend/joanie/tests/core/api/organizations/test_contracts_signature_link.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_contracts_signature_link.py
@@ -100,7 +100,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertIn(
-            "https://dummysignaturebackend.fr/?requestToken=",
+            "https://dummysignaturebackend.fr/?reference=",
             content["invitation_link"],
         )
         self.assertCountEqual(
@@ -154,7 +154,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertIn(
-            "https://dummysignaturebackend.fr/?requestToken=",
+            "https://dummysignaturebackend.fr/?reference=",
             content["invitation_link"],
         )
 
@@ -306,7 +306,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertIn(
-            "https://dummysignaturebackend.fr/?requestToken=",
+            "https://dummysignaturebackend.fr/?reference=",
             content["invitation_link"],
         )
 
@@ -368,7 +368,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         content = response.json()
         self.assertIn(
-            "https://dummysignaturebackend.fr/?requestToken=",
+            "https://dummysignaturebackend.fr/?reference=",
             content["invitation_link"],
         )
 

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -594,7 +594,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         self.assertIsNotNone(order.contract.signature_backend_reference)
         self.assertIsNotNone(order.contract.definition_checksum)
         self.assertIn(
-            "https://dummysignaturebackend.fr/?requestToken=", raw_invitation_link
+            "https://dummysignaturebackend.fr/?reference=", raw_invitation_link
         )
         context_with_images = mock_generate_document.call_args.kwargs["context"]
         organization_logo = context_with_images["organization"]["logo"]
@@ -645,7 +645,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
             contract.signature_backend_reference,
             "wfl_fake_dummy_id_1",
         )
-        self.assertIn("https://dummysignaturebackend.fr/?requestToken=", invitation_url)
+        self.assertIn("https://dummysignaturebackend.fr/?reference=", invitation_url)
 
     def test_models_order_submit_for_signature_with_contract_context_has_changed_and_still_valid(
         self,
@@ -669,7 +669,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         invitation_url = order.submit_for_signature(user=order.owner)
 
         contract.refresh_from_db()
-        self.assertIn("https://dummysignaturebackend.fr/?requestToken=", invitation_url)
+        self.assertIn("https://dummysignaturebackend.fr/?reference=", invitation_url)
         self.assertIn("wfl_fake_dummy_", contract.signature_backend_reference)
         self.assertIn("fake_dummy_file_hash", contract.definition_checksum)
         self.assertIsNotNone(contract.submitted_for_signature_on)
@@ -731,7 +731,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         self.assertEqual(
             contract.context, json.loads(DjangoJSONEncoder().encode(context))
         )
-        self.assertIn("https://dummysignaturebackend.fr/?requestToken=", invitation_url)
+        self.assertIn("https://dummysignaturebackend.fr/?reference=", invitation_url)
         self.assertIn("fake_dummy_file_hash", contract.definition_checksum)
         self.assertNotEqual("wfl_fake_dummy_id_1", contract.signature_backend_reference)
         self.assertIsNotNone(contract.submitted_for_signature_on)

--- a/src/backend/joanie/tests/core/test_models_organization.py
+++ b/src/backend/joanie/tests/core/test_models_organization.py
@@ -418,7 +418,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
         (invitation_url, contract_ids) = organization.contracts_signature_link(
             user=user
         )
-        self.assertIn("https://dummysignaturebackend.fr/?requestToken=", invitation_url)
+        self.assertIn("https://dummysignaturebackend.fr/?reference=", invitation_url)
         contracts_to_sign_ids = [contract.id for contract in contracts]
         self.assertCountEqual(contracts_to_sign_ids, contract_ids)
 
@@ -453,7 +453,7 @@ class OrganizationModelsTestCase(BaseAPITestCase):
         (invitation_url, contract_ids) = organization.contracts_signature_link(
             user=user, contract_ids=contracts_to_sign_ids
         )
-        self.assertIn("https://dummysignaturebackend.fr/?requestToken=", invitation_url)
+        self.assertIn("https://dummysignaturebackend.fr/?reference=", invitation_url)
         self.assertCountEqual(contract_ids, contracts_to_sign_ids)
 
     def test_models_organization_contracts_signature_link_empty(self):

--- a/src/frontend/admin/src/components/templates/orders/view/translations.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/translations.tsx
@@ -240,6 +240,11 @@ export const orderStatesMessages = defineMessages<OrderStatesEnum>({
     defaultMessage: "To sign",
     description: "Text for to sign order state",
   },
+  signing: {
+    id: "components.templates.orders.view.orderStatesMessages.signing",
+    defaultMessage: "Signing",
+    description: "Text for signing order state",
+  },
   pending: {
     id: "components.templates.orders.view.orderStatesMessages.pending",
     defaultMessage: "Pending",

--- a/src/frontend/admin/src/services/api/models/Order.ts
+++ b/src/frontend/admin/src/services/api/models/Order.ts
@@ -107,6 +107,7 @@ export enum OrderStatesEnum {
   ORDER_STATE_ASSIGNED = "assigned", // order has been assigned to an organization
   ORDER_STATE_TO_SAVE_PAYMENT_METHOD = "to_save_payment_method", // order needs a payment method
   ORDER_STATE_TO_SIGN = "to_sign", // order needs a contract signature
+  ORDER_STATE_SIGNING = "signing", // order is pending for contract signature validation
   ORDER_STATE_PENDING = "pending", // payment has failed but can be retried
   ORDER_STATE_CANCELED = "canceled", // has been canceled
   ORDER_STATE_PENDING_PAYMENT = "pending_payment", // payment is pending


### PR DESCRIPTION
## Purpose

1. We recently remove the automatic update of contract when an API consumer request
 an invitation link with the dummy signature backend. That means now, the API
 consumer has to call manually the notification endpoint to confirm the
 signature but some information where missing to update properly the contract,
 so we complete the invitation_link method to bind missing information.

2. Then we recently add a new order state: "signing". But we do not update the admin
application accordingly, so order views were broken when a signing order must be
 displayed.


## Proposal

- [x] Complete dummy signature backend
- [x] Manage signing order state into BO
