### PR TITLE
🥅 (backend) improve error catching of signature notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Fixed
 
+- Improve signature backend `handle_notification` error catching
 - Allow to cancel an enrollment order linked to an archived course run
 
 ## [2.6.1] - 2024-07-25

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
@@ -78,16 +78,8 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase
 
         backend = get_signature_backend()
 
-        with (
-            self.assertRaises(ValidationError) as context,
-            self.assertLogs("joanie") as logger,
-        ):
+        with self.assertLogs("joanie") as logger:
             backend.handle_notification(request)
-
-        self.assertEqual(
-            str(context.exception),
-            "['The notification workflowStarted is not supported.']",
-        )
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(responses.calls[0].request.url, api_url)
@@ -155,16 +147,8 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase
         )
         backend = get_signature_backend()
 
-        with (
-            self.assertRaises(ValidationError) as context,
-            self.assertLogs("joanie") as logger,
-        ):
+        with self.assertLogs("joanie") as logger:
             backend.handle_notification(request)
-
-        self.assertEqual(
-            str(context.exception),
-            "['The notification workflowStopped is not supported.']",
-        )
 
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(responses.calls[0].request.url, api_url)
@@ -497,16 +481,9 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase
 
         backend = get_signature_backend()
 
-        with (
-            self.assertRaises(ValidationError) as context,
-            self.assertLogs("joanie") as logger,
-        ):
+        with self.assertLogs("joanie") as logger:
             backend.handle_notification(request)
 
-        self.assertEqual(
-            str(context.exception),
-            "['The contract validity date of expiration has passed.']",
-        )
         self.assertIsNotNone(contract.submitted_for_signature_on)
         self.assertIsNone(contract.student_signed_on)
         self.assertLogsEquals(


### PR DESCRIPTION
## Purpose

Currently, when your signature provider sends a notification, if our internal logic raise an error, an error HTTP Response is returned. Then the signature provider will retry to send this notification and it could lead to heavy latency to receive other notification. So we improve error catching from your side to prevent to return Error HTTP response if an error is raised from an internal server error.