### PR TITLE
👔(backend) update condition to transition order to pending_payment

### DIFF
--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -781,10 +781,13 @@ class OrderGeneratorFactory(factory.django.DjangoModelFactory):
             )
             submitted_for_signature_on = kwargs.get(
                 "submitted_for_signature_on",
-                django_timezone.now() if not organization_signed_on else None,
+                django_timezone.now()
+                if student_signed_on and not organization_signed_on
+                else None,
             )
             definition_checksum = kwargs.get(
-                "definition_checksum", "fake_test_file_hash_1" if is_signed else None
+                "definition_checksum",
+                "fake_test_file_hash_1" if is_signed else None,
             )
             signature_backend_reference = kwargs.get(
                 "signature_backend_reference",
@@ -899,7 +902,7 @@ class OrderGeneratorFactory(factory.django.DjangoModelFactory):
             if target_state == enums.ORDER_STATE_NO_PAYMENT:
                 self.payment_schedule[0]["state"] = enums.PAYMENT_STATE_REFUSED
             if target_state == enums.ORDER_STATE_FAILED_PAYMENT:
-                self.flow.update()
+                self.state = target_state
                 self.payment_schedule[0]["state"] = enums.PAYMENT_STATE_PAID
                 self.payment_schedule[1]["state"] = enums.PAYMENT_STATE_REFUSED
             if target_state == enums.ORDER_STATE_COMPLETED:

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -836,7 +836,8 @@ class OrderGeneratorFactory(factory.django.DjangoModelFactory):
             self.target_courses.set(extracted)
 
     @factory.post_generation
-    # pylint: disable=unused-argument
+    # pylint: disable=unused-argument, too-many-branches
+    # ruff: noqa: PLR0912
     def billing_address(self, create, extracted, **kwargs):
         """
         Create a billing address for the order.
@@ -873,7 +874,11 @@ class OrderGeneratorFactory(factory.django.DjangoModelFactory):
                 self.init_flow(billing_address=BillingAddressDictFactory())
 
         if target_state == enums.ORDER_STATE_SIGNING:
-            self.submit_for_signature(self.owner)
+            if not self.contract.submitted_for_signature_on:
+                self.submit_for_signature(self.owner)
+            else:
+                self.state = target_state
+                self.save()
 
         if (
             not self.is_free

--- a/src/backend/joanie/core/flows/order.py
+++ b/src/backend/joanie/core/flows/order.py
@@ -166,12 +166,16 @@ class OrderFlow:
 
     def _can_be_state_pending_payment(self):
         """
-        An order state can be set to pending_payment if no installment
-        is refused.
+        An order state can be set to pending_payment if the first installment
+        is paid and all others are not refused.
         """
-        return not any(
-            installment.get("state") in [enums.PAYMENT_STATE_REFUSED]
-            for installment in self.instance.payment_schedule
+
+        [first_installment_state, *other_installments_states] = [
+            installment.get("state") for installment in self.instance.payment_schedule
+        ]
+
+        return first_installment_state == enums.PAYMENT_STATE_PAID and not any(
+            state == enums.PAYMENT_STATE_REFUSED for state in other_installments_states
         )
 
     @state.transition(

--- a/src/backend/joanie/core/flows/order.py
+++ b/src/backend/joanie/core/flows/order.py
@@ -49,9 +49,13 @@ class OrderFlow:
     def _can_be_state_to_save_payment_method(self):
         """
         An order state can be set to_save_payment_method if the order is not free
-        and has no payment method.
+        has no payment method and no contract to sign.
         """
-        return not self.instance.is_free and not self.instance.has_payment_method
+        return (
+            not self.instance.is_free
+            and not self.instance.has_payment_method
+            and not self.instance.has_unsigned_contract
+        )
 
     @state.transition(
         source=[
@@ -71,7 +75,10 @@ class OrderFlow:
         """
         An order state can be set to to_sign if the order has an unsigned contract.
         """
-        return self.instance.has_unsigned_contract
+        return (
+            self.instance.has_unsigned_contract
+            and not self.instance.has_submitted_contract
+        )
 
     @state.transition(
         source=[enums.ORDER_STATE_ASSIGNED, enums.ORDER_STATE_SIGNING],

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -979,7 +979,7 @@ class Order(BaseModel):
             )
             raise ValidationError(message)
 
-        if self.state != enums.ORDER_STATE_TO_SIGN:
+        if self.state not in [enums.ORDER_STATE_TO_SIGN, enums.ORDER_STATE_SIGNING]:
             message = "Cannot submit an order that is not to sign."
             logger.error(message, extra={"context": {"order": self.to_dict()}})
             raise ValidationError(message)

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -601,10 +601,21 @@ class Order(BaseModel):
     @property
     def has_contract(self):
         """
-        Return True if the order has an unsigned contract.
+        Return True if the order has a contract.
         """
         try:
             return self.contract is not None  # pylint: disable=no-member
+        except Contract.DoesNotExist:
+            return False
+
+    @property
+    def has_submitted_contract(self):
+        """
+        Return True if the order has a submitted contract.
+        Which means a contract in the process of being signed
+        """
+        try:
+            return self.contract.submitted_for_signature_on is not None  # pylint: disable=no-member
         except Contract.DoesNotExist:
             return False
 

--- a/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
@@ -94,7 +94,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
                 )
                 content = response.json()
 
-                if state == enums.ORDER_STATE_TO_SIGN:
+                if state in [enums.ORDER_STATE_TO_SIGN, enums.ORDER_STATE_SIGNING]:
                     self.assertEqual(response.status_code, HTTPStatus.OK)
                     self.assertIsNotNone(content.get("invitation_link"))
                 elif state in [enums.ORDER_STATE_DRAFT, enums.ORDER_STATE_ASSIGNED]:
@@ -203,7 +203,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         In return we must have in the response the invitation link to sign the file.
         """
         order = factories.OrderGeneratorFactory(
-            state=enums.ORDER_STATE_TO_SIGN,
+            state=enums.ORDER_STATE_SIGNING,
             contract__submitted_for_signature_on=django_timezone.now()
             - timedelta(days=16),
             contract__signature_backend_reference="wfl_fake_dummy_id_will_be_updated",
@@ -244,7 +244,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         response in return.
         """
         order = factories.OrderGeneratorFactory(
-            state=enums.ORDER_STATE_TO_SIGN,
+            state=enums.ORDER_STATE_SIGNING,
             contract__submitted_for_signature_on=django_timezone.now()
             - timedelta(days=2),
             contract__signature_backend_reference="wfl_fake_dummy_id",

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -545,7 +545,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
             with self.subTest(state=state):
                 order = factories.OrderGeneratorFactory(owner=user, state=state)
 
-                if state == enums.ORDER_STATE_TO_SIGN:
+                if state in [enums.ORDER_STATE_TO_SIGN, enums.ORDER_STATE_SIGNING]:
                     order.submit_for_signature(user=user)
                 else:
                     with (
@@ -619,7 +619,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         'signature_backend_reference' of the contract.
         """
         order = factories.OrderGeneratorFactory(
-            state=enums.ORDER_STATE_TO_SIGN,
+            state=enums.ORDER_STATE_SIGNING,
             contract__signature_backend_reference="wfl_fake_dummy_id_1",
             contract__definition_checksum="fake_dummy_file_hash_1",
             contract__context="content",
@@ -658,7 +658,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         'signature_backend_reference'
         """
         order = factories.OrderGeneratorFactory(
-            state=enums.ORDER_STATE_TO_SIGN,
+            state=enums.ORDER_STATE_SIGNING,
             contract__signature_backend_reference="wfl_fake_dummy_id_123",
             contract__definition_checksum="fake_test_file_hash_1",
             contract__context="content",
@@ -697,7 +697,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         """
         user = factories.UserFactory()
         order = factories.OrderFactory(
-            state=enums.ORDER_STATE_ASSIGNED,
+            state=enums.ORDER_STATE_TO_SIGN,
             owner=user,
             product__contract_definition=factories.ContractDefinitionFactory(),
             product__target_courses=[

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -1042,6 +1042,39 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         )
         self.assertFalse(order.has_payment_method)
 
+    def test_models_order_has_submitted_contract(self):
+        """
+        Check that the `has_submitted_contract` property returns True if the order has a
+        submitted contract.
+        """
+        order = factories.OrderFactory()
+        factories.ContractFactory(
+            order=order,
+            definition=factories.ContractDefinitionFactory(),
+            submitted_for_signature_on=datetime(2023, 9, 20, 8, 0, tzinfo=timezone.utc),
+        )
+        self.assertTrue(order.has_submitted_contract)
+
+    def test_models_order_has_submitted_contract_not_submitted(self):
+        """
+        Check that the `has_submitted_contract` property returns True if the order has a
+        submitted contract.
+        """
+        order = factories.OrderFactory()
+        factories.ContractFactory(
+            order=order,
+            definition=factories.ContractDefinitionFactory(),
+        )
+        self.assertFalse(order.has_submitted_contract)
+
+    def test_models_order_has_submitted_contract_no_contract(self):
+        """
+        Check that the `has_submitted_contract` property returns True if the order has a
+        submitted contract.
+        """
+        order = factories.OrderFactory()
+        self.assertFalse(order.has_submitted_contract)
+
     def test_models_order_has_unsigned_contract(self):
         """
         Check that the `has_unsigned_contract` property returns True


### PR DESCRIPTION
## Purpose

Currently, an order in pending state is able to transition to pending_payment once no installment has been refused. That means we are able to transition to this state order to which we never try to pay an installment that is weird. Indeed, only orders with the first installment paid and all others installment not refused should be allowed to transition to pending_payment state
