### PR TITLE
✨(backend) allow to generate payment schedule for any kind of product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 
 ### Changed
 
+- Generate payment schedule for any kind of product
 - Sort credit card list by is_main then descending creation date
 - Rework order statuses
 - Update the task `process_today_installment` to catch up on late

--- a/src/backend/joanie/core/flows/order.py
+++ b/src/backend/joanie/core/flows/order.py
@@ -268,6 +268,13 @@ class OrderFlow:
         """Post transition actions"""
         self.instance.save()
 
+        if (
+            not self.instance.payment_schedule
+            and not self.instance.is_free
+            and target in [enums.ORDER_STATE_PENDING, enums.ORDER_STATE_COMPLETED]
+        ):
+            self.instance.generate_schedule()
+
         # When an order is completed, if the user was previously enrolled for free in any of the
         # course runs targeted by the purchased product, we should change their enrollment mode on
         # these course runs to "verified".

--- a/src/backend/joanie/core/utils/payment_schedule.py
+++ b/src/backend/joanie/core/utils/payment_schedule.py
@@ -86,7 +86,7 @@ def _calculate_installments(total, due_dates, percentages):
     """
     Calculate the installments for the order.
     """
-    total_amount = Money(total, settings.DEFAULT_CURRENCY)
+    total_amount = Money(total)
     installments = []
     for i, due_date in enumerate(due_dates):
         if i < len(due_dates) - 1:

--- a/src/backend/joanie/tests/core/api/order/test_create.py
+++ b/src/backend/joanie/tests/core/api/order/test_create.py
@@ -10,6 +10,7 @@ from django.conf import settings
 
 from joanie.core import enums, factories, models
 from joanie.core.api.client import OrderViewSet
+from joanie.core.models import CourseState
 from joanie.core.serializers import fields
 from joanie.payment.factories import BillingAddressDictFactory, CreditCardFactory
 from joanie.tests.base import BaseAPITestCase
@@ -1317,7 +1318,10 @@ class OrderCreateApiTest(BaseAPITestCase):
         user = factories.UserFactory()
         token = self.generate_token_from_user(user)
         course = factories.CourseFactory()
-        product = factories.ProductFactory(courses=[course])
+        run = factories.CourseRunFactory(state=CourseState.ONGOING_OPEN)
+        product = factories.ProductFactory(
+            courses=[course], target_courses=[run.course]
+        )
         organization = product.course_relations.first().organizations.first()
         billing_address = BillingAddressDictFactory()
         credit_card = CreditCardFactory(owner=user)

--- a/src/backend/joanie/tests/core/api/order/test_payment_method.py
+++ b/src/backend/joanie/tests/core/api/order/test_payment_method.py
@@ -3,6 +3,7 @@
 from http import HTTPStatus
 
 from joanie.core import enums, factories
+from joanie.core.models import CourseState
 from joanie.payment.factories import CreditCardFactory
 from joanie.tests.base import BaseAPITestCase
 
@@ -120,7 +121,9 @@ class OrderPaymentMethodApiTest(BaseAPITestCase):
         Authenticated users should be able to set a payment method on an order
         by providing a credit card id.
         """
+        run = factories.CourseRunFactory(state=CourseState.ONGOING_OPEN)
         order = factories.OrderFactory(
+            product__target_courses=[run.course],
             state=enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
             credit_card=None,
         )

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -15,6 +15,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone as django_timezone
 
 from joanie.core import enums, factories
+from joanie.core.factories import CourseRunFactory
 from joanie.core.models import Contract, CourseState
 from joanie.core.utils import contract_definition
 from joanie.payment.factories import (
@@ -505,7 +506,9 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         When an order is submitted, product target courses should be copied to the order
         """
         product = factories.ProductFactory(
-            target_courses=factories.CourseFactory.create_batch(2),
+            target_courses=factories.CourseFactory.create_batch(
+                2, course_runs=[CourseRunFactory()]
+            ),
         )
         order = factories.OrderFactory(product=product)
 
@@ -1042,20 +1045,6 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         self.assertIsInstance(contract.context["course"]["price"], str)
         self.assertEqual(order.total, Decimal("1202.99"))
         self.assertEqual(contract.context["course"]["price"], "1202.99")
-
-    def test_models_order_submit_for_signature_generate_schedule(self):
-        """
-        Order submit_for_signature should generate a schedule for the order.
-        """
-        order = factories.OrderGeneratorFactory(
-            state=enums.ORDER_STATE_TO_SIGN,
-            product__price=Decimal("100.00"),
-        )
-        self.assertIsNone(order.payment_schedule)
-
-        order.submit_for_signature(user=order.owner)
-
-        self.assertIsNotNone(order.payment_schedule)
 
     def test_models_order_is_free(self):
         """


### PR DESCRIPTION
## Purpose

Currently, the payment schedule was generated on the signature submit. But this was weird as some product can have no contract and in this case, no payment schedule is generated. So in order to support this kind of product, we move the payment schedule generation logic on pending transition success.