### PR TITLE
⬆️(backend) upgrade Weasyprint to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Joanie, power up Richie catalog
 
 # ---- base image to inherit from ----
-FROM python:3.10-slim-bullseye as base
+FROM python:3.10-slim-bullseye AS base
 
 # Upgrade pip to its latest release to speed up dependencies installation
 RUN python -m pip install --upgrade pip
@@ -12,7 +12,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 # ---- Back-end builder image ----
-FROM base as back-builder
+FROM base AS back-builder
 
 WORKDIR /builder
 
@@ -24,7 +24,7 @@ RUN mkdir /install && \
 
 
 # ---- mails ----
-FROM node:16 as mail-builder
+FROM node:16 AS mail-builder
 
 COPY ./src/mail /mail/app
 
@@ -35,7 +35,7 @@ RUN yarn install --frozen-lockfile && \
 
 
 # ---- static link collector ----
-FROM base as link-collector
+FROM base AS link-collector
 ARG JOANIE_STATIC_ROOT=/data/static
 
 # Install libpangocairo & rdfind
@@ -62,7 +62,7 @@ RUN DJANGO_CONFIGURATION=Build DJANGO_JWT_PRIVATE_SIGNING_KEY=Dummy \
 RUN rdfind -makesymlinks true -followsymlinks true -makeresultsfile false ${JOANIE_STATIC_ROOT}
 
 # ---- Core application image ----
-FROM base as core
+FROM base AS core
 
 ENV PYTHONUNBUFFERED=1
 
@@ -97,7 +97,7 @@ WORKDIR /app
 ENTRYPOINT [ "/usr/local/bin/entrypoint" ]
 
 # ---- Development image ----
-FROM core as development
+FROM core AS development
 
 # Switch back to the root user to install development dependencies
 USER root:root
@@ -125,7 +125,7 @@ ENV DB_HOST=postgresql \
 CMD python manage.py runserver 0.0.0.0:8000
 
 # ---- Production image ----
-FROM core as production
+FROM core AS production
 
 ARG JOANIE_STATIC_ROOT=/data/static
 

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,7 @@
       ],
       "matchPackageNames": [
         "hashids",
-        "PyMongo",
-        "WeasyPrint"
+        "PyMongo"
       ]
     },
     {

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "stockholm==0.5.7",
     "timedelta-isoformat==0.6.2.11",
     "url-normalize==1.4.3",
-    "WeasyPrint>=60.2,<62",
+    "WeasyPrint==62.3",
     "workalendar==17.0.0",
     "whitenoise==6.7.0",
     # edx_imports


### PR DESCRIPTION
## Purpose

Upgrade Weasyprint to version 62.