### PR TITLE
🐛(backend) allow to cancel order linked to archived course run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow to cancel an enrollment order linked to an archived course run
+
 ## [2.6.1] - 2024-07-25
 
 ### Fixed

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -623,12 +623,14 @@ class Order(BaseModel):
                     )
                 )
             if (
+                not self.created_on or self.state not in [enums.ORDER_STATE_CANCELED]
+            ) and (
                 self.enrollment.course_run.course.state["priority"]
                 >= CourseState.ARCHIVED_CLOSED
             ):
                 error_dict["course"].append(
                     _(
-                        "The order cannot be generated on course run that is in archived state."
+                        "The order cannot be created on course run that is in archived state."
                     )
                 )
 


### PR DESCRIPTION
## Purpose

Currently, if an order relies on an enrollment linked to an archived course run,
 it is not possible to cancel it.