### PR TITLE
 🐛(backend)  add timeout handling for submit for signature on order model when deleting signature procedure (for dev branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 
 ### Fixed
 
+- Handle timeout in `submit_for_signature` to update the contract
+  without the outdated references
 - Prevent duplicate Address objects for a user or an organization
 - Allow to cancel an enrollment order linked to an archived course run
 

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -16,6 +16,7 @@ from django.utils.translation import gettext_lazy as _
 
 import requests
 from parler import models as parler_models
+from requests.exceptions import ReadTimeout
 from stockholm import Money
 from urllib3.util import Retry
 
@@ -1020,9 +1021,30 @@ class Order(BaseModel):
         )
 
         if should_be_resubmitted:
-            backend_signature.delete_signing_procedure(
-                self.contract.signature_backend_reference
-            )
+            # The signature provider may take some time to respond with the confirmation of the
+            # deletion. If we reach the timeout limit, we should reset the contract submission
+            # values because the signature provider will delete them.
+            # We won't be able to use the `contract.signature_backend_reference` again.
+            try:
+                backend_signature.delete_signing_procedure(
+                    self.contract.signature_backend_reference
+                )
+            except ReadTimeout as exception:  # pylint: disable=unused-variable
+                message = (
+                    "Signature Provider is taking a while on deletion "
+                    f"of reference {self.contract.signature_backend_reference}."
+                )
+                logger.error(
+                    message,
+                    extra={
+                        "context": {
+                            "order": self.to_dict(),
+                            "product": self.product.to_dict(),
+                        }
+                    },
+                )
+                self.contract.reset_submission_for_signature()
+                was_already_submitted = False
 
         # We want to submit or re-submit the contract for signature in three cases:
         # 1- the contract was never submitted for signature before


### PR DESCRIPTION
 ## Purpose

We have identified an issue with the signature provider that we use, where it takes a while before responding back to us that the workflow has been deleted on their side. This issue was letting our `contract` with outdated references, which would cause bugs afterwards when the student request the invitation link to sign the document. Simply, because the 
`signature_backend_reference` would not exists anymore on the signature provider side and because he still managed to delete the previous signature backend reference of the workflow (but we never got the answer back in time).

To avoid this situation, we have added a timeout handling in `submit_for_signature` to update the contract after signature provider delay to delete the old signature workflow. This fix catches timeout errors during the deletion process when contract elements change before student signs. It ensures the contract is updated correctly, preventing errors caused by outdated references after the timeout.

## Proposal

- [x] Add timeout handling in the method `submit_for_signature` of the Order model