### PR TITLE
:sparkles:(backend) debit installment on order pending transition if due date is current day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Debit installment on pending order transition if due date is on current day
 - Display order credit card detail in the back office
 - Send an email reminder to the user when an installment
   will be debited on his credit card on his order's payment schedule

--- a/src/backend/joanie/tests/core/api/order/test_payment_method.py
+++ b/src/backend/joanie/tests/core/api/order/test_payment_method.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 
 from joanie.core import enums, factories
 from joanie.core.models import CourseState
-from joanie.payment.factories import CreditCardFactory
+from joanie.payment.factories import CreditCardFactory, InvoiceFactory
 from joanie.tests.base import BaseAPITestCase
 
 
@@ -127,6 +127,8 @@ class OrderPaymentMethodApiTest(BaseAPITestCase):
             state=enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
             credit_card=None,
         )
+        InvoiceFactory(order=order)
+
         self.assertFalse(order.has_payment_method)
 
         credit_card = CreditCardFactory(owner=order.owner)


### PR DESCRIPTION
## Purpose

When we generate the payment schedule and if the course has already started,
the 1st installment due date of the order's payment schedule will be set to the current
day. Since we only debit the next night through a cronjob, we need be able to make the
user pay to have access to his course, and avoid that the has to wait the next
day to start it.

## Proposal

- [x] Add new logic to trigger payment if **1st** installment **due date** is **current day** for the user in `post_transition_success` of the order flow.

