### PR TITLE
🐛(edx_imports) fix signatories retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix signatories retrieval logic in edx certificate import
+
 ## [2.5.1] - 2024-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add management command to fix imported certificates without signatory
+
 ### Fixed
 
 - Fix signatories retrieval logic in edx certificate import

--- a/src/backend/joanie/edx_imports/management/commands/populate_certificate_signatory.py
+++ b/src/backend/joanie/edx_imports/management/commands/populate_certificate_signatory.py
@@ -1,0 +1,66 @@
+"""populate_certificate_signatory command module"""
+
+import logging
+
+from django.core.management import BaseCommand
+
+from joanie.edx_imports.checks import (
+    check_import_db_connections,
+    check_import_env,
+    check_openedx_host,
+)
+from joanie.edx_imports.tasks import populate_signatory_certificates_task
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Retrieve certificate without signatory then try to populate missing signatory"""
+
+    def add_arguments(self, parser):
+        """Add arguments to the command"""
+        parser.add_argument(
+            "--skip-check",
+            action="store_true",
+            default=False,
+            help="Skip check the env vars and db connections",
+        )
+        parser.add_argument(
+            "--id",
+            type=str,
+            help="To populate signatory for a specific certificate",
+        )
+        parser.add_argument(
+            "--course-id",
+            type=str,
+            help="To populate signatory for all certificates of a specific course",
+        )
+
+    def handle(self, *args, **options):
+        """Handle the command"""
+
+        skip_check = options.get("skip_check")
+        certificate_id = options.get("id")
+        course_id = options.get("course_id")
+
+        if not skip_check:
+            logger.info("Checking the environment and database connections...")
+            check_result = check_import_env(self.style)
+            check_result = check_openedx_host(self.style) and check_result
+            check_result = check_import_db_connections(self.style) and check_result
+            if not check_result:
+                logger.error(self.style.ERROR("\nCheck failed"))
+                continue_import = input(
+                    "\nDo you want to continue importing data? (yes/no): "
+                )
+                if continue_import.lower() not in ["yes", "y"]:
+                    return
+                logger.warning(
+                    self.style.WARNING("Continuing import despite failed checks")
+                )
+
+        populate_signatory_certificates_task.delay(
+            certificate_id=certificate_id, course_id=course_id
+        )
+
+        logger.info("Populate signatory certificates tasks launched")

--- a/src/backend/joanie/edx_imports/tasks/__init__.py
+++ b/src/backend/joanie/edx_imports/tasks/__init__.py
@@ -1,6 +1,9 @@
 """Module for importing tasks."""
 
-from .certificates import import_certificates_batch_task
+from .certificates import (
+    import_certificates_batch_task,
+    populate_signatory_certificates_task,
+)
 from .course_runs import import_course_runs_batch_task
 from .enrollments import import_enrollments_batch_task
 from .universities import import_universities_batch_task

--- a/src/backend/joanie/edx_imports/tasks/certificates.py
+++ b/src/backend/joanie/edx_imports/tasks/certificates.py
@@ -168,8 +168,8 @@ def import_certificates_batch(
 
             if edx_certificate.mode == OPENEDX_MODE_VERIFIED:
                 certificate_template = DEGREE
-                signatory = edx_mongodb.get_signature_from_enrollment(
-                    enrollment.course_run.course.code
+                signatory = edx_mongodb.get_signatory_from_course_id(
+                    edx_certificate.course_id
                 )
 
                 signature = None

--- a/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_migrate_certificates.py
@@ -53,7 +53,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         factories.CertificateDefinitionFactory.create(template=DEGREE)
         factories.CertificateDefinitionFactory.create(template=CERTIFICATE)
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @patch("joanie.core.models.Enrollment.set")
@@ -63,7 +63,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         _,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are created from the edx certificates.
@@ -105,7 +105,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -122,7 +122,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         ]
         self.assertLogsContains(logger, expected)
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @patch("joanie.core.models.Enrollment.set")
@@ -131,7 +131,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         _,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are updated from the edx certificates.
@@ -169,7 +169,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -186,7 +186,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         ]
         self.assertLogsContains(logger, expected)
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @patch("joanie.core.models.Enrollment.set")
@@ -196,7 +196,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         _,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are not created from the edx certificates if the enrollment
@@ -249,7 +249,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates_with_joanie_enrollments
         ]
@@ -269,7 +269,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         ]
         self.assertLogsContains(logger, expected)
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @patch("joanie.core.models.Enrollment.set")
@@ -279,7 +279,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         _,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are created from the edx certificates.
@@ -329,7 +329,7 @@ class MigrateOpenEdxCertificatesTestCase(MigrateOpenEdxBaseTestCase):
         mock_get_certificates.side_effect = get_edx_certificates
         mock_get_certificates_count.return_value = 10
 
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]

--- a/src/backend/joanie/tests/edx_imports/test_commands_populate_signatory_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_commands_populate_signatory_certificates.py
@@ -1,0 +1,196 @@
+# pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+"""Tests the populate_signatory_certificates command."""
+
+import os
+from os.path import dirname, join, realpath
+from unittest.mock import patch
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+from django.test import override_settings
+
+import responses
+
+from joanie.core import factories
+from joanie.core.models import DocumentImage
+from joanie.core.utils import file_checksum
+from joanie.edx_imports import edx_factories
+from joanie.tests.edx_imports.base_test_commands_migrate import (
+    MigrateOpenEdxBaseTestCase,
+)
+
+SIGNATURE_NAME = "creative_common.jpeg"
+SIGNATURE_PATH = join(dirname(realpath(__file__)), f"images/{SIGNATURE_NAME}")
+
+with open(SIGNATURE_PATH, "rb") as signature_image:
+    SIGNATURE_CONTENT = signature_image.read()
+    SIGNATURE_CHECKSUM = file_checksum(ContentFile(content=SIGNATURE_CONTENT))
+
+
+@override_settings(
+    EDX_DOMAIN="openedx.test",
+    EDX_SECRET="test",
+    EDX_TIME_ZONE="UTC",
+    STORAGES={
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+            "OPTIONS": {
+                "location": os.path.join(settings.MEDIA_ROOT, "tests"),
+                "base_url": "/media/tests/",
+            },
+        }
+    },
+)
+class PopulateSignatoryCertificatesCommandTestCase(MigrateOpenEdxBaseTestCase):
+    """Tests for the populate_signatory_certificates command."""
+
+    @patch("joanie.core.models.Enrollment.set")
+    def test_command_populate_certificate_signatory_skipped(self, _):
+        """
+        The command should skip certificates if those one have already a signatory.
+        """
+        organization = factories.OrganizationFactory()
+        certs = factories.EnrollmentCertificateFactory.create_batch(
+            3,
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+        )
+
+        with self.assertLogs() as logger:
+            call_command("populate_certificate_signatory", "--skip-check")
+
+        expected = "3 certificates processed, 0 populated, 3 skipped, 0 errors"
+
+        self.assertLogsContains(logger, [expected])
+        self.assertIsNotNone(
+            certs[0].localized_context["en-us"]["organizations"][0]["representative"]
+        )
+        self.assertIsNotNone(
+            certs[0].localized_context["en-us"]["organizations"][0]["signature_id"]
+        )
+
+    @patch("joanie.core.models.Enrollment.set")
+    def test_command_populate_certificate_signatory_filter_by_certificate_id(self, _):
+        """The command should allow to filter certificates by id."""
+        organization = factories.OrganizationFactory()
+        [cert, *_] = factories.EnrollmentCertificateFactory.create_batch(
+            3,
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+        )
+
+        with self.assertLogs() as logger:
+            call_command(
+                "populate_certificate_signatory", "--skip-check", f"--id={cert.id}"
+            )
+
+        expected = "1 certificates processed, 0 populated, 1 skipped, 0 errors"
+
+        self.assertLogsContains(logger, [expected])
+        self.assertIsNotNone(
+            cert.localized_context["en-us"]["organizations"][0]["representative"]
+        )
+        self.assertIsNotNone(
+            cert.localized_context["en-us"]["organizations"][0]["signature_id"]
+        )
+
+    @patch("joanie.core.models.Enrollment.set")
+    def test_command_populate_certificate_signatory_filter_by_course_id(self, _):
+        """The command should allow to filter certificates by course id."""
+        organization = factories.OrganizationFactory()
+        course_id = "course-v1:fun+101+run01"
+        resource_link = f"http://openedx.test/courses/{course_id}/course"
+        factories.EnrollmentCertificateFactory.create_batch(
+            3,
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+            enrollment__course_run__resource_link=resource_link,
+        )
+        factories.EnrollmentCertificateFactory.create_batch(
+            3,
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+        )
+
+        with self.assertLogs() as logger:
+            call_command(
+                "populate_certificate_signatory",
+                "--skip-check",
+                f"--course-id={course_id}",
+            )
+
+        expected = "3 certificates processed, 0 populated, 3 skipped, 0 errors"
+
+        self.assertLogsContains(logger, [expected])
+
+    @patch("joanie.core.models.Enrollment.set")
+    def test_command_populate_certificate_signatory_error(self, _):
+        """
+        The command should report an error if certificate has no organizations in its context.
+        """
+        cert = factories.EnrollmentCertificateFactory(
+            certificate_definition__template="degree",
+            enrollment__course_run__course__organizations=[],
+        )
+
+        with self.assertLogs() as logger:
+            call_command("populate_certificate_signatory", "--skip-check")
+
+        expected = "1 certificates processed, 0 populated, 0 skipped, 1 errors"
+
+        self.assertLogsContains(logger, [expected])
+        self.assertEqual(cert.localized_context["en-us"]["organizations"], [])
+
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
+    @patch("joanie.core.models.Enrollment.set")
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_command_populate_certificate_signatory_populate(
+        self, _, mock_get_signatory_from_course_id
+    ):
+        """
+        The command should populate the certificate with the signatory information if
+        some information are missing.
+        """
+        organization = factories.OrganizationFactory(representative="")
+        cert = factories.EnrollmentCertificateFactory(
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+        )
+
+        edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
+        mock_get_signatory_from_course_id.return_value = edx_mongo_signatory
+        responses.add(
+            responses.GET,
+            f"https://{settings.EDX_DOMAIN}"
+            f"{edx_mongo_signatory.get('signature_image_path')}",
+            body=SIGNATURE_CONTENT,
+        )
+
+        with self.assertLogs() as logger:
+            call_command("populate_certificate_signatory", "--skip-check")
+
+        expected = "1 certificates processed, 1 populated, 0 skipped, 0 errors"
+
+        self.assertLogsContains(logger, [expected])
+        cert.refresh_from_db()
+        self.assertEqual(
+            cert.localized_context["en-us"]["organizations"][0]["representative"],
+            edx_mongo_signatory["name"],
+        )
+        self.assertEqual(
+            cert.localized_context["en-us"]["organizations"][0][
+                "representative_profession"
+            ],
+            edx_mongo_signatory["title"],
+        )
+        signature = DocumentImage.objects.get(checksum=SIGNATURE_CHECKSUM)
+        self.assertEqual(
+            cert.localized_context["en-us"]["organizations"][0]["signature_id"],
+            str(signature.id),
+        )

--- a/src/backend/joanie/tests/edx_imports/test_edx_mongodb.py
+++ b/src/backend/joanie/tests/edx_imports/test_edx_mongodb.py
@@ -11,62 +11,99 @@ class TestGetEnrollment(TestCase):
     """Tests for the edx_mongodb module."""
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_signature_from_enrollment(self, mock_mongo_client):
-        """Test the get_signature_from_enrollment method."""
-        course_id = "test_course"
+    def test_edx_mongodb_get_signatory_from_course_id(self, mock_mongo_client):
+        """Test the get_signatory_from_course_id method."""
+        course_id = "course-v1:fun+101+run01"
         mock_mongo_client.return_value = MagicMock()
-        mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
-            "_id": {"org": "test_org", "category": "course", "course": course_id},
-            "metadata": {
-                "certificates": {"certificates": [{"signatories": ["test_signatory"]}]}
-            },
+        mock_mongo_client.return_value.edxapp.modulestore.active_versions.find_one.return_value = {
+            "versions": {"published-branch": "branch_id"},
+        }
+        mock_mongo_client.return_value.edxapp.modulestore.structures.find_one.return_value = {
+            "_id": "branch_id",
+            "blocks": [
+                {
+                    "block_type": "course",
+                    "fields": {
+                        "certificates": {
+                            "certificates": [{"signatories": ["test_signatory"]}]
+                        }
+                    },
+                }
+            ],
         }
 
-        result = edx_mongodb.get_signature_from_enrollment(course_id)
+        result = edx_mongodb.get_signatory_from_course_id(course_id)
 
         self.assertEqual(result, "test_signatory")
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_signature_from_enrollment_no_certificates(
+    def test_edx_mongodb_get_signatory_from_course_id_no_certificates(
         self, mock_mongo_client
     ):
-        """Test the get_signature_from_enrollment method when there are no certificates."""
-        course_id = "test_course"
+        """Test the get_signatory_from_course_id method when there are no certificates."""
+        course_id = "course-v1:fun+101+run01"
         mock_mongo_client.return_value = MagicMock()
-        mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
-            "_id": {"org": "test_org", "category": "course", "course": course_id},
-            "metadata": {},
+        mock_mongo_client.return_value.edxapp.modulestore.active_versions.find_one.return_value = {
+            "versions": {"published-branch": "branch_id"},
+        }
+        mock_mongo_client.return_value.edxapp.modulestore.structures.find_one.return_value = {
+            "_id": "branch_id",
+            "blocks": [],
         }
 
-        result = edx_mongodb.get_signature_from_enrollment(course_id)
+        result = edx_mongodb.get_signatory_from_course_id(course_id)
 
         self.assertEqual(result, None)
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_signature_from_enrollment_no_signatories(
+    def test_edx_mongodb_get_signatory_from_course_id_no_signatories(
         self, mock_mongo_client
     ):
-        """Test the get_signature_from_enrollment method when there are no certificates."""
-        course_id = "test_course"
+        """Test the get_signatory_from_course_id method when there are no signatories."""
+        course_id = "fun/101/run01"
         mock_mongo_client.return_value = MagicMock()
-        mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = {
-            "_id": {"org": "test_org", "category": "course", "course": course_id},
-            "metadata": {"certificates": {"certificates": []}},
+        mock_mongo_client.return_value.edxapp.modulestore.active_versions.find_one.return_value = {
+            "versions": {"published-branch": "branch_id"},
+        }
+        mock_mongo_client.return_value.edxapp.modulestore.structures.find_one.return_value = {
+            "_id": "branch_id",
+            "blocks": [
+                {
+                    "block_type": "course",
+                    "fields": {"certificates": {"certificates": [{"signatories": []}]}},
+                }
+            ],
         }
 
-        result = edx_mongodb.get_signature_from_enrollment(course_id)
+        result = edx_mongodb.get_signatory_from_course_id(course_id)
 
         self.assertEqual(result, None)
 
     @patch("joanie.edx_imports.edx_mongodb.MongoClient")
-    def test_edx_mongodb_get_signature_from_enrollment_no_result(
+    def test_edx_mongodb_get_signatory_from_course_id_no_course_block(
         self, mock_mongo_client
     ):
-        """Test the get_signature_from_enrollment method when there is no enrollment."""
-        course_id = "test_course"
+        """Test the get_signatory_from_course_id method when there is no course block."""
+        course_id = "course-v1:fun+101+run01"
         mock_mongo_client.return_value = MagicMock()
-        mock_mongo_client.return_value.edxapp.modulestore.find_one.return_value = None
+        mock_mongo_client.return_value.edxapp.modulestore.active_versions.find_one.return_value = {
+            "versions": {"published-branch": "branch_id"},
+        }
+        mock_mongo_client.return_value.edxapp.modulestore.structures.find_one.return_value = None
 
-        result = edx_mongodb.get_signature_from_enrollment(course_id)
+        result = edx_mongodb.get_signatory_from_course_id(course_id)
+
+        self.assertEqual(result, None)
+
+    @patch("joanie.edx_imports.edx_mongodb.MongoClient")
+    def test_edx_mongodb_get_signatory_from_course_id_no_result(
+        self, mock_mongo_client
+    ):
+        """Test the get_signatory_from_course_id method when there is no enrollment."""
+        course_id = "course-v1:fun+101+run01"
+        mock_mongo_client.return_value = MagicMock()
+        mock_mongo_client.return_value.edxapp.modulestore.active_versions.find_one.return_value = None  # pylint: disable=line-too-long
+
+        result = edx_mongodb.get_signatory_from_course_id(course_id)
 
         self.assertEqual(result, None)

--- a/src/backend/joanie/tests/edx_imports/test_import_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_import_certificates.py
@@ -63,7 +63,7 @@ class EdxImportCertificatesTestCase(TestCase):
         """Tear down the test case."""
         edx_factories.session.rollback()
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
@@ -71,7 +71,7 @@ class EdxImportCertificatesTestCase(TestCase):
         self,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are created from the edx certificates.
@@ -114,7 +114,7 @@ class EdxImportCertificatesTestCase(TestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -211,14 +211,14 @@ class EdxImportCertificatesTestCase(TestCase):
 
             self.assertEqual(certificate.images.count(), 2 if has_signatory else 1)
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     def test_import_certificates_update(
         self,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are updated from the edx certificates.
@@ -259,7 +259,7 @@ class EdxImportCertificatesTestCase(TestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -288,7 +288,7 @@ class EdxImportCertificatesTestCase(TestCase):
                 certificate.issued_on, make_date_aware(edx_certificate.created_date)
             )
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
@@ -296,7 +296,7 @@ class EdxImportCertificatesTestCase(TestCase):
         self,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are not created from the edx certificates if the enrollment
@@ -346,7 +346,7 @@ class EdxImportCertificatesTestCase(TestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates_with_joanie_enrollments
         ]
@@ -367,7 +367,7 @@ class EdxImportCertificatesTestCase(TestCase):
                 ).exists()
             )
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
@@ -375,7 +375,7 @@ class EdxImportCertificatesTestCase(TestCase):
         self,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that certificates are created from the edx certificates with missing signatory.
@@ -423,7 +423,7 @@ class EdxImportCertificatesTestCase(TestCase):
 
         mock_get_certificates.return_value = edx_certificates
         mock_get_certificates_count.return_value = len(edx_certificates)
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
             for edx_certificate in edx_certificates
         ]
@@ -515,7 +515,7 @@ class EdxImportCertificatesTestCase(TestCase):
                 },
             )
 
-    @patch("joanie.edx_imports.edx_mongodb.get_signature_from_enrollment")
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates_count")
     @patch("joanie.edx_imports.edx_database.OpenEdxDB.get_certificates")
     @responses.activate(assert_all_requests_are_fired=True)
@@ -523,7 +523,7 @@ class EdxImportCertificatesTestCase(TestCase):
         self,
         mock_get_certificates,
         mock_get_certificates_count,
-        mock_get_signature_from_enrollment,
+        mock_get_signatory_from_course_id,
     ):
         """
         Test that signatures are not stored if the signature is not found.
@@ -562,7 +562,7 @@ class EdxImportCertificatesTestCase(TestCase):
 
         mock_get_certificates.return_value = [edx_certificate]
         mock_get_certificates_count.return_value = 1
-        mock_get_signature_from_enrollment.side_effect = [
+        mock_get_signatory_from_course_id.side_effect = [
             mongo_enrollments[edx_certificate.id]
         ]
 

--- a/src/backend/joanie/tests/edx_imports/test_populate_signatory_certificates.py
+++ b/src/backend/joanie/tests/edx_imports/test_populate_signatory_certificates.py
@@ -1,0 +1,184 @@
+# pylint: disable=unexpected-keyword-arg,no-value-for-parameter
+"""Test case for the populate_signatory_certificates task"""
+
+import os
+import uuid
+from os.path import dirname, join, realpath
+from unittest.mock import patch
+
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.test import TestCase, override_settings
+
+import responses
+
+from joanie.core import factories
+from joanie.core.models import DocumentImage
+from joanie.core.utils import file_checksum
+from joanie.edx_imports import edx_factories
+from joanie.edx_imports.tasks import populate_signatory_certificates_task
+
+SIGNATURE_NAME = "creative_common.jpeg"
+SIGNATURE_PATH = join(dirname(realpath(__file__)), f"images/{SIGNATURE_NAME}")
+
+with open(SIGNATURE_PATH, "rb") as signature_image:
+    SIGNATURE_CONTENT = signature_image.read()
+    SIGNATURE_CHECKSUM = file_checksum(ContentFile(content=SIGNATURE_CONTENT))
+
+
+@override_settings(
+    EDX_DOMAIN="openedx.test",
+    EDX_SECRET="test",
+    EDX_TIME_ZONE="UTC",
+    STORAGES={
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+            "OPTIONS": {
+                "location": os.path.join(settings.MEDIA_ROOT, "tests"),
+                "base_url": "/media/tests/",
+            },
+        }
+    },
+)
+class PopulateSignatoryCertificatesTestCase(TestCase):
+    """Test case for the populate_signatory_certificates task"""
+
+    def test_populate_signatory_certificates_task_empty_queryset(self):
+        """If there is no certificate to process, an empty report should be returned."""
+
+        report = populate_signatory_certificates_task(certificate_id=uuid.uuid4())
+
+        self.assertEqual(
+            report, "0 certificates processed, 0 populated, 0 skipped, 0 errors"
+        )
+
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
+    @patch("joanie.core.models.Enrollment.set")
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_populate_signatory_certificates_task_retrieve_signatory_from_edx(
+        self, _, mock_get_signatory_from_course_id
+    ):
+        """The task should try to retrieve signatory from edx first."""
+        organization = factories.OrganizationFactory(signature=None)
+        cert = factories.EnrollmentCertificateFactory(
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+        )
+
+        edx_mongo_signatory = edx_factories.EdxMongoSignatoryFactory()
+        mock_get_signatory_from_course_id.return_value = edx_mongo_signatory
+
+        responses.add(
+            responses.GET,
+            f"https://{settings.EDX_DOMAIN}"
+            f"{edx_mongo_signatory.get('signature_image_path')}",
+            body=SIGNATURE_CONTENT,
+        )
+
+        report = populate_signatory_certificates_task()
+        self.assertEqual(
+            report, "1 certificates processed, 1 populated, 0 skipped, 0 errors"
+        )
+
+        cert.refresh_from_db()
+        organization_context = cert.localized_context["en-us"]["organizations"][0]
+        signature = DocumentImage.objects.get(checksum=SIGNATURE_CHECKSUM)
+        self.assertEqual(
+            organization_context["representative"], edx_mongo_signatory["name"]
+        )
+        self.assertEqual(
+            organization_context["representative_profession"],
+            edx_mongo_signatory["title"],
+        )
+        self.assertEqual(organization_context["signature_id"], str(signature.id))
+
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
+    @patch("joanie.core.models.Enrollment.set")
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_populate_signatory_certificates_task_retrieve_signatory_from_organization(
+        self, _, mock_get_signatory_from_course_id
+    ):
+        """If OpenEdX returns no signatory, we should fallback to the certificate organization."""
+        organization = factories.OrganizationFactory()
+        cert = factories.EnrollmentCertificateFactory(
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+        )
+        # Update cert localized context to remove signatory information
+        for language, _ in settings.LANGUAGES:
+            cert.localized_context[language]["organizations"][0]["representative"] = ""
+            cert.localized_context[language]["organizations"][0][
+                "representative_profession"
+            ] = ""
+            del cert.localized_context[language]["organizations"][0]["signature_id"]
+        cert.save()
+
+        mock_get_signatory_from_course_id.return_value = None
+
+        report = populate_signatory_certificates_task()
+        self.assertEqual(
+            report, "1 certificates processed, 1 populated, 0 skipped, 0 errors"
+        )
+
+        cert.refresh_from_db()
+        organization_context = cert.localized_context["en-us"]["organizations"][0]
+        signature = DocumentImage.objects.get(
+            checksum=file_checksum(organization.signature)
+        )
+        self.assertEqual(
+            organization_context["representative"], organization.representative
+        )
+        self.assertEqual(
+            organization_context["representative_profession"],
+            organization.representative_profession,
+        )
+        self.assertEqual(organization_context["signature_id"], str(signature.id))
+
+    @patch("joanie.edx_imports.edx_mongodb.get_signatory_from_course_id")
+    @patch("joanie.core.models.Enrollment.set")
+    @responses.activate(assert_all_requests_are_fired=True)
+    def test_populate_signatory_certificates_task_retrieve_signatory_from_organization_signatory(
+        self, _, mock_get_signatory_from_course_id
+    ):
+        """If an Organization has signatory name, it should be used over the representative."""
+        organization = factories.OrganizationFactory(
+            signatory_representative="John Doe",
+            signatory_representative_profession="Official signatory",
+        )
+        cert = factories.EnrollmentCertificateFactory(
+            certificate_definition__template="degree",
+            organization=organization,
+            enrollment__course_run__course__organizations=[organization],
+        )
+        # Update cert localized context to remove signatory information
+        for language, _ in settings.LANGUAGES:
+            cert.localized_context[language]["organizations"][0]["representative"] = ""
+            cert.localized_context[language]["organizations"][0][
+                "representative_profession"
+            ] = ""
+            del cert.localized_context[language]["organizations"][0]["signature_id"]
+        cert.save()
+
+        mock_get_signatory_from_course_id.return_value = None
+
+        report = populate_signatory_certificates_task()
+        self.assertEqual(
+            report, "1 certificates processed, 1 populated, 0 skipped, 0 errors"
+        )
+
+        cert.refresh_from_db()
+        organization_context = cert.localized_context["en-us"]["organizations"][0]
+        signature = DocumentImage.objects.get(
+            checksum=file_checksum(organization.signature)
+        )
+        self.assertEqual(
+            organization_context["representative"],
+            organization.signatory_representative,
+        )
+        self.assertEqual(
+            organization_context["representative_profession"],
+            organization.signatory_representative_profession,
+        )
+        self.assertEqual(organization_context["signature_id"], str(signature.id))


### PR DESCRIPTION
## Purpose

Currently, on certificate import, most of the time, we are not able to retrieve
certificate signatory. It appears that the Mongo DB request to get this data is
wrong. So we fix this method to retrieve signatory information.

## Proposal

- [x] Fix logic to retrieve signatory from open edx
- [x] Create management command to populate signatory for degree certificate without it
