### PR TITLE
✨ (backend) Mail when installment debit has failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Send an email to the user when an installment debit has been
+  refused
 - Send an email to the user when an installment is successfully
   paid
 - Support of payment_schedule for certificate products

--- a/src/backend/joanie/core/utils/emails.py
+++ b/src/backend/joanie/core/utils/emails.py
@@ -1,0 +1,46 @@
+"""Utility to prepare email context data variables for installment payments"""
+
+from django.conf import settings
+
+from stockholm import Money
+
+from joanie.core.enums import PAYMENT_STATE_PAID, PAYMENT_STATE_REFUSED
+
+
+def prepare_context_data(
+    order, installment_amount, product_title, payment_refused: bool
+):
+    """
+    Prepare the context variables for the email when an installment has been paid
+    or refused.
+    """
+    context_data = {
+        "fullname": order.owner.get_full_name() or order.owner.username,
+        "email": order.owner.email,
+        "product_title": product_title,
+        "installment_amount": Money(installment_amount),
+        "product_price": Money(order.product.price),
+        "credit_card_last_numbers": order.credit_card.last_numbers,
+        "order_payment_schedule": order.payment_schedule,
+        "dashboard_order_link": (
+            settings.JOANIE_DASHBOARD_ORDER_LINK.replace(":orderId", str(order.id))
+        ),
+        "site": {
+            "name": settings.JOANIE_CATALOG_NAME,
+            "url": settings.JOANIE_CATALOG_BASE_URL,
+        },
+        "targeted_installment_index": (
+            order.get_index_of_last_installment(state=PAYMENT_STATE_REFUSED)
+            if payment_refused
+            else order.get_index_of_last_installment(state=PAYMENT_STATE_PAID)
+        ),
+    }
+
+    if not payment_refused:
+        variable_context_part = {
+            "remaining_balance_to_pay": order.get_remaining_balance_to_pay(),
+            "date_next_installment_to_pay": order.get_date_next_installment_to_pay(),
+        }
+        context_data.update(variable_context_part)
+
+    return context_data

--- a/src/backend/joanie/debug/urls.py
+++ b/src/backend/joanie/debug/urls.py
@@ -12,6 +12,8 @@ from joanie.debug.views import (
     DebugInvoiceTemplateView,
     DebugMailAllInstallmentPaidViewHtml,
     DebugMailAllInstallmentPaidViewTxt,
+    DebugMailInstallmentRefusedPaymentViewHtml,
+    DebugMailInstallmentRefusedPaymentViewTxt,
     DebugMailSuccessInstallmentPaidViewHtml,
     DebugMailSuccessInstallmentPaidViewTxt,
     DebugMailSuccessPaymentViewHtml,
@@ -74,5 +76,15 @@ urlpatterns = [
         "__debug__/mail/installments-fully-paid-txt",
         DebugMailAllInstallmentPaidViewTxt.as_view(),
         name="debug.mail.installments_fully_paid_txt",
+    ),
+    path(
+        "__debug__/mail/installment-refused-html",
+        DebugMailInstallmentRefusedPaymentViewHtml.as_view(),
+        name="debug.mail.installment_refused_html",
+    ),
+    path(
+        "__debug__/mail/installment-refused-txt",
+        DebugMailInstallmentRefusedPaymentViewTxt.as_view(),
+        name="debug.mail.installment_refused_txt",
     ),
 ]

--- a/src/backend/joanie/debug/views.py
+++ b/src/backend/joanie/debug/views.py
@@ -25,6 +25,7 @@ from joanie.core.enums import (
     DEGREE,
     ORDER_STATE_PENDING_PAYMENT,
     PAYMENT_STATE_PAID,
+    PAYMENT_STATE_REFUSED,
 )
 from joanie.core.factories import (
     OrderGeneratorFactory,
@@ -189,6 +190,39 @@ class DebugMailAllInstallmentPaidViewTxt(DebugMailAllInstallmentPaid):
     in txt format."""
 
     template_name = "mail/text/installments_fully_paid.txt"
+
+
+class DebugMailInstallmentRefusedPayment(DebugMailInstallmentPayment):
+    """Debug View to check the layout of when an installment debit is refused by email"""
+
+    def get_context_data(self, **kwargs):
+        """
+        Base method to prepare the document context to render in the email for the debug view.
+        """
+
+        context = super().get_context_data()
+        order = context.get("order")
+        order.payment_schedule[2]["state"] = PAYMENT_STATE_REFUSED
+        context["targeted_installment_index"] = order.get_index_of_last_installment(
+            state=PAYMENT_STATE_REFUSED
+        )
+        context["installment_amount"] = Money(order.payment_schedule[2]["amount"])
+
+        return context
+
+
+class DebugMailInstallmentRefusedPaymentViewHtml(DebugMailInstallmentRefusedPayment):
+    """Debug View to check the layout of when an installment debit is refused by email
+    in html format."""
+
+    template_name = "mail/html/installment_refused.html"
+
+
+class DebugMailInstallmentRefusedPaymentViewTxt(DebugMailInstallmentRefusedPayment):
+    """Debug View to check the layout of when an installment debit is refused by email
+    in txt format."""
+
+    template_name = "mail/text/installment_refused.txt"
 
 
 class DebugPdfTemplateView(TemplateView):

--- a/src/backend/joanie/payment/backends/dummy.py
+++ b/src/backend/joanie/payment/backends/dummy.py
@@ -128,6 +128,11 @@ class DummyPaymentBackend(BasePaymentBackend):
             order=order, amount=amount, upcoming_installment=upcoming_installment
         )
 
+    @classmethod
+    def _send_mail_refused_debit(cls, order, installment_id):
+        logger.info("Mail is sent to %s from dummy payment", order.owner.email)
+        super()._send_mail_refused_debit(order, installment_id)
+
     def _get_payment_data(
         self,
         order,

--- a/src/backend/joanie/tests/core/models/order/test_schedule.py
+++ b/src/backend/joanie/tests/core/models/order/test_schedule.py
@@ -1333,9 +1333,11 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
 
         self.assertEqual(str(remains), "499.99")
 
-    def test_models_order_get_position_last_paid_installment(self):
-        """Should return the position of the last installment paid from the payment schedule."""
-
+    def test_models_order_get_index_of_last_installment_with_paid_state(self):
+        """
+        Should return the index of the last installment with state 'paid'
+        from the payment schedule.
+        """
         order = factories.OrderFactory(
             state=ORDER_STATE_PENDING_PAYMENT,
             payment_schedule=[
@@ -1380,4 +1382,43 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
 
         self.assertEqual(
             2, order.get_index_of_last_installment(state=PAYMENT_STATE_PAID)
+        )
+
+    def test_models_order_get_index_of_last_installment_state_refused(self):
+        """
+        Should return the index of the last installment with state 'refused'
+        from the payment schedule.
+        """
+        order = factories.OrderFactory(
+            state=ORDER_STATE_PENDING_PAYMENT,
+            payment_schedule=[
+                {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+                    "amount": "200.00",
+                    "due_date": "2024-01-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "300.00",
+                    "due_date": "2024-02-17",
+                    "state": PAYMENT_STATE_REFUSED,
+                },
+                {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
+                    "amount": "300.00",
+                    "due_date": "2024-03-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+                {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
+                    "amount": "199.99",
+                    "due_date": "2024-04-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        self.assertEqual(
+            1, order.get_index_of_last_installment(state=PAYMENT_STATE_REFUSED)
         )

--- a/src/backend/joanie/tests/core/utils/test_emails_prepare_context_data.py
+++ b/src/backend/joanie/tests/core/utils/test_emails_prepare_context_data.py
@@ -1,0 +1,172 @@
+"""Test suite for `prepare_context_data` email utility for installment payments"""
+
+from decimal import Decimal
+
+from django.test import TestCase, override_settings
+
+from stockholm import Money
+
+from joanie.core.enums import (
+    ORDER_STATE_PENDING_PAYMENT,
+    PAYMENT_STATE_PAID,
+    PAYMENT_STATE_PENDING,
+    PAYMENT_STATE_REFUSED,
+)
+from joanie.core.factories import OrderFactory, ProductFactory, UserFactory
+from joanie.core.utils.emails import prepare_context_data
+
+
+@override_settings(
+    JOANIE_CATALOG_NAME="Test Catalog",
+    JOANIE_CATALOG_BASE_URL="https://richie.education",
+)
+class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
+    """
+    Test suite for `prepare_context_data` for email utility when installment is paid or refused
+    """
+
+    def test_utils_emails_prepare_context_data_when_installment_debit_is_successful(
+        self,
+    ):
+        """
+        When an installment is successfully paid, the `prepare_context_data` method should
+        create the context with the following keys : `fullname`, `email`, `product_title`,
+        `installment_amount`, `product_price`, `credit_card_last_numbers`,
+        `order_payment_schedule`, `dashboard_order_link`, `site`, `remaining_balance_to_pay`,
+        `date_next_installment_to_pay`, and `targeted_installment_index`.
+        """
+        product = ProductFactory(price=Decimal("1000.00"), title="Product 1")
+        order = OrderFactory(
+            product=product,
+            state=ORDER_STATE_PENDING_PAYMENT,
+            owner=UserFactory(
+                first_name="John",
+                last_name="Doe",
+                language="en-us",
+                email="johndoe@fun-test.fr",
+            ),
+            payment_schedule=[
+                {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+                    "amount": "200.00",
+                    "due_date": "2024-01-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "300.00",
+                    "due_date": "2024-02-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
+                    "amount": "300.00",
+                    "due_date": "2024-03-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+                {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
+                    "amount": "199.99",
+                    "due_date": "2024-04-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        context_data = prepare_context_data(
+            order, Money("300.00"), product.title, payment_refused=False
+        )
+
+        self.assertDictEqual(
+            context_data,
+            {
+                "fullname": "John Doe",
+                "email": "johndoe@fun-test.fr",
+                "product_title": "Product 1",
+                "installment_amount": Money("300.00"),
+                "product_price": Money("1000.00"),
+                "credit_card_last_numbers": order.credit_card.last_numbers,
+                "order_payment_schedule": order.payment_schedule,
+                "dashboard_order_link": (
+                    f"http://localhost:8070/dashboard/courses/orders/{order.id}/"
+                ),
+                "site": {
+                    "name": "Test Catalog",
+                    "url": "https://richie.education",
+                },
+                "remaining_balance_to_pay": Money("499.99"),
+                "date_next_installment_to_pay": "2024-03-17",
+                "targeted_installment_index": 1,
+            },
+        )
+
+    def test_utils_emails_prepare_context_data_when_installment_debit_is_refused(self):
+        """
+        When an installment debit has been refused, the `prepare_context_data` method should
+        create the context and we should not find the following keys : `remaining_balance_to_pay`,
+        and `date_next_installment_to_pay`.
+        """
+        product = ProductFactory(price=Decimal("1000.00"), title="Product 1")
+        order = OrderFactory(
+            product=product,
+            state=ORDER_STATE_PENDING_PAYMENT,
+            owner=UserFactory(
+                first_name="John",
+                last_name="Doe",
+                language="en-us",
+                email="johndoe@fun-test.fr",
+            ),
+            payment_schedule=[
+                {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+                    "amount": "200.00",
+                    "due_date": "2024-01-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "300.00",
+                    "due_date": "2024-02-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
+                    "amount": "300.00",
+                    "due_date": "2024-03-17",
+                    "state": PAYMENT_STATE_REFUSED,
+                },
+                {
+                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
+                    "amount": "199.99",
+                    "due_date": "2024-04-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        context_data = prepare_context_data(
+            order, Money("300.00"), product.title, payment_refused=True
+        )
+
+        self.assertNotIn("remaining_balance_to_pay", context_data)
+        self.assertNotIn("date_next_installment_to_pay", context_data)
+        self.assertDictEqual(
+            context_data,
+            {
+                "fullname": "John Doe",
+                "email": "johndoe@fun-test.fr",
+                "product_title": "Product 1",
+                "installment_amount": Money("300.00"),
+                "product_price": Money("1000.00"),
+                "credit_card_last_numbers": order.credit_card.last_numbers,
+                "order_payment_schedule": order.payment_schedule,
+                "dashboard_order_link": (
+                    f"http://localhost:8070/dashboard/courses/orders/{order.id}/"
+                ),
+                "site": {
+                    "name": "Test Catalog",
+                    "url": "https://richie.education",
+                },
+                "targeted_installment_index": 2,
+            },
+        )

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -447,8 +447,8 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
         # - Payment has failed gracefully and changed order state to no payment
         self.assertEqual(order.state, enums.ORDER_STATE_NO_PAYMENT)
 
-        # - No email has been sent
-        self.assertEqual(len(mail.outbox), 0)
+        # - An email should be sent mentioning the payment failure
+        self._check_installment_refused_email_sent(order.owner.email, order)
 
         # - An event has been created
         self.assertPaymentFailedActivityLog(order)
@@ -530,9 +530,8 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
             ],
         )
 
-        # - No email has been sent
-        self.assertEqual(len(mail.outbox), 0)
-
+        # - An email should be sent mentioning the payment failure
+        self._check_installment_refused_email_sent(order.owner.email, order)
         # - An event has been created
         self.assertPaymentFailedActivityLog(order)
 
@@ -1148,3 +1147,91 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
         # because there is no translation in german for the product title
         email_content = " ".join(mail.outbox[0].body.split())
         self.assertIn("Product 1", email_content)
+
+    @override_settings(
+        LANGUAGES=(
+            ("en-us", ("English")),
+            ("fr-fr", ("French")),
+            ("de-de", ("German")),
+        )
+    )
+    def test_payment_backend_base_mail_sent_on_installment_payment_failure_in_french(
+        self,
+    ):
+        """
+        When an installment debit has been refused an email should be sent
+        with the information about the payment failure in the current language
+        of the user.
+        """
+        backend = TestBasePaymentBackend()
+        product = ProductFactory(title="Product 1", price=Decimal("149.00"))
+        product.translations.create(language_code="fr-fr", title="Produit 1")
+        order = OrderFactory(
+            state=enums.ORDER_STATE_PENDING,
+            product=product,
+            owner=UserFactory(
+                email="sam@fun-test.fr",
+                language="fr-fr",
+                first_name="John",
+                last_name="Doe",
+            ),
+            payment_schedule=[
+                {
+                    "id": "3d0efbff-6b09-4fb4-82ce-54b6bb57a809",
+                    "amount": "149.00",
+                    "due_date": "2024-08-07",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        backend.call_do_on_payment_failure(
+            order, installment_id="3d0efbff-6b09-4fb4-82ce-54b6bb57a809"
+        )
+
+        self.assertEqual(order.state, enums.ORDER_STATE_NO_PAYMENT)
+        self._check_installment_refused_email_sent("sam@fun-test.fr", order)
+
+    @override_settings(
+        LANGUAGES=(
+            ("en-us", ("English")),
+            ("fr-fr", ("French")),
+            ("de-de", ("German")),
+        )
+    )
+    def test_payment_backend_base_mail_sent_on_installment_payment_failure_use_fallback_language(
+        self,
+    ):
+        """
+        If the translation of the product title does not exists, it should use the fallback
+        language that is english.
+        """
+        backend = TestBasePaymentBackend()
+        product = ProductFactory(title="Product 1", price=Decimal("150.00"))
+        # Create on purpose another translation of the product title that is not the user language
+        product.translations.create(language_code="fr-fr", title="Produit 1")
+        order = OrderFactory(
+            state=enums.ORDER_STATE_PENDING,
+            product=product,
+            owner=UserFactory(
+                email="sam@fun-test.fr",
+                language="de-de",
+                first_name="John",
+                last_name="Doe",
+            ),
+            payment_schedule=[
+                {
+                    "id": "3d0efbff-6b09-4fb4-82ce-54b6bb57a809",
+                    "amount": "150.00",
+                    "due_date": "2024-08-07",
+                    "state": enums.PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        backend.call_do_on_payment_failure(
+            order, installment_id="3d0efbff-6b09-4fb4-82ce-54b6bb57a809"
+        )
+
+        self.assertEqual(order.state, enums.ORDER_STATE_NO_PAYMENT)
+        self._check_installment_refused_email_sent("sam@fun-test.fr", order)

--- a/src/backend/joanie/tests/payment/test_backend_lyra.py
+++ b/src/backend/joanie/tests/payment/test_backend_lyra.py
@@ -1016,7 +1016,7 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
     ):
         """
         When backend receives a payment notification which failed, the generic
-        method `_do_on_failure` should be called.
+        method `_do_on_payment_failure` should be called.
         """
         backend = LyraBackend(self.configuration)
         order = OrderGeneratorFactory(
@@ -1534,3 +1534,184 @@ class LyraBackendTestCase(BasePaymentTestCase, BaseLogMixinTestCase):
             ),
         ]
         self.assertLogsEquals(logger.records, expected_logs)
+
+    @patch.object(BasePaymentBackend, "_send_mail_refused_debit")
+    def test_payment_backend_lyra_handle_notification_payment_failure_sends_email(
+        self, mock_send_mail_refused_debit
+    ):
+        """
+        When backend receives a payment notification which failed, the generic
+        method `_do_on_payment_failure` should be called and it must also call
+        the method responsible to send the email to the user.
+        """
+        backend = LyraBackend(self.configuration)
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="en-us",
+            email="john.doe@acme.org",
+        )
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product__price=D("123.45"),
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        with self.open("lyra/requests/payment_refused.json") as file:
+            json_request = json.loads(file.read())
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data=json_request, format="multipart"
+        )
+
+        backend.handle_notification(request)
+
+        mock_send_mail_refused_debit.assert_called_once_with(
+            order, first_installment["id"]
+        )
+
+    def test_payment_backend_lyra_handle_notification_payment_failure_send_mail_in_user_language(
+        self,
+    ):
+        """
+        When backend receives a payment notification which failed, the generic
+        method `_do_on_payment_failure` should be called and the email must be sent
+        in the preferred language of the user.
+        """
+        backend = LyraBackend(self.configuration)
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="en-us",
+            email="john.doe@acme.org",
+        )
+        product = ProductFactory(price=D("1000.00"), title="Product 1")
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product=product,
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        with self.open("lyra/requests/payment_refused.json") as file:
+            json_request = json.loads(file.read())
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data=json_request, format="multipart"
+        )
+
+        backend.handle_notification(request)
+
+        email_content = " ".join(mail.outbox[0].body.split())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to[0], "john.doe@acme.org")
+        self.assertIn(
+            "An installment debit has failed",
+            mail.outbox[0].subject,
+        )
+        self.assertIn("Product 1", email_content)
+        self.assertIn("installment debit has failed", email_content)
+
+    def test_payment_backend_lyra_payment_failure_send_mail_in_user_language_that_is_french(
+        self,
+    ):
+        """
+        When backend receives a payment notification which failed, the generic
+        method `_do_on_payment_failure` should be called and the email must be sent
+        in the preferred language of the user. In our case, it will be the French language.
+        """
+        backend = LyraBackend(self.configuration)
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="fr-fr",
+            email="john.doe@acme.org",
+        )
+        product = ProductFactory(price=D("1000.00"), title="Product 1")
+        product.translations.create(language_code="fr-fr", title="Produit 1")
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product=product,
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        with self.open("lyra/requests/payment_refused.json") as file:
+            json_request = json.loads(file.read())
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data=json_request, format="multipart"
+        )
+
+        backend.handle_notification(request)
+
+        email_content = " ".join(mail.outbox[0].body.split())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to[0], "john.doe@acme.org")
+        self.assertIn("Produit 1", email_content)
+
+    @override_settings(
+        LANGUAGES=(
+            ("en-us", ("English")),
+            ("fr-fr", ("French")),
+            ("de-de", ("German")),
+        )
+    )
+    def test_payment_backend_lyra_payment_failure_send_mail_use_fallback_language_translation(
+        self,
+    ):
+        """
+        When backend receives a payment notification which failed, the generic
+        method `_do_on_payment_failure` should be called and the email must be sent
+        in the fallback language if the translation does not exist.
+        """
+        backend = LyraBackend(self.configuration)
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="de-de",
+            email="john.doe@acme.org",
+        )
+        product = ProductFactory(price=D("1000.00"), title="Product 1")
+        product.translations.create(language_code="fr-fr", title="Produit 1")
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product=product,
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        with self.open("lyra/requests/payment_refused.json") as file:
+            json_request = json.loads(file.read())
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data=json_request, format="multipart"
+        )
+
+        backend.handle_notification(request)
+
+        email_content = " ".join(mail.outbox[0].body.split())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to[0], "john.doe@acme.org")
+        self.assertIn(
+            "An installment debit has failed",
+            mail.outbox[0].subject,
+        )
+        self.assertIn("Product 1", email_content)

--- a/src/backend/joanie/tests/payment/test_backend_payplug.py
+++ b/src/backend/joanie/tests/payment/test_backend_payplug.py
@@ -4,6 +4,7 @@ import re
 from decimal import Decimal as D
 from unittest import mock
 
+from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
 
@@ -37,7 +38,7 @@ from joanie.payment.models import CreditCard
 from joanie.tests.payment.base_payment import BasePaymentTestCase
 
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods, too-many-lines
 class PayplugBackendTestCase(BasePaymentTestCase):
     """Test case of the Payplug backend"""
 
@@ -889,3 +890,215 @@ class PayplugBackendTestCase(BasePaymentTestCase):
                 "The server gave the following response: `Abort this payment is forbidden.`."
             ),
         )
+
+    @mock.patch.object(BasePaymentBackend, "_send_mail_refused_debit")
+    @mock.patch.object(payplug.notifications, "treat")
+    def test_payment_backend_payplug_payment_failure_on_installment_should_trigger_email_method(
+        self, mock_treat, mock_send_mail_refused_debit
+    ):
+        """
+        When the backend receives a payment notification which mentions that the payment
+        debit has failed, the generic method `_do_on_payment_failure` should be called and
+        also call the method that is responsible to send an email to the user.
+        """
+        backend = PayplugBackend(self.configuration)
+        payment_id = "pay_failure"
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="en-us",
+            email="john.doe@acme.org",
+        )
+        product = ProductFactory(price=D("999.99"), title="Product 1")
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product=product,
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        mock_treat.return_value = PayplugFactories.PayplugPaymentFactory(
+            id=payment_id,
+            failure=True,
+            metadata={
+                "order_id": str(order.id),
+                "installment_id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+            },
+        )
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data={"id": payment_id}, format="json"
+        )
+
+        backend.handle_notification(request)
+
+        mock_send_mail_refused_debit.assert_called_once_with(
+            order, "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        )
+
+    @mock.patch.object(payplug.notifications, "treat")
+    def test_payment_backend_payplug_refused_installment_email_should_use_user_language_in_english(
+        self, mock_treat
+    ):
+        """
+        When backend receives a payment notification which failed, the generic method
+        `_do_on_payment_failure` should be called and should send an email mentioning about
+        the refused debit on the installment in the user's preferred language that is English
+        in this case.
+        """
+        backend = PayplugBackend(self.configuration)
+        payment_id = "pay_failure"
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="en-us",
+            email="john.doe@acme.org",
+        )
+        product = ProductFactory(price=D("999.99"), title="Product 1")
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product=product,
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        mock_treat.return_value = PayplugFactories.PayplugPaymentFactory(
+            id=payment_id,
+            failure=True,
+            metadata={
+                "order_id": str(order.id),
+                "installment_id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+            },
+        )
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data={"id": payment_id}, format="json"
+        )
+
+        backend.handle_notification(request)
+
+        email_content = " ".join(mail.outbox[0].body.split())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to[0], "john.doe@acme.org")
+        self.assertIn(
+            "An installment debit has failed",
+            mail.outbox[0].subject,
+        )
+        self.assertIn("Product 1", email_content)
+
+    @mock.patch.object(payplug.notifications, "treat")
+    def test_payment_backend_payplug_refused_installment_email_should_use_user_language_in_french(
+        self, mock_treat
+    ):
+        """
+        When the backend receives a payment notification which failed, the generic method
+        `_do_on_payment_failure` should be called and should send an email mentioning about
+        the refused debit on the installment in the user's preferred language that is
+        the French language in this case.
+        """
+        backend = PayplugBackend(self.configuration)
+        payment_id = "pay_failure"
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="fr-fr",
+            email="john.doe@acme.org",
+        )
+        product = ProductFactory(price=D("999.99"), title="Product 1")
+        product.translations.create(language_code="fr-fr", title="Produit 1")
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product=product,
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        mock_treat.return_value = PayplugFactories.PayplugPaymentFactory(
+            id=payment_id,
+            failure=True,
+            metadata={
+                "order_id": str(order.id),
+                "installment_id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+            },
+        )
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data={"id": payment_id}, format="json"
+        )
+
+        backend.handle_notification(request)
+
+        email_content = " ".join(mail.outbox[0].body.split())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to[0], "john.doe@acme.org")
+        self.assertIn("Produit 1", email_content)
+
+    @override_settings(
+        LANGUAGES=(
+            ("en-us", ("English")),
+            ("fr-fr", ("French")),
+            ("de-de", ("German")),
+        )
+    )
+    @mock.patch.object(payplug.notifications, "treat")
+    def test_payment_backend_payplug_send_email_refused_installment_should_use_fallback_language(
+        self, mock_treat
+    ):
+        """
+        When the backend receives a payment notification which failed, the generic method
+        `_do_on_payment_failure` should be called and should send an email with the fallback
+        language if the translation title does not exist into the user's preferred language.
+        In this case, the fallback language should be in English.
+        """
+        backend = PayplugBackend(self.configuration)
+        payment_id = "pay_failure"
+        user = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            language="de-de",
+            email="john.doe@acme.org",
+        )
+        product = ProductFactory(price=D("1000.00"), title="Test Product 1")
+        product.translations.create(language_code="fr-fr", title="Test Produit 1")
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING,
+            id="758c2570-a7af-4335-b091-340d0cc6e694",
+            owner=user,
+            product=product,
+        )
+        # Force the first installment id to match the stored request
+        first_installment = order.payment_schedule[0]
+        first_installment["id"] = "d9356dd7-19a6-4695-b18e-ad93af41424a"
+        order.save()
+
+        mock_treat.return_value = PayplugFactories.PayplugPaymentFactory(
+            id=payment_id,
+            failure=True,
+            metadata={
+                "order_id": str(order.id),
+                "installment_id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+            },
+        )
+
+        request = APIRequestFactory().post(
+            reverse("payment_webhook"), data={"id": payment_id}, format="json"
+        )
+
+        backend.handle_notification(request)
+
+        email_content = " ".join(mail.outbox[0].body.split())
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to[0], "john.doe@acme.org")
+        self.assertIn("Test Product 1", email_content)

--- a/src/mail/mjml/installment_paid.mjml
+++ b/src/mail/mjml/installment_paid.mjml
@@ -2,26 +2,7 @@
   <mj-include path="./partial/header.mjml" />
   <mj-body mj-class="bg--blue-100">
     <mj-wrapper css-class="wrapper" padding="20px 40px 40px 40px">
-      <mj-section>
-        <mj-column>
-          <mj-image src="{% base64_static 'joanie/images/logo_fun.png' %}" width="200px" align="left" alt="{%trans 'Company logo' %}" />
-        </mj-column>
-      </mj-section>
-      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="30px 50px 10px 50px">
-        <mj-column>
-          <mj-text padding="0">
-            {% if fullname %}
-              <p>
-              {% blocktranslate with name=fullname%}
-                Hello {{ name }},
-              {% endblocktranslate %}
-              </p>
-            {% else %}
-              {% trans "Hello," %}
-            {% endif %}<br />
-          </mj-text>
-        </mj-column>
-      </mj-section>
+      <mj-include path="./partial/welcome.mjml" />
       <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
         <mj-column>
           <mj-text padding="0">

--- a/src/mail/mjml/installment_refused.mjml
+++ b/src/mail/mjml/installment_refused.mjml
@@ -1,0 +1,33 @@
+<mjml>
+  <mj-include path="./partial/header.mjml" />
+  <mj-body mj-class="bg--blue-100">
+    <mj-wrapper css-class="wrapper" padding="20px 40px 40px 40px">
+      <mj-include path="./partial/welcome.mjml" />
+      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate with product_title=product_title installment_amount=installment_amount|format_currency_with_symbol targeted_installment_index=targeted_installment_index|add:1|ordinal title=product_title %}
+              For the course <strong>{{ title }}</strong>, the {{ targeted_installment_index }}
+              installment debit has failed.
+              <br />
+              We have tried to debit an amount of <strong>{{ installment_amount }}</strong>
+              on the credit card •••• •••• •••• {{ credit_card_last_numbers }}.
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-include path="./partial/installment_table.mjml" />
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate %}
+              Please correct the failed payment as soon as possible using
+              <a href="{{ dashboard_order_link }}">your dashboard</a>.
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-include path="./partial/footer.mjml" />
+  </mj-body>
+</mjml>

--- a/src/mail/mjml/installments_fully_paid.mjml
+++ b/src/mail/mjml/installments_fully_paid.mjml
@@ -2,26 +2,7 @@
   <mj-include path="./partial/header.mjml" />
   <mj-body mj-class="bg--blue-100">
     <mj-wrapper css-class="wrapper" padding="20px 40px 40px 40px">
-      <mj-section>
-        <mj-column>
-          <mj-image src="{% base64_static 'joanie/images/logo_fun.png' %}" width="200px" align="left" alt="{%trans 'Company logo' %}" />
-        </mj-column>
-      </mj-section>
-      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="30px 50px 10px 50px">
-        <mj-column>
-          <mj-text padding="0">
-            {% if fullname %}
-              <p>
-              {% blocktranslate with name=fullname%}
-                Hello {{ name }},
-              {% endblocktranslate %}
-              </p>
-            {% else %}
-              {% trans "Hello," %}
-            {% endif %}<br />
-          </mj-text>
-        </mj-column>
-      </mj-section>
+      <mj-include path="./partial/welcome.mjml" />
       <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
         <mj-column>
           <mj-text padding="0">

--- a/src/mail/mjml/partial/welcome.mjml
+++ b/src/mail/mjml/partial/welcome.mjml
@@ -1,0 +1,20 @@
+<mj-section>
+  <mj-column>
+    <mj-image src="{% base64_static 'joanie/images/logo_fun.png' %}" width="200px" align="left" alt="{%trans 'Company logo' %}" />
+  </mj-column>
+</mj-section>
+<mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="30px 50px 10px 50px">
+  <mj-column>
+    <mj-text padding="0">
+      {% if fullname %}
+        <p>
+        {% blocktranslate with name=fullname%}
+          Hello {{ name }},
+        {% endblocktranslate %}
+        </p>
+      {% else %}
+        {% trans "Hello," %}
+      {% endif %}<br />
+    </mj-text>
+  </mj-column>
+</mj-section>


### PR DESCRIPTION
## Purpose

This PR will solve this [issue](https://github.com/openfun/joanie/issues/863)
When an installment debit has failed, we need to inform the user with an email about the failed payment.

## Proposal

- [x] Create MJML template email  when an installment is refused
- [x] Create debug view for our fellow developers to see the layout and how is rendered the email sent to the user
- [x] Adjust logic in base payment backend when installment payment fails
