### PR TITLE
💚(circleci) upgrade remote_docker for hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,7 +601,7 @@ jobs:
       - <<: *generate-version-file
       # Activate docker-in-docker
       - setup_remote_docker:
-          version: 20.10.23
+          version: default
       - run:
           name: Build production image
           command: docker build -t joanie:${CIRCLE_SHA1} --target production .


### PR DESCRIPTION
## Purpose

remote_docker version 20.10.23 has been deprecated. We use the `default` version to prevent future issue of this kind.