### PR TITLE
🔧(tray) add configMap env into db_migrate job

### DIFF
--- a/src/tray/templates/services/app/job_db_migrate.yml.j2
+++ b/src/tray/templates/services/app/job_db_migrate.yml.j2
@@ -45,9 +45,19 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ joanie_secret_name }}"
+            - configMapRef:
+                name: "joanie-app-dotenv-{{ deployment_stamp }}"
           command: ["python", "manage.py", "migrate"]
           resources: {{ joanie_app_job_db_migrate_resources }}
+          volumeMounts:
+            - name: joanie-configmap
+              mountPath: /app/joanie/configs
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}
+      volumes:
+        - name: joanie-configmap
+          configMap:
+            defaultMode: 420
+            name: joanie-app-{{ deployment_stamp }}


### PR DESCRIPTION
## Purpose

Currently, the env configMap volume is not mounted but we need it to be able to access to S3 Storage.