### PR TITLE
🔥(admin) remove has_consent_to_terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to
 
 - Allow to cancel an enrollment order linked to an archived course run
 
+### Removed
+
+- Remove the `has_consent_to_terms` field from the `Order` edit view 
+  in the back office application
+
 
 ## [2.6.1] - 2024-07-25
 

--- a/src/frontend/admin/src/components/templates/orders/view/OrderView.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/OrderView.tsx
@@ -11,7 +11,6 @@ import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
 import Alert from "@mui/material/Alert";
 import Typography from "@mui/material/Typography";
-import FormControlLabel from "@mui/material/FormControlLabel";
 import { HighlightOff, TaskAlt } from "@mui/icons-material";
 import Stack from "@mui/material/Stack";
 import Table from "@mui/material/Table";
@@ -209,17 +208,6 @@ export function OrderView({ order }: Props) {
                 disabled={true}
                 label={intl.formatMessage(orderViewMessages.state)}
                 value={intl.formatMessage(orderStatesMessages[order.state])}
-              />
-            </Grid>
-            <Grid xs={12}>
-              <FormControlLabel
-                sx={{ ml: 0.1 }}
-                control={getSignedIcon(order.has_consent_to_terms, true)}
-                label={intl.formatMessage(
-                  order.has_consent_to_terms
-                    ? orderViewMessages.hasConsentToTerms
-                    : orderViewMessages.hasNotConsentToTerms,
-                )}
               />
             </Grid>
           </Grid>

--- a/src/frontend/admin/src/components/templates/orders/view/translations.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/translations.tsx
@@ -87,18 +87,6 @@ export const orderViewMessages = defineMessages({
     defaultMessage: "tax included",
     description: "Helper text for the price filed",
   },
-  hasConsentToTerms: {
-    id: "components.templates.orders.view.hasConsentToTerms",
-    defaultMessage:
-      "The user has accepted the terms and conditions when purchasing",
-    description: "Text for the has consent to term label",
-  },
-  hasNotConsentToTerms: {
-    id: "components.templates.orders.view.hasNotConsentToTerms",
-    defaultMessage:
-      "The user has not accepted the terms and conditions when purchasing",
-    description: "Text for the has consent to term label",
-  },
   certificate: {
     id: "components.templates.orders.view.certificate",
     defaultMessage: "Certificate",

--- a/src/frontend/admin/src/services/api/models/Order.ts
+++ b/src/frontend/admin/src/services/api/models/Order.ts
@@ -47,7 +47,6 @@ export type Order = AbstractOrder & {
   enrollment: Nullable<Enrollment>;
   certificate: Nullable<GeneratedCertificate>;
   main_invoice: OrderMainInvoice;
-  has_consent_to_terms: boolean;
   contract: Nullable<OrderContractDetails>;
   payment_schedule: Nullable<OrderPaymentSchedule[]>;
 };

--- a/src/frontend/admin/src/services/factories/orders/index.ts
+++ b/src/frontend/admin/src/services/factories/orders/index.ts
@@ -50,7 +50,6 @@ const build = (state?: OrderStatesEnum): Order => {
       definition_title: "Fake definition",
       issued_on: faker.date.anytime().toString(),
     },
-    has_consent_to_terms: faker.datatype.boolean(),
     contract: {
       definition_title: "Fake contract definition",
       id: faker.string.uuid(),


### PR DESCRIPTION
## Purpose

With the new workflow, the order field has_consent_to_terms has been deprecated so we can remove it from the order detail view in the BO application