### PR TITLE
✨(backend) bind payment_schedule into OrderLightSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 
 ### Changed
 
+- Bind payment_schedule into `OrderLightSerializer`
 - Generate payment schedule for any kind of product
 - Sort credit card list by is_main then descending creation date
 - Rework order statuses


### PR DESCRIPTION
## Purpose

On enrollment order resource, our api consumer needs to be able to retrieve payment schedule information so we update the OrderLightSerializer to add this field.