### PR TITLE
✨(backend) Ensure due_date in payment schedule decoder returns a date object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to
 
 ### Changed
 
+- Updated `OrderPaymentScheduleDecoder` to return a `date` object for
+  the `due_date` attribute and a `Money` object for `amount` attribute
+  in the payment_schedule, instead of string values
 - Bind payment_schedule into `OrderLightSerializer`
 - Generate payment schedule for any kind of product
 - Sort credit card list by is_main then descending creation date

--- a/src/backend/joanie/core/exceptions.py
+++ b/src/backend/joanie/core/exceptions.py
@@ -29,3 +29,9 @@ class CertificateGenerationError(Exception):
     Exception raised when the certificate generation process fails due to the order not meeting
     all specified conditions.
     """
+
+
+class InvalidConversionError(Exception):
+    """
+    Exception raised when a conversion fails.
+    """

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -30,6 +30,10 @@ from joanie.core.models import (
 )
 from joanie.core.serializers import AddressSerializer
 from joanie.core.utils import contract_definition, file_checksum
+from joanie.core.utils.payment_schedule import (
+    convert_amount_str_to_money_object,
+    convert_date_str_to_date_object,
+)
 
 
 def generate_thumbnails_for_field(field, include_global=False):
@@ -683,6 +687,22 @@ class OrderFactory(factory.django.DjangoModelFactory):
 
         return None
 
+    @factory.post_generation
+    # pylint: disable=method-hidden
+    def payment_schedule(self, create, extracted, **kwargs):
+        """
+        Cast input strings for the fields `amount` and `due_date` into the appropriate types
+        """
+        if create and extracted:
+            for item in extracted:
+                if isinstance(item["due_date"], str):
+                    item["due_date"] = convert_date_str_to_date_object(item["due_date"])
+                if isinstance(item["amount"], str):
+                    item["amount"] = convert_amount_str_to_money_object(item["amount"])
+            self.payment_schedule = extracted
+            return extracted
+        return None
+
 
 class OrderGeneratorFactory(factory.django.DjangoModelFactory):
     """A factory to create an Order"""
@@ -919,6 +939,22 @@ class OrderGeneratorFactory(factory.django.DjangoModelFactory):
 
         if target_state == enums.ORDER_STATE_CANCELED:
             self.flow.cancel()
+
+    @factory.post_generation
+    # pylint: disable=method-hidden
+    def payment_schedule(self, create, extracted, **kwargs):
+        """
+        Cast input strings for the fields `amount` and `due_date` into the appropriate types
+        """
+        if create and extracted:
+            for item in extracted:
+                if isinstance(item["due_date"], str):
+                    item["due_date"] = convert_date_str_to_date_object(item["due_date"])
+                if isinstance(item["amount"], str):
+                    item["amount"] = convert_amount_str_to_money_object(item["amount"])
+            self.payment_schedule = extracted
+            return extracted
+        return None
 
 
 class OrderTargetCourseRelationFactory(factory.django.DjangoModelFactory):

--- a/src/backend/joanie/core/fields/schedule.py
+++ b/src/backend/joanie/core/fields/schedule.py
@@ -1,5 +1,6 @@
 """Utils for the order payment schedule field"""
 
+from datetime import date
 from json import JSONDecoder
 from json.decoder import WHITESPACE
 
@@ -29,4 +30,5 @@ class OrderPaymentScheduleDecoder(JSONDecoder):
         payment_schedule = super().decode(s, _w)
         for installment in payment_schedule:
             installment["amount"] = Money(installment["amount"])
+            installment["due_date"] = date.fromisoformat(installment["due_date"])
         return payment_schedule

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -1161,7 +1161,7 @@ class Order(BaseModel):
             raise ValidationError("No payment schedule found for this order")
 
         # check if current date is greater than the first installment due date
-        if timezone.now().isoformat() >= self.payment_schedule[0]["due_date"]:
+        if timezone.now().date() >= self.payment_schedule[0]["due_date"]:
             raise ValidationError(
                 "Cannot withdraw order after the first installment due date"
             )

--- a/src/backend/joanie/tests/core/api/order/test_submit_installment_payment.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_installment_payment.py
@@ -1,9 +1,12 @@
 """Tests for the Order to submit installment payment API endpoint."""
 
 import uuid
+from datetime import date
 from decimal import Decimal as D
 from http import HTTPStatus
 from unittest import mock
+
+from stockholm import Money
 
 from joanie.core.enums import (
     ORDER_STATE_CANCELED,
@@ -352,8 +355,8 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             billing_address=order.main_invoice.recipient_address,
             installment={
                 "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                "amount": "300.00",
-                "due_date": "2024-02-17",
+                "amount": Money("300.00"),
+                "due_date": date(2024, 2, 17),
                 "state": PAYMENT_STATE_REFUSED,
             },
         )
@@ -432,8 +435,8 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             credit_card_token=credit_card.token,
             installment={
                 "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                "amount": "300.00",
-                "due_date": "2024-03-17",
+                "amount": Money("300.00"),
+                "due_date": date(2024, 3, 17),
                 "state": PAYMENT_STATE_REFUSED,
             },
         )
@@ -561,8 +564,8 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             credit_card_token=credit_card.token,
             installment={
                 "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                "amount": "200.00",
-                "due_date": "2024-01-17",
+                "amount": Money("200.00"),
+                "due_date": date(2024, 1, 17),
                 "state": PAYMENT_STATE_REFUSED,
             },
         )
@@ -628,8 +631,8 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             billing_address=order.main_invoice.recipient_address,
             installment={
                 "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                "amount": "200.00",
-                "due_date": "2024-01-17",
+                "amount": Money("200.00"),
+                "due_date": date(2024, 1, 17),
                 "state": PAYMENT_STATE_REFUSED,
             },
         )
@@ -696,8 +699,8 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             billing_address=order.main_invoice.recipient_address,
             installment={
                 "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                "amount": "300.00",
-                "due_date": "2024-03-17",
+                "amount": Money("300.00"),
+                "due_date": date(2024, 3, 17),
                 "state": PAYMENT_STATE_REFUSED,
             },
         )
@@ -774,8 +777,8 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
             credit_card_token=credit_card.token,
             installment={
                 "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                "amount": "199.99",
-                "due_date": "2024-04-17",
+                "amount": Money("199.99"),
+                "due_date": date(2024, 4, 17),
                 "state": PAYMENT_STATE_REFUSED,
             },
         )

--- a/src/backend/joanie/tests/core/api/organizations/test_contracts_signature_link.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_contracts_signature_link.py
@@ -32,7 +32,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -76,7 +76,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -127,7 +127,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -238,7 +238,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -280,7 +280,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -329,7 +329,6 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
         access = factories.UserOrganizationAccessFactory(
             organization=organization, role="owner"
         )
-
         # Create two contracts for the same organization and course product relation
         orders = factories.OrderFactory.create_batch(
             2,
@@ -339,7 +338,7 @@ class OrganizationApiContractSignatureLinkTest(BaseAPITestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],

--- a/src/backend/joanie/tests/core/models/order/test_factory.py
+++ b/src/backend/joanie/tests/core/models/order/test_factory.py
@@ -1,4 +1,6 @@
-"""Test suite for the OrderGeneratorFactory."""
+"""Test suite for the OrderGeneratorFactory and OrderFactory"""
+
+from datetime import date
 
 from django.test import TestCase, override_settings
 
@@ -18,7 +20,8 @@ from joanie.core.enums import (
     PAYMENT_STATE_PENDING,
     PAYMENT_STATE_REFUSED,
 )
-from joanie.core.factories import OrderGeneratorFactory
+from joanie.core.exceptions import InvalidConversionError
+from joanie.core.factories import OrderFactory, OrderGeneratorFactory
 
 
 @override_settings(
@@ -181,3 +184,73 @@ class TestOrderGeneratorFactory(TestCase):
         self.assertEqual(order.payment_schedule[0]["state"], PAYMENT_STATE_PENDING)
         self.assertEqual(order.payment_schedule[1]["state"], PAYMENT_STATE_PENDING)
         self.assertEqual(order.payment_schedule[2]["state"], PAYMENT_STATE_PENDING)
+
+    def test_factory_order_passed_isoformat_string_due_date_value_to_convert_to_date_object(
+        self,
+    ):
+        """
+        When passing a string of date in isoformat for the due_date, it should transform
+        that string into a date object.
+        """
+        order = OrderGeneratorFactory(
+            state=ORDER_STATE_PENDING_PAYMENT, product__price=100
+        )
+        order.payment_schedule[0]["due_date"] = "2024-09-01"
+
+        order.refresh_from_db()
+
+        self.assertIsInstance(order.payment_schedule[0]["due_date"], date)
+
+
+class TestOrderFactory(TestCase):
+    """Test suite for the `OrderFactory`."""
+
+    def test_factory_order_payment_schedule_due_date_wrong_format_raise_invalid_conversion_error(
+        self,
+    ):
+        """
+        Test that `OrderFactory` raises an `InvalidConversionError` when a string with an
+        incorrect ISO date format is passed as the `due_date` in the payment schedule.
+        """
+        with self.assertRaises(InvalidConversionError) as context:
+            OrderFactory(
+                state=ORDER_STATE_PENDING_PAYMENT,
+                payment_schedule=[
+                    {
+                        "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                        "due_date": "abc01-6-22",
+                        "amount": "200.00",
+                        "state": PAYMENT_STATE_PENDING,
+                    }
+                ],
+            )
+
+        self.assertEqual(
+            str(context.exception),
+            "Invalid date format for date_str: Invalid isoformat string: 'abc01-6-22'.",
+        )
+
+    def test_factory_order_payment_schedule_amount_wrong_format_raise_invalid_conversion_error(
+        self,
+    ):
+        """
+        Test that `OrderFactory` raises an `InvalidConversionError` when a string with an
+        incorrect amount value is passed as the `amount` in the payment schedule.
+        """
+        with self.assertRaises(InvalidConversionError) as context:
+            OrderFactory(
+                state=ORDER_STATE_PENDING_PAYMENT,
+                payment_schedule=[
+                    {
+                        "id": "a1cf9f39-594f-4528-a657-a0b9018b90ad",
+                        "due_date": "2024-09-01",
+                        "amount": "abc02",
+                        "state": PAYMENT_STATE_PENDING,
+                    }
+                ],
+            )
+
+        self.assertEqual(
+            str(context.exception),
+            "Invalid format for amount: Input value cannot be used as monetary amount : 'abc02'.",
+        )

--- a/src/backend/joanie/tests/core/models/order/test_schedule.py
+++ b/src/backend/joanie/tests/core/models/order/test_schedule.py
@@ -177,14 +177,14 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": str(first_uuid),
-                    "amount": "0.90",
-                    "due_date": "2024-01-17",
+                    "amount": Money("0.90"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": str(second_uuid),
-                    "amount": "2.10",
-                    "due_date": "2024-03-01",
+                    "amount": Money("2.10"),
+                    "due_date": date(2024, 3, 1),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -246,20 +246,20 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": str(first_uuid),
-                    "amount": "1.80",
-                    "due_date": "2024-01-17",
+                    "amount": Money("1.80"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": str(second_uuid),
-                    "amount": "2.70",
-                    "due_date": "2024-03-01",
+                    "amount": Money("2.70"),
+                    "due_date": date(2024, 3, 1),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": str(third_uuid),
-                    "amount": "1.50",
-                    "due_date": "2024-04-01",
+                    "amount": Money("1.50"),
+                    "due_date": date(2024, 4, 1),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -322,20 +322,20 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": str(first_uuid),
-                    "amount": "1.80",
-                    "due_date": "2024-01-01",
+                    "amount": Money("1.80"),
+                    "due_date": date(2024, 1, 1),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": str(second_uuid),
-                    "amount": "2.70",
-                    "due_date": "2024-02-01",
+                    "amount": Money("2.70"),
+                    "due_date": date(2024, 2, 1),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": str(third_uuid),
-                    "amount": "1.50",
-                    "due_date": "2024-03-01",
+                    "amount": Money("1.50"),
+                    "due_date": date(2024, 3, 1),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -526,26 +526,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -562,26 +562,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_REFUSED,
                 },
             ],
@@ -639,26 +639,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -712,26 +712,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -785,26 +785,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
             ],
@@ -840,8 +840,8 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
             ],
@@ -895,26 +895,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_REFUSED,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -968,26 +968,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_REFUSED,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1041,26 +1041,26 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_REFUSED,
                 },
             ],
@@ -1096,8 +1096,8 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_REFUSED,
                 },
             ],
@@ -1123,6 +1123,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
                 },
             ]
         )
+        order.refresh_from_db()
 
         mocked_now = datetime(2024, 1, 12, 8, 8, tzinfo=ZoneInfo("UTC"))
         with mock.patch("django.utils.timezone.now", return_value=mocked_now):
@@ -1158,6 +1159,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
                 },
             ]
         )
+        order.refresh_from_db()
 
         mocked_now = datetime(2024, 2, 18, 8, 8)
         with mock.patch("django.utils.timezone.now", return_value=mocked_now):
@@ -1167,7 +1169,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             ):
                 order.withdraw()
 
-    def test_models_order_get_first_installment_refused_returns_installment_object(
+    def test_models_order_schedule_get_first_installment_refused_returns_installment_object(
         self,
     ):
         """
@@ -1210,13 +1212,13 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             installment,
             {
                 "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                "amount": "300.00",
-                "due_date": "2024-02-17",
+                "amount": Money("300.00"),
+                "due_date": date(2024, 2, 17),
                 "state": PAYMENT_STATE_REFUSED,
             },
         )
 
-    def test_models_order_get_first_installment_refused_returns_none(self):
+    def test_models_order_schedule_get_first_installment_refused_returns_none(self):
         """
         The method `get_first_installment_refused` should return `None` if there is no installment
         in payment schedule found for the order with the state `PAYMENT_STATE_REFUSED`.
@@ -1255,7 +1257,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
 
         self.assertIsNone(installment)
 
-    def test_models_order_get_date_next_installment_to_pay(self):
+    def test_models_order_schedule_get_date_next_installment_to_pay(self):
         """
         Should return the date of the next installment to pay for the user on his order's
         payment schedule.
@@ -1292,9 +1294,9 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
 
         date_next_installment = order.get_date_next_installment_to_pay()
 
-        self.assertEqual(date_next_installment, order.payment_schedule[-1]["due_date"])
+        self.assertEqual(date_next_installment, date(2024, 4, 17))
 
-    def test_models_order_get_remaining_balance_to_pay(self):
+    def test_models_order_schedule_get_remaining_balance_to_pay(self):
         """
         Should return the leftover amount still remaining to be paid on an order's
         payment schedule
@@ -1331,9 +1333,9 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
 
         remains = order.get_remaining_balance_to_pay()
 
-        self.assertEqual(str(remains), "499.99")
+        self.assertEqual(remains, Money("499.99"))
 
-    def test_models_order_get_index_of_last_installment_with_paid_state(self):
+    def test_models_order_schedule_get_index_of_last_installment_with_paid_state(self):
         """
         Should return the index of the last installment with state 'paid'
         from the payment schedule.
@@ -1384,7 +1386,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             2, order.get_index_of_last_installment(state=PAYMENT_STATE_PAID)
         )
 
-    def test_models_order_get_index_of_last_installment_state_refused(self):
+    def test_models_order_schedule_get_index_of_last_installment_state_refused(self):
         """
         Should return the index of the last installment with state 'refused'
         from the payment schedule.
@@ -1422,3 +1424,29 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         self.assertEqual(
             1, order.get_index_of_last_installment(state=PAYMENT_STATE_REFUSED)
         )
+
+    def test_models_order_schedule_returns_a_date_object_for_due_date(self):
+        """
+        Check that the `due_date` in the payment schedule is returned as a date object
+        after reloading the object from the database.
+        """
+        order = factories.OrderFactory(
+            state=ORDER_STATE_PENDING_PAYMENT,
+            payment_schedule=[
+                {
+                    "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
+                    "amount": "200.00",
+                    "due_date": "2024-01-17",
+                    "state": PAYMENT_STATE_PAID,
+                },
+                {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "300.00",
+                    "due_date": "2024-02-17",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+
+        self.assertIsInstance(order.payment_schedule[0]["due_date"], date)
+        self.assertIsInstance(order.payment_schedule[1]["due_date"], date)

--- a/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
+++ b/src/backend/joanie/tests/core/tasks/test_payment_schedule.py
@@ -3,7 +3,7 @@ Test suite for payment schedule tasks
 """
 
 import json
-from datetime import datetime
+from datetime import date, datetime
 from logging import Logger
 from unittest import mock
 from zoneinfo import ZoneInfo
@@ -12,6 +12,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from rest_framework.test import APIRequestFactory
+from stockholm import Money
 
 from joanie.core.enums import (
     ORDER_STATE_PENDING,
@@ -93,8 +94,8 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             credit_card_token=order.credit_card.token,
             installment={
                 "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                "amount": "200.00",
-                "due_date": "2024-01-17",
+                "amount": Money("200.00"),
+                "due_date": date(2024, 1, 17),
                 "state": PAYMENT_STATE_PENDING,
             },
         )
@@ -142,26 +143,26 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_REFUSED,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],
@@ -230,8 +231,8 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
                 credit_card_token=order.credit_card.token,
                 installment={
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ),
@@ -240,8 +241,8 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
                 credit_card_token=order.credit_card.token,
                 installment={
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ),
@@ -250,6 +251,7 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
         mocked_now = datetime(2024, 3, 17, 0, 0, tzinfo=ZoneInfo("UTC"))
         with mock.patch("django.utils.timezone.now", return_value=mocked_now):
             debit_pending_installment.run(order.id)
+
         mock_create_zero_click_payment.assert_has_calls(expected_calls, any_order=False)
 
         backend = get_payment_backend()
@@ -294,26 +296,26 @@ class PaymentScheduleTasksTestCase(TestCase, BaseLogMixinTestCase):
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": PAYMENT_STATE_PENDING,
                 },
             ],

--- a/src/backend/joanie/tests/core/test_api_contract.py
+++ b/src/backend/joanie/tests/core/test_api_contract.py
@@ -1382,7 +1382,7 @@ class ContractApiTest(BaseAPITestCase):
                 payment_schedule=[
                     {
                         "amount": "200.00",
-                        "due_date": "2024-01-17T00:00:00+00:00",
+                        "due_date": "2024-01-17",
                         "state": enums.PAYMENT_STATE_PAID,
                     }
                 ],
@@ -1474,7 +1474,7 @@ class ContractApiTest(BaseAPITestCase):
                 payment_schedule=[
                     {
                         "amount": "200.00",
-                        "due_date": "2024-01-17T00:00:00+00:00",
+                        "due_date": "2024-01-17",
                         "state": enums.PAYMENT_STATE_PAID,
                     }
                 ],

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -2037,7 +2037,7 @@ class EnrollmentApiTest(BaseAPITestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
             ],

--- a/src/backend/joanie/tests/core/test_flows_order.py
+++ b/src/backend/joanie/tests/core/test_flows_order.py
@@ -224,7 +224,7 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "10.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -989,22 +989,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
             ],
@@ -1024,22 +1024,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
             ],
@@ -1059,22 +1059,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1094,22 +1094,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1130,22 +1130,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_REFUSED,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1165,22 +1165,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1200,22 +1200,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_REFUSED,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1235,22 +1235,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1270,22 +1270,22 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-02-17T00:00:00+00:00",
+                    "due_date": "2024-02-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "amount": "300.00",
-                    "due_date": "2024-03-17T00:00:00+00:00",
+                    "due_date": "2024-03-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "amount": "199.99",
-                    "due_date": "2024-04-17T00:00:00+00:00",
+                    "due_date": "2024-04-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -1306,7 +1306,7 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -371,7 +371,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -828,7 +828,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],
@@ -996,7 +996,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
             payment_schedule=[
                 {
                     "amount": "200.00",
-                    "due_date": "2024-01-17T00:00:00+00:00",
+                    "due_date": "2024-01-17",
                     "state": enums.PAYMENT_STATE_PAID,
                 }
             ],

--- a/src/backend/joanie/tests/core/utils/test_emails_prepare_context_data.py
+++ b/src/backend/joanie/tests/core/utils/test_emails_prepare_context_data.py
@@ -1,5 +1,6 @@
 """Test suite for `prepare_context_data` email utility for installment payments"""
 
+from datetime import date
 from decimal import Decimal
 
 from django.test import TestCase, override_settings
@@ -24,6 +25,8 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
     """
     Test suite for `prepare_context_data` for email utility when installment is paid or refused
     """
+
+    maxDiff = None
 
     def test_utils_emails_prepare_context_data_when_installment_debit_is_successful(
         self,
@@ -66,7 +69,7 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
+                    "amount": "200.00",
                     "due_date": "2024-04-17",
                     "state": PAYMENT_STATE_PENDING,
                 },
@@ -94,8 +97,8 @@ class UtilsEmailPrepareContextDataInstallmentPaymentTestCase(TestCase):
                     "name": "Test Catalog",
                     "url": "https://richie.education",
                 },
-                "remaining_balance_to_pay": Money("499.99"),
-                "date_next_installment_to_pay": "2024-03-17",
+                "remaining_balance_to_pay": Money("500.00"),
+                "date_next_installment_to_pay": date(2024, 3, 17),
                 "targeted_installment_index": 1,
             },
         )

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -1,12 +1,15 @@
 """Test suite of the Base Payment backend"""
 
 import smtplib
+from datetime import date
 from decimal import Decimal
 from logging import Logger
 from unittest import mock
 
 from django.core import mail
 from django.test import override_settings
+
+from stockholm import Money
 
 from joanie.core import enums
 from joanie.core.factories import (
@@ -322,26 +325,26 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": enums.PAYMENT_STATE_PAID,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],
@@ -505,26 +508,26 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
             [
                 {
                     "id": "d9356dd7-19a6-4695-b18e-ad93af41424a",
-                    "amount": "200.00",
-                    "due_date": "2024-01-17",
+                    "amount": Money("200.00"),
+                    "due_date": date(2024, 1, 17),
                     "state": enums.PAYMENT_STATE_REFUSED,
                 },
                 {
                     "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
-                    "amount": "300.00",
-                    "due_date": "2024-02-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 2, 17),
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "168d7e8c-a1a9-4d70-9667-853bf79e502c",
-                    "amount": "300.00",
-                    "due_date": "2024-03-17",
+                    "amount": Money("300.00"),
+                    "due_date": date(2024, 3, 17),
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
                 {
                     "id": "9fcff723-7be4-4b77-87c6-2865e000f879",
-                    "amount": "199.99",
-                    "due_date": "2024-04-17",
+                    "amount": Money("199.99"),
+                    "due_date": date(2024, 4, 17),
                     "state": enums.PAYMENT_STATE_PENDING,
                 },
             ],


### PR DESCRIPTION
## Purpose

The **OrderPaymentScheduleDecoder** was returning a **string representation** of the due_date **instead** of a **datetime.date object**. This behavior complicated **comparisons** and **operations**, as handling both strings and date objects increased the complexity for nothing.

To simplify date **handling** and ensure **consistency**, a transformation was added to the decoder, converting the string from the database into a datetime.date object. 

## Proposal

- [x] Update the `OrderPaymentScheduleDecoder` to transform the string representing the due_date into a datetime.date object, and the factories ( `OrderFactory` and `OrderGeneratorFactory` ) which led to update the methods where it compares the installment's due_date a date object.