### PR TITLE
✨ (backend) Mail reminder upcoming debit installment payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Send an email reminder to the user when an installment
+  will be debited on his credit card on his order's payment schedule
 - Send an email to the user when an installment debit has been
   refused
 - Send an email to the user when an installment is successfully

--- a/src/backend/joanie/core/management/commands/send_mail_upcoming_debit.py
+++ b/src/backend/joanie/core/management/commands/send_mail_upcoming_debit.py
@@ -1,0 +1,52 @@
+"""Management command to send a reminder email to the order's owner on next installment to pay"""
+
+import logging
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.utils import timezone
+
+from joanie.core.models import Order
+from joanie.core.tasks.payment_schedule import send_mail_reminder_installment_debit_task
+from joanie.core.utils.payment_schedule import is_next_installment_to_debit
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Command to send an email to the order's owner notifying them that an upcoming
+    installment debit from their payment schedule will be debited soon on their credit card.
+    """
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        """
+        Retrieve all upcoming pending payment schedules depending on the target due date and
+        send an email reminder to the order's owner who will be soon debited.
+        """
+        logger.info(
+            "Starting processing order payment schedule for upcoming installments."
+        )
+        due_date = timezone.localdate() + timedelta(
+            days=settings.JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS
+        )
+
+        found_orders_count = 0
+        for order in Order.objects.find_pending_installments().iterator():
+            for installment in order.payment_schedule:
+                if is_next_installment_to_debit(
+                    installment=installment, due_date=due_date
+                ):
+                    logger.info("Sending reminder mail for order %s.", order.id)
+                    send_mail_reminder_installment_debit_task.delay(
+                        order_id=order.id, installment_id=installment["id"]
+                    )
+            found_orders_count += 1
+
+        logger.info(
+            "Found %s upcoming 'pending' installment to debit",
+            found_orders_count,
+        )

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -1231,25 +1231,26 @@ class Order(BaseModel):
             None,
         )
 
-    def get_index_of_last_installment(self, state):
+    def get_installment_index(self, state, find_first=False):
         """
-        Retrieve the index of the last installment in the payment schedule based on the input
-        parameter payment state.
+        Retrieve the index of the first or last occurrence of an installment in the
+        payment schedule based on the input parameter payment state.
         """
         position = None
         for index, entry in enumerate(self.payment_schedule, start=0):
             if entry["state"] == state:
                 position = index
+                if find_first:
+                    break
         return position
 
     def get_remaining_balance_to_pay(self):
         """Get the amount of installments remaining to pay in the payment schedule."""
-        amounts = (
-            Money(installment["amount"])
+        return Money.sum(
+            installment["amount"]
             for installment in self.payment_schedule
             if installment["state"] == enums.PAYMENT_STATE_PENDING
         )
-        return Money.sum(amounts)
 
 
 class OrderTargetCourseRelation(BaseModel):

--- a/src/backend/joanie/core/tasks/payment_schedule.py
+++ b/src/backend/joanie/core/tasks/payment_schedule.py
@@ -4,7 +4,10 @@ from logging import getLogger
 
 from joanie.celery_app import app
 from joanie.core.models import Order
-from joanie.core.utils.payment_schedule import is_installment_to_debit
+from joanie.core.utils.payment_schedule import (
+    is_installment_to_debit,
+    send_mail_reminder_for_installment_debit,
+)
 from joanie.payment import get_payment_backend
 
 logger = getLogger(__name__)
@@ -30,3 +33,20 @@ def debit_pending_installment(order_id):
                 credit_card_token=order.credit_card.token,
                 installment=installment,
             )
+
+
+@app.task
+def send_mail_reminder_installment_debit_task(order_id, installment_id):
+    """
+    Task to send an email reminder to the order's owner about the next installment debit.
+    """
+    order = Order.objects.get(id=order_id)
+    installment = next(
+        (
+            installment
+            for installment in order.payment_schedule
+            if installment["id"] == installment_id
+        ),
+        None,
+    )
+    send_mail_reminder_for_installment_debit(order, installment)

--- a/src/backend/joanie/debug/urls.py
+++ b/src/backend/joanie/debug/urls.py
@@ -14,6 +14,8 @@ from joanie.debug.views import (
     DebugMailAllInstallmentPaidViewTxt,
     DebugMailInstallmentRefusedPaymentViewHtml,
     DebugMailInstallmentRefusedPaymentViewTxt,
+    DebugMailInstallmentReminderPaymentViewHtml,
+    DebugMailInstallmentReminderPaymentViewTxt,
     DebugMailSuccessInstallmentPaidViewHtml,
     DebugMailSuccessInstallmentPaidViewTxt,
     DebugMailSuccessPaymentViewHtml,
@@ -86,5 +88,15 @@ urlpatterns = [
         "__debug__/mail/installment-refused-txt",
         DebugMailInstallmentRefusedPaymentViewTxt.as_view(),
         name="debug.mail.installment_refused_txt",
+    ),
+    path(
+        "__debug__/mail/installment-reminder-html",
+        DebugMailInstallmentReminderPaymentViewHtml.as_view(),
+        name="debug.mail.installment_reminder_html",
+    ),
+    path(
+        "__debug__/mail/installment-reminder-txt",
+        DebugMailInstallmentReminderPaymentViewTxt.as_view(),
+        name="debug.mail.installment_reminder_txt",
     ),
 ]

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -445,6 +445,13 @@ class Base(Configuration):
         environ_name="JOANIE_DASHBOARD_ORDER_LINK",
         environ_prefix=None,
     )
+    # Add here the number of days ahead before notifying a user
+    # on his next installment debit
+    JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS = values.Value(
+        2,
+        environ_name="JOANIE_INSTALLMENT_REMINDER_DAYS_BEFORE",
+        environ_prefix=None,
+    )
 
     # CORS
     CORS_ALLOW_CREDENTIALS = True

--- a/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
+++ b/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
@@ -4,11 +4,15 @@ Test suite for payment schedule tasks
 
 import json
 from datetime import date, datetime
+from decimal import Decimal as D
 from logging import Logger
 from unittest import mock
 from zoneinfo import ZoneInfo
 
+from django.core import mail
+from django.core.management import call_command
 from django.test import TestCase
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from rest_framework.test import APIRequestFactory
@@ -16,13 +20,22 @@ from stockholm import Money
 
 from joanie.core.enums import (
     ORDER_STATE_PENDING,
+    ORDER_STATE_PENDING_PAYMENT,
     ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
     PAYMENT_STATE_PAID,
     PAYMENT_STATE_PENDING,
     PAYMENT_STATE_REFUSED,
 )
-from joanie.core.factories import OrderFactory, UserAddressFactory, UserFactory
-from joanie.core.tasks.payment_schedule import debit_pending_installment
+from joanie.core.factories import (
+    OrderFactory,
+    OrderGeneratorFactory,
+    UserAddressFactory,
+    UserFactory,
+)
+from joanie.core.tasks.payment_schedule import (
+    debit_pending_installment,
+    send_mail_reminder_installment_debit_task,
+)
 from joanie.payment import get_payment_backend
 from joanie.payment.backends.dummy import DummyPaymentBackend
 from joanie.payment.factories import InvoiceFactory
@@ -320,3 +333,119 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
                 },
             ],
         )
+
+    @override_settings(
+        JOANIE_PAYMENT_SCHEDULE_LIMITS={
+            5: (30, 70),
+        },
+        JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS=2,
+        DEFAULT_CURRENCY="EUR",
+    )
+    def test_payment_scheduled_send_mail_reminder_installment_debit_task_full_cycle(
+        self,
+    ):
+        """
+        According to the value configured in the setting `JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS`,
+        that is 2 days for this test, the command should find the orders that must be treated
+        and calls the method responsible to send the reminder email to the owner orders.
+        """
+        owner_1 = UserFactory(
+            first_name="John",
+            last_name="Doe",
+            email="john.doe@acme.org",
+            language="fr-fr",
+        )
+        UserAddressFactory(owner=owner_1)
+        owner_2 = UserFactory(
+            first_name="Sam", last_name="Doe", email="sam@fun-test.fr", language="fr-fr"
+        )
+        UserAddressFactory(owner=owner_2)
+        order_1 = OrderGeneratorFactory(
+            owner=owner_1,
+            state=ORDER_STATE_PENDING_PAYMENT,
+            product__price=D("5"),
+            product__title="Product 1",
+        )
+        order_1.payment_schedule[0]["state"] = PAYMENT_STATE_PAID
+        order_1.payment_schedule[0]["due_date"] = date(2024, 1, 17)
+        order_1.payment_schedule[1]["id"] = "1932fbc5-d971-48aa-8fee-6d637c3154a5"
+        order_1.payment_schedule[1]["due_date"] = date(2024, 2, 17)
+        order_1.payment_schedule[1]["state"] = PAYMENT_STATE_PENDING
+        order_1.save()
+        order_2 = OrderGeneratorFactory(
+            owner=owner_2,
+            state=ORDER_STATE_PENDING_PAYMENT,
+            product__price=D("5"),
+            product__title="Product 2",
+        )
+        order_2.payment_schedule[0]["state"] = PAYMENT_STATE_PAID
+        order_2.payment_schedule[1]["id"] = "a1cf9f39-594f-4528-a657-a0b9018b90ad"
+        order_2.payment_schedule[1]["due_date"] = date(2024, 2, 17)
+        order_2.save()
+        # This order should be ignored by the django command `send_mail_upcoming_debit`
+        order_3 = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING_PAYMENT,
+            product__price=D("5"),
+            product__title="Product 2",
+        )
+        order_3.payment_schedule[0]["state"] = PAYMENT_STATE_PAID
+        order_3.payment_schedule[1]["due_date"] = date(2024, 2, 18)
+        order_3.save()
+
+        # Orders that should be found with their installment that will be debited soon
+        expected_calls = [
+            mock.call.delay(
+                order_id=order_2.id,
+                installment_id="a1cf9f39-594f-4528-a657-a0b9018b90ad",
+            ),
+            mock.call.delay(
+                order_id=order_1.id,
+                installment_id="1932fbc5-d971-48aa-8fee-6d637c3154a5",
+            ),
+        ]
+
+        with (
+            mock.patch(
+                "django.utils.timezone.localdate", return_value=date(2024, 2, 15)
+            ),
+            mock.patch(
+                "joanie.core.tasks.payment_schedule.send_mail_reminder_installment_debit_task"
+            ) as mock_send_mail_reminder_installment_debit_task,
+        ):
+            call_command("send_mail_upcoming_debit")
+
+        mock_send_mail_reminder_installment_debit_task.assert_has_calls(
+            expected_calls, any_order=False
+        )
+
+        # Trigger now the task `send_mail_reminder_installment_debit_task` for order_1
+        send_mail_reminder_installment_debit_task.run(
+            order_id=order_1.id, installment_id=order_1.payment_schedule[1]["id"]
+        )
+
+        # Check if mail was sent to owner_1 about next upcoming debit
+        self.assertEqual(mail.outbox[0].to[0], "john.doe@acme.org")
+        self.assertIn("will be debited in 2 days.", mail.outbox[0].subject)
+        email_content_1 = " ".join(mail.outbox[0].body.split())
+        fullname_1 = order_1.owner.get_full_name()
+        self.assertIn(f"Hello {fullname_1}", email_content_1)
+        self.assertIn("installment will be withdrawn on 2 days", email_content_1)
+        self.assertIn("We will try to debit an amount of", email_content_1)
+        self.assertIn("3,5", email_content_1)
+        self.assertIn("Product 1", email_content_1)
+
+        # Trigger now the task `send_mail_reminder_installment_debit_task` for order_2
+        send_mail_reminder_installment_debit_task.run(
+            order_id=order_2.id, installment_id=order_2.payment_schedule[1]["id"]
+        )
+
+        # Check if mail was sent to owner_2 about next upcoming debit
+        self.assertEqual(mail.outbox[1].to[0], "sam@fun-test.fr")
+        self.assertIn("will be debited in 2 days.", mail.outbox[1].subject)
+        fullname_2 = order_2.owner.get_full_name()
+        email_content_2 = " ".join(mail.outbox[1].body.split())
+        self.assertIn(f"Hello {fullname_2}", email_content_2)
+        self.assertIn("installment will be withdrawn on 2 days", email_content_2)
+        self.assertIn("We will try to debit an amount of", email_content_2)
+        self.assertIn("1,5", email_content_2)
+        self.assertIn("Product 2", email_content_2)

--- a/src/backend/joanie/tests/core/test_commands_send_mail_upcoming_debit.py
+++ b/src/backend/joanie/tests/core/test_commands_send_mail_upcoming_debit.py
@@ -1,0 +1,68 @@
+"""Tests for the `send_mail_upcoming_debit` management command"""
+
+from datetime import date
+from decimal import Decimal as D
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from joanie.core import enums, factories
+
+
+@override_settings(
+    JOANIE_PAYMENT_SCHEDULE_LIMITS={1000: (20, 30, 30, 20)},
+    JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS=2,
+    DEFAULT_CURRENCY="EUR",
+)
+class SendMailUpcomingDebitManagementCommandTestCase(TestCase):
+    """Test case for the management command `send_mail_upcoming_debit`"""
+
+    @override_settings(JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS=2)
+    def test_command_send_mail_upcoming_debit_with_installment_reminder_period_of_2_days(
+        self,
+    ):
+        """
+        According to the value configured in the setting `JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS`,
+        that is 2 days for this test, the command should find the 2nd installment that will
+        be debited next and call the task that is responsible to send an email to the order's
+        owner. The task must be called with the `order.id` and the installment id
+        that is concerned in the order payment schedule.
+        """
+        order = factories.OrderGeneratorFactory(
+            state=enums.ORDER_STATE_PENDING_PAYMENT,
+            product__price=D("1000.00"),
+            product__title="Product 1",
+        )
+        order.payment_schedule[0]["state"] = enums.PAYMENT_STATE_PAID
+        order.payment_schedule[0]["due_date"] = date(2024, 1, 17)
+        order.payment_schedule[1]["id"] = "1932fbc5-d971-48aa-8fee-6d637c3154a5"
+        order.payment_schedule[1]["state"] = enums.PAYMENT_STATE_PENDING
+        order.payment_schedule[1]["due_date"] = date(2024, 2, 17)
+        order.save()
+
+        order_2 = factories.OrderGeneratorFactory(
+            state=enums.ORDER_STATE_PENDING_PAYMENT,
+            product__price=D("1000.00"),
+            product__title="Product 2",
+        )
+        order_2.payment_schedule[0]["state"] = enums.PAYMENT_STATE_PAID
+        order_2.payment_schedule[1]["due_date"] = date(2024, 2, 18)
+        order_2.payment_schedule[1]["state"] = enums.PAYMENT_STATE_PENDING
+        order_2.save()
+
+        with (
+            mock.patch(
+                "django.utils.timezone.localdate", return_value=date(2024, 2, 15)
+            ),
+            mock.patch(
+                "joanie.core.management.commands.send_mail_upcoming_debit"
+                ".send_mail_reminder_installment_debit_task"
+            ) as send_mail_reminder_installment_debit_task,
+        ):
+            call_command("send_mail_upcoming_debit")
+
+        send_mail_reminder_installment_debit_task.delay.assert_called_once_with(
+            order_id=order.id, installment_id="1932fbc5-d971-48aa-8fee-6d637c3154a5"
+        )

--- a/src/backend/joanie/tests/core/utils/test_emails_prepare_context_data.py
+++ b/src/backend/joanie/tests/core/utils/test_emails_prepare_context_data.py
@@ -3,6 +3,7 @@
 from datetime import date
 from decimal import Decimal
 
+from django.conf import settings
 from django.test import TestCase, override_settings
 
 from stockholm import Money
@@ -10,16 +11,23 @@ from stockholm import Money
 from joanie.core.enums import (
     ORDER_STATE_PENDING_PAYMENT,
     PAYMENT_STATE_PAID,
-    PAYMENT_STATE_PENDING,
     PAYMENT_STATE_REFUSED,
 )
-from joanie.core.factories import OrderFactory, ProductFactory, UserFactory
-from joanie.core.utils.emails import prepare_context_data
+from joanie.core.factories import OrderGeneratorFactory, ProductFactory, UserFactory
+from joanie.core.utils.emails import (
+    prepare_context_data,
+    prepare_context_for_upcoming_installment,
+)
 
 
 @override_settings(
     JOANIE_CATALOG_NAME="Test Catalog",
     JOANIE_CATALOG_BASE_URL="https://richie.education",
+    JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS=2,
+    JOANIE_PAYMENT_SCHEDULE_LIMITS={
+        1000: (20, 30, 30, 20),
+    },
+    DEFAULT_CURRENCY="EUR",
 )
 class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
     """
@@ -39,7 +47,7 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
         `date_next_installment_to_pay`, and `targeted_installment_index`.
         """
         product = ProductFactory(price=Decimal("1000.00"), title="Product 1")
-        order = OrderFactory(
+        order = OrderGeneratorFactory(
             product=product,
             state=ORDER_STATE_PENDING_PAYMENT,
             owner=UserFactory(
@@ -48,36 +56,17 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
                 language="en-us",
                 email="johndoe@fun-test.fr",
             ),
-            payment_schedule=[
-                {
-                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
-                    "state": PAYMENT_STATE_PAID,
-                },
-                {
-                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
-                    "state": PAYMENT_STATE_PAID,
-                },
-                {
-                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
-                    "state": PAYMENT_STATE_PENDING,
-                },
-                {
-                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "200.00",
-                    "due_date": "2024-04-17",
-                    "state": PAYMENT_STATE_PENDING,
-                },
-            ],
         )
+        order.payment_schedule[0]["state"] = PAYMENT_STATE_PAID
+        order.payment_schedule[1]["state"] = PAYMENT_STATE_PAID
+        order.payment_schedule[2]["due_date"] = date(2024, 3, 17)
+        order.save()
 
         context_data = prepare_context_data(
-            order, Money("300.00"), product.title, payment_refused=False
+            order,
+            order.payment_schedule[2]["amount"],
+            product.title,
+            payment_refused=False,
         )
 
         self.assertDictEqual(
@@ -110,7 +99,7 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
         and `date_next_installment_to_pay`.
         """
         product = ProductFactory(price=Decimal("1000.00"), title="Product 1")
-        order = OrderFactory(
+        order = OrderGeneratorFactory(
             product=product,
             state=ORDER_STATE_PENDING_PAYMENT,
             owner=UserFactory(
@@ -119,36 +108,18 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
                 language="en-us",
                 email="johndoe@fun-test.fr",
             ),
-            payment_schedule=[
-                {
-                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
-                    "state": PAYMENT_STATE_PAID,
-                },
-                {
-                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
-                    "state": PAYMENT_STATE_PAID,
-                },
-                {
-                    "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
-                    "state": PAYMENT_STATE_REFUSED,
-                },
-                {
-                    "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
-                    "state": PAYMENT_STATE_PENDING,
-                },
-            ],
         )
+        order.payment_schedule[0]["state"] = PAYMENT_STATE_PAID
+        order.payment_schedule[1]["state"] = PAYMENT_STATE_PAID
+        order.payment_schedule[2]["state"] = PAYMENT_STATE_REFUSED
+        order.payment_schedule[2]["due_date"] = date(2024, 3, 17)
+        order.save()
 
         context_data = prepare_context_data(
-            order, Money("300.00"), product.title, payment_refused=True
+            order,
+            order.payment_schedule[2]["amount"],
+            product.title,
+            payment_refused=True,
         )
 
         self.assertNotIn("remaining_balance_to_pay", context_data)
@@ -171,5 +142,67 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
                     "url": "https://richie.education",
                 },
                 "targeted_installment_index": 2,
+            },
+        )
+
+    def test_utils_emails_prepare_context_for_upcoming_installment_email(
+        self,
+    ):
+        """
+        When an installment will soon be debited for the order's owners, the method
+        `prepare_context_for_upcoming_installment` will prepare the context variable that
+        will be used for the email.
+
+        We should find the following keys : `fullname`, `email`, `product_title`,
+        `installment_amount`, `product_price`, `credit_card_last_numbers`,
+        `order_payment_schedule`, `dashboard_order_link`, `site`, `remaining_balance_to_pay`,
+        `date_next_installment_to_pay`, `targeted_installment_index`, and `days_until_debit`
+        """
+        product = ProductFactory(price=Decimal("1000.00"), title="Product 1")
+        order = OrderGeneratorFactory(
+            product=product,
+            state=ORDER_STATE_PENDING_PAYMENT,
+            owner=UserFactory(
+                first_name="John",
+                last_name="Doe",
+                language="en-us",
+                email="johndoe@fun-test.fr",
+            ),
+        )
+        order.payment_schedule[0]["state"] = PAYMENT_STATE_PAID
+        order.payment_schedule[1]["state"] = PAYMENT_STATE_PAID
+        order.payment_schedule[2]["due_date"] = date(2024, 3, 17)
+        order.save()
+
+        context_data_for_upcoming_installment_email = (
+            prepare_context_for_upcoming_installment(
+                order,
+                order.payment_schedule[2]["amount"],
+                product.title,
+                days_until_debit=settings.JOANIE_INSTALLMENT_REMINDER_PERIOD_DAYS,
+            )
+        )
+
+        self.assertDictEqual(
+            context_data_for_upcoming_installment_email,
+            {
+                "fullname": "John Doe",
+                "email": "johndoe@fun-test.fr",
+                "product_title": "Product 1",
+                "installment_amount": Money("300.00"),
+                "product_price": Money("1000.00"),
+                "credit_card_last_numbers": order.credit_card.last_numbers,
+                "order_payment_schedule": order.payment_schedule,
+                "dashboard_order_link": (
+                    f"http://localhost:8070/dashboard/courses/orders/{order.id}/"
+                ),
+                "site": {
+                    "name": "Test Catalog",
+                    "url": "https://richie.education",
+                },
+                "remaining_balance_to_pay": Money("500.00"),
+                "date_next_installment_to_pay": date(2024, 3, 17),
+                "targeted_installment_index": 2,
+                "days_until_debit": 2,
             },
         )

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -604,7 +604,7 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
         )
 
     @mock.patch(
-        "joanie.payment.backends.base.send_mail",
+        "joanie.core.utils.emails.send_mail",
         side_effect=smtplib.SMTPException("Error SMTPException"),
     )
     @mock.patch.object(Logger, "error")

--- a/src/mail/mjml/installment_reminder.mjml
+++ b/src/mail/mjml/installment_reminder.mjml
@@ -1,0 +1,32 @@
+<mjml>
+  <mj-include path="./partial/header.mjml" />
+  <mj-body mj-class="bg--blue-100">
+    <mj-wrapper css-class="wrapper" padding="20px 40px 40px 40px">
+    <mj-include path="./partial/welcome.mjml" />
+      <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate with installment_amount=installment_amount|format_currency_with_symbol targeted_installment_index=targeted_installment_index|add:1|ordinal title=product_title %}
+              For the course <strong>{{ title }}</strong>, the {{ targeted_installment_index }}
+              installment will be withdrawn on {{ days_until_debit }} days.
+            <br />
+              We will try to debit an amount of <strong>{{ installment_amount }}</strong> on the credit card
+              •••• •••• •••• {{ credit_card_last_numbers }}.
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-include path="./partial/installment_table.mjml" />
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% blocktranslate %}
+              See order details on your dashboard : <a href="{{ dashboard_order_link }}">dashboard</a>
+            {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-include path="./partial/footer.mjml" />
+  </mj-body>
+</mjml>

--- a/src/tray/templates/services/app/cronjob_send_mail_upcoming_debit.yml.j2
+++ b/src/tray/templates/services/app/cronjob_send_mail_upcoming_debit.yml.j2
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app: joanie
+    service: app
+    version: "{{ joanie_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "joanie-send-mail-upcoming-debit-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ joanie_send_mail_upcoming_debit_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+         name: "joanie-send-mail-upcoming-debit-{{ deployment_stamp }}"
+         labels:
+            app: joanie
+            service: app
+            version: "{{ joanie_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = joanie_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: "joanie-send-mail-upcoming-debit"
+              image: "{{ joanie_image_name }}:{{ joanie_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py send_mail_upcoming_debit
+              env:
+                - name: DB_HOST
+                  value: "joanie-{{ joanie_database_host }}-{{ deployment_stamp }}"
+                - name: DB_NAME
+                  value: "{{ joanie_database_name }}"
+                - name: DB_PORT
+                  value: "{{ joanie_database_port }}"
+                - name: DJANGO_ALLOWED_HOSTS
+                  value: "{{ joanie_host | blue_green_hosts }},{{ joanie_admin_host | blue_green_hosts }}"
+                - name: DJANGO_CSRF_TRUSTED_ORIGINS
+                  value: "{{ joanie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},{{ joanie_admin_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ joanie_django_configuration }}"
+                - name: DJANGO_CORS_ALLOWED_ORIGINS
+                  value: "{{ richie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},{{ joanie_admin_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+                - name: DJANGO_CSRF_COOKIE_DOMAIN
+                  value: ".{{ joanie_host }}"
+                - name: DJANGO_SETTINGS_MODULE
+                  value: joanie.configs.settings
+                - name: JOANIE_BACKOFFICE_BASE_URL
+                  value: "https://{{ joanie_admin_host }}"
+                - name: DJANGO_CELERY_DEFAULT_QUEUE
+                  value: "default-queue-{{ deployment_stamp }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ joanie_secret_name }}"
+                - configMapRef:
+                    name: "joanie-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ joanie_send_mail_upcoming_debit_cronjob_resources }}
+              volumeMounts:
+              - name: joanie-configmap
+                mountPath: /app/joanie/configs
+          restartPolicy: Never
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: joanie-configmap
+              configMap:
+                defaultMode: 420
+                name: joanie-app-{{ deployment_stamp }}

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -54,7 +54,7 @@ joanie_activate_http_basic_auth: false
 
 # -- joanie celery
 joanie_celery_replicas: 1
-joanie_celery_command: 
+joanie_celery_command:
   - celery
   - -A
   - joanie.celery_app
@@ -84,7 +84,7 @@ joanie_celery_readynessprobe:
 
 # Joanie cronjobs
 joanie_process_payment_schedules_cronjob_schedule: "0 3 * * *"
-
+joanie_send_mail_upcoming_debit_cronjob_schedule: "0 3 * * *"
 
 # -- resources
 {% set app_resources = {
@@ -97,6 +97,7 @@ joanie_process_payment_schedules_cronjob_schedule: "0 3 * * *"
 joanie_app_resources: "{{ app_resources }}"
 joanie_app_job_db_migrate_resources: "{{ app_resources }}"
 joanie_process_payment_schedules_cronjob_resources: "{{ app_resources }}"
+joanie_send_mail_upcoming_debit_cronjob_resources: "{{ app_resources }}"
 
 joanie_nginx_resources:
   requests:


### PR DESCRIPTION
## Purpose

This PR will solve this [issue](https://github.com/openfun/joanie/issues/864)

We need to notify the order's owner that an upcoming installment payment debit will happen soon on their
credit card.

The reminder frequency that is set in days will be a configuration setting. 

By default, it will be 2 days by default in JOANIE settings.

## Proposal

- [x] Create MJML template for the reminder of an installment debit.
- [x] Create a debug view for our fellow developers to see the layout and the rendering of the email reminder.
- [x] Create a django command to trigger email  with celery task to notify the about the upcoming installment debit payment.
- [x] Add cronjob schedule to trigger the django command `send_mail_upcoming_debit`