### PR TITLE
👔(backend) update find_today_installments to retrieve past due payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to
 - Generate payment schedule for any kind of product
 - Sort credit card list by is_main then descending creation date
 - Rework order statuses
-- Update the task `process_today_installment` to catch up on late
+- Update the task `debit_pending_installment` to catch up on late
   payments of installments that are in the past
 - Deprecated field `has_consent_to_terms` for `Order` model
 

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -380,9 +380,8 @@ class OrderManager(models.Manager):
             .filter(payment_schedule__contains=[{"due_date": due_date.isoformat()}])
         )
 
-    def find_today_installments(self):
-        """Retrieve orders with a payment due today."""
-        due_date = timezone.now().date().isoformat()
+    def find_pending_installments(self):
+        """Retrieve orders with at least one pending installment."""
         return (
             super()
             .get_queryset()
@@ -391,9 +390,7 @@ class OrderManager(models.Manager):
                     enums.ORDER_STATE_PENDING,
                     enums.ORDER_STATE_PENDING_PAYMENT,
                 ],
-                payment_schedule__contains=[
-                    {"due_date": due_date, "state": enums.PAYMENT_STATE_PENDING}
-                ],
+                payment_schedule__contains=[{"state": enums.PAYMENT_STATE_PENDING}],
             )
         )
 

--- a/src/backend/joanie/core/utils/payment_schedule.py
+++ b/src/backend/joanie/core/utils/payment_schedule.py
@@ -7,6 +7,7 @@ import uuid
 from datetime import timedelta
 
 from django.conf import settings
+from django.utils import timezone
 
 from dateutil.relativedelta import relativedelta
 from stockholm import Money, Number
@@ -124,3 +125,25 @@ def generate(total, beginning_contract_date, course_start_date, course_end_date)
     installments = _calculate_installments(total, due_dates, percentages)
 
     return installments
+
+
+def is_installment_to_debit(installment):
+    """
+    Check if the installment is pending and has reached due date.
+    """
+    due_date = timezone.localdate().isoformat()
+
+    return (
+        installment["state"] == enums.PAYMENT_STATE_PENDING
+        and installment["due_date"] <= due_date
+    )
+
+
+def has_installments_to_debit(order):
+    """
+    Check if the order has any pending installments with reached due date.
+    """
+
+    return any(
+        is_installment_to_debit(installment) for installment in order.payment_schedule
+    )

--- a/src/backend/joanie/tests/core/test_commands_process_payment_schedules.py
+++ b/src/backend/joanie/tests/core/test_commands_process_payment_schedules.py
@@ -77,9 +77,9 @@ class ProcessPaymentSchedulesTestCase(TestCase):
         with (
             mock.patch("django.utils.timezone.now", return_value=mocked_now),
             mock.patch(
-                "joanie.core.tasks.payment_schedule.process_today_installment"
-            ) as process_today_installment,
+                "joanie.core.tasks.payment_schedule.debit_pending_installment"
+            ) as debit_pending_installment,
         ):
             call_command("process_payment_schedules")
 
-        process_today_installment.delay.assert_called_once_with(order.id)
+        debit_pending_installment.delay.assert_called_once_with(order.id)


### PR DESCRIPTION
## Purpose

`find_today_installments` currently retrieve only installments which have a due_date sets to today. Instead we would like to retrieve all installements which are due to payment today.
