### PR TITLE
🐛(backend) do not list all enrollments in admin order view

### DIFF
--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -576,7 +576,7 @@ class OrderAdmin(DjangoObjectActions, admin.ModelAdmin):
     """Admin class for the Order model"""
 
     actions = (ACTION_NAME_CANCEL, ACTION_NAME_GENERATE_CERTIFICATES)
-    autocomplete_fields = ["course", "organization", "owner", "product"]
+    autocomplete_fields = ["course", "enrollment", "organization", "owner", "product"]
     change_actions = (ACTION_NAME_GENERATE_CERTIFICATES,)
     list_display = ("id", "organization", "owner", "product", "state")
     list_filter = [OwnerFilter, OrganizationFilter, ProductFilter, "state"]


### PR DESCRIPTION


## Purpose

As we have a very large amount of enrollments in our staging and production database, we can't display them all in a select box. Using an autocomplete field prevent this.
