### PR TITLE
✅(backend) Fix failing tests due to missing updates of the `OrderFactory` and improve `OrderGeneratorFactory`

### DIFF
--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -671,9 +671,9 @@ class OrderFactory(factory.django.DjangoModelFactory):
                 extracted.save()
                 return extracted
 
-            if self.state == enums.ORDER_STATE_COMPLETED:
-                # If the order is not fee and its state is validated, create
-                # a main invoice with related transaction.
+            if self.state != enums.ORDER_STATE_DRAFT and not self.is_free:
+                # If the order is not free and its state is not 'draft'
+                # create a main invoice with related transaction.
                 from joanie.payment.factories import (  # pylint: disable=import-outside-toplevel, cyclic-import
                     TransactionFactory,
                 )

--- a/src/backend/joanie/demo/management/commands/create_dev_demo.py
+++ b/src/backend/joanie/demo/management/commands/create_dev_demo.py
@@ -253,10 +253,6 @@ class Command(BaseCommand):
             student_signed_on=django_timezone.now(),
         )
 
-        payment_factories.InvoiceFactory(
-            order=order, recipient_address__owner=order.owner, total=order.total
-        )
-
         order.generate_schedule()
         installment = order.payment_schedule[0]
         order.set_installment_refused(installment["id"])

--- a/src/backend/joanie/tests/core/api/order/test_payment_method.py
+++ b/src/backend/joanie/tests/core/api/order/test_payment_method.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 
 from joanie.core import enums, factories
 from joanie.core.models import CourseState
-from joanie.payment.factories import CreditCardFactory, InvoiceFactory
+from joanie.payment.factories import CreditCardFactory
 from joanie.tests.base import BaseAPITestCase
 
 
@@ -127,7 +127,6 @@ class OrderPaymentMethodApiTest(BaseAPITestCase):
             state=enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
             credit_card=None,
         )
-        InvoiceFactory(order=order)
 
         self.assertFalse(order.has_payment_method)
 

--- a/src/backend/joanie/tests/core/api/order/test_read_list.py
+++ b/src/backend/joanie/tests/core/api/order/test_read_list.py
@@ -1017,7 +1017,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "credit_card_id": str(order.credit_card.id),
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice_reference": None,
+                        "main_invoice_reference": order.main_invoice.reference,
                         "order_group_id": None,
                         "organization": {
                             "id": str(order.organization.id),
@@ -1109,7 +1109,7 @@ class OrderListApiTest(BaseAPITestCase):
                         "credit_card_id": None,
                         "enrollment": None,
                         "target_enrollments": [],
-                        "main_invoice_reference": order.main_invoice.reference,
+                        "main_invoice_reference": None,
                         "order_group_id": None,
                         "organization": {
                             "id": str(order.organization.id),

--- a/src/backend/joanie/tests/core/api/order/test_submit_installment_payment.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_installment_payment.py
@@ -23,10 +23,7 @@ from joanie.core.enums import (
 from joanie.core.factories import OrderFactory, ProductFactory, UserFactory
 from joanie.payment.backends.dummy import DummyPaymentBackend
 from joanie.payment.exceptions import PaymentProviderAPIException
-from joanie.payment.factories import (
-    CreditCardFactory,
-    InvoiceFactory,
-)
+from joanie.payment.factories import CreditCardFactory
 from joanie.tests.base import BaseAPITestCase
 
 
@@ -341,7 +338,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
                 },
             ],
         )
-        InvoiceFactory(order=order)
         token = self.generate_token_from_user(user)
 
         response = self.client.post(
@@ -417,7 +413,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
                 },
             ],
         )
-        InvoiceFactory(order=order)
         credit_card = CreditCardFactory(owner=user)
         payload = {"credit_card_id": credit_card.id}
         token = self.generate_token_from_user(user)
@@ -487,7 +482,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
                 },
             ],
         )
-        InvoiceFactory(order=order)
         token = self.generate_token_from_user(user)
 
         response = self.client.post(
@@ -547,7 +541,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
                 },
             ],
         )
-        InvoiceFactory(order=order)
         payload = {"credit_card_id": credit_card.id}
         token = self.generate_token_from_user(user)
 
@@ -617,7 +610,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
                 },
             ],
         )
-        InvoiceFactory(order=order)
         token = self.generate_token_from_user(user)
 
         response = self.client.post(
@@ -685,7 +677,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
                 },
             ],
         )
-        InvoiceFactory(order=order)
         token = self.generate_token_from_user(user)
 
         response = self.client.post(
@@ -759,7 +750,6 @@ class OrderSubmitInstallmentPaymentApiTest(BaseAPITestCase):
                 },
             ],
         )
-        InvoiceFactory(order=order)
         credit_card = CreditCardFactory(owner=user)
         payload = {"credit_card_id": credit_card.id}
         token = self.generate_token_from_user(user)

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -18,7 +18,6 @@ from joanie.core.factories import CourseRunFactory, EnrollmentFactory
 from joanie.core.models import CourseState
 from joanie.core.serializers import fields
 from joanie.lms_handler.backends.openedx import OpenEdXLMSBackend
-from joanie.payment.factories import InvoiceFactory
 from joanie.tests import format_date
 from joanie.tests.base import BaseAPITestCase
 
@@ -2043,11 +2042,8 @@ class EnrollmentApiTest(BaseAPITestCase):
             ],
         )
         order.flow.complete()
-
-        # - Create an invoice related to the order to mark it as validated and trigger the
-        #   auto enrollment logic on validate transition
-        InvoiceFactory(order=order, total=order.total)
-
+        # OrderFactory creates an invoice related to the order to mark
+        # it as validated and trigger the auto enrollment logic on validate transition
         # The enrollment should have been activated automatically
         enrollment.refresh_from_db()
         self.assertTrue(enrollment.is_active)

--- a/src/backend/joanie/tests/core/test_flows_order.py
+++ b/src/backend/joanie/tests/core/test_flows_order.py
@@ -27,11 +27,7 @@ from joanie.lms_handler.backends.openedx import (
     OPENEDX_MODE_VERIFIED,
 )
 from joanie.payment.backends.dummy import DummyPaymentBackend
-from joanie.payment.factories import (
-    BillingAddressDictFactory,
-    CreditCardFactory,
-    InvoiceFactory,
-)
+from joanie.payment.factories import BillingAddressDictFactory, CreditCardFactory
 from joanie.tests.base import BaseLogMixinTestCase
 
 
@@ -232,7 +228,6 @@ class OrderFlowsTestCase(TestCase, BaseLogMixinTestCase):
                 }
             ],
         )
-        InvoiceFactory(order=order_invoice)
         self.assertEqual(order_invoice.flow._can_be_state_completed(), True)  # pylint: disable=protected-access
         order_invoice.flow.complete()
         self.assertEqual(order_invoice.state, enums.ORDER_STATE_COMPLETED)

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -377,9 +377,8 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
             ],
         )
 
-        # 2 - When an invoice is linked to the order, and the method complete() is
-        # called its state is `completed`
-        InvoiceFactory(order=order, total=order.total)
+        # 2 - OrderFactory creates the invoice linked to the order,
+        # and the method complete() is called, then its state becomes `completed`
         order.flow.complete()
         self.assertEqual(order.state, enums.ORDER_STATE_COMPLETED)
 

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -20,11 +20,7 @@ from joanie.core.factories import (
 )
 from joanie.core.models import Address
 from joanie.payment.backends.base import BasePaymentBackend
-from joanie.payment.factories import (
-    BillingAddressDictFactory,
-    CreditCardFactory,
-    InvoiceFactory,
-)
+from joanie.payment.factories import BillingAddressDictFactory, CreditCardFactory
 from joanie.payment.models import Transaction
 from joanie.tests.base import ActivityLogMixingTestCase
 from joanie.tests.payment.base_payment import BasePaymentTestCase
@@ -836,7 +832,6 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
             ],
         )
         billing_address = BillingAddressDictFactory()
-        InvoiceFactory(order=order)
         payment = {
             "id": "pay_0",
             "amount": 30000,
@@ -913,7 +908,6 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
             ],
         )
         billing_address = BillingAddressDictFactory()
-        InvoiceFactory(order=order)
         payment = {
             "id": "pay_0",
             "amount": 30000,
@@ -974,7 +968,6 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
             ],
         )
         billing_address = BillingAddressDictFactory()
-        InvoiceFactory(order=order)
         payment_0 = {
             "id": "pay_0",
             "amount": 20000,
@@ -1102,7 +1095,6 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
                 },
             ],
         )
-        InvoiceFactory(order=order)
         billing_address = BillingAddressDictFactory()
         payment = {
             "id": "pay_0",


### PR DESCRIPTION
## Purpose

In a past [PR](https://github.com/openfun/joanie/pull/916), we have added in the `post_transition_success` of the **order flows** to enable a payment for the user if the course has already started (and the 1st installment due date is on the current day), which allows the student to enter the course directly instead of waiting overnight.

By adding this new transition action when the state goes from `to_save_payment_method` to `pending`, it seems like somes tests failed suddenly after the branch being merged to `dev` branch. 

We've decided to fix the `OrderFactory` class by creating main invoice when the order is not in state `draft`. 
It eases the life of developers while testing that specific state for an order,  they won't have to create the main invoice by hand in a test after creating the order. On the order hand, it will protect the order because there is a protected foreign key relationship with the invoice created and the order, making the order not deletable.

Since we are working on the Order factories, I've identified that the paid installment in an order didn't have a transaction nor a children invoices related to when using `OrderGeneratorFactory`.  I've decided to add them because
they should be created when an installment is paid.

## Proposal

- [x] Adjust `OrderFactory` to create main invoice when the state is `to_save_payment_method`.
- [x] Improve `OrderGeneratorFactory` to create transactions and children invoices when an installment is paid depending the state used when creating an order. 
