### PR TITLE
✨(backend) display payment schedule in contract template 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to
 - Send an email to the user when an installment is successfully
   paid
 - Support of payment_schedule for certificate products
+- Display payment schedule in contract template
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to
 - Update the task `debit_pending_installment` to catch up on late
   payments of installments that are in the past
 - Deprecated field `has_consent_to_terms` for `Order` model
+- Move signature fields before appendices in contract definition template
 
 ### Fixed
 

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -1068,7 +1068,7 @@ class Order(BaseModel):
             for key, value in aggregate.items()
         }
 
-    def _get_schedule_dates(self):
+    def get_schedule_dates(self):
         """
         Return the schedule dates for the order.
         The schedules date are based on contract sign date or the time the schedule is generated
@@ -1099,7 +1099,7 @@ class Order(BaseModel):
         Generate payment schedule for the order.
         """
         beginning_contract_date, course_start_date, course_end_date = (
-            self._get_schedule_dates()
+            self.get_schedule_dates()
         )
         installments = generate_payment_schedule(
             self.total, beginning_contract_date, course_start_date, course_end_date

--- a/src/backend/joanie/core/templates/issuers/contract_definition.css
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.css
@@ -125,6 +125,7 @@
   flex-direction: row;
   justify-content: space-between;
   margin-top: 20mm;
+  page-break-after: always;
 }
 
 /* == Content - Syllabus appendix */

--- a/src/backend/joanie/core/templates/issuers/contract_definition.css
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.css
@@ -128,6 +128,68 @@
   page-break-after: always;
 }
 
+/* == Context - Payment schedule appendix */
+.installments-table {
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.installments-table th {
+  padding: 1mm 2mm;
+}
+.installments-table tfoot td:last-child,
+.installments-table tbody td {
+  padding: 3mm 2mm;
+}
+
+.installments-table th:first-child {
+  min-width: 40mm;
+}
+.installments-table th:last-child {
+  min-width: 25mm;
+}
+
+.installments-table tfoot td:first-child {
+  text-align: right;
+}
+
+.installments-table tbody tr td:first-child{
+  border-left: thin solid #BBB;
+}
+
+.installments-table tbody tr td:last-child{
+  border-right: thin solid #BBB;
+}
+
+.installments-table tbody tr:first-child td:first-child{
+  border-left: thin solid #BBB;
+  border-top: thin solid #BBB;
+  border-radius: 4px 0 0 0;
+}
+.installments-table tbody tr:first-child td:last-child{
+  border-right: thin solid #BBB;
+  border-top: thin solid #BBB;
+  border-radius: 0 4px 0 0;
+}
+.installments-table tbody tr:last-child td:first-child{
+  border-left: thin solid #BBB;
+  border-bottom: thin solid #BBB;
+  border-radius: 0 0 0 4px;
+}
+.installments-table tbody tr:last-child td:last-child{
+  border-right: thin solid #BBB;
+  border-bottom: thin solid #BBB;
+  border-radius: 0 0 4px 0;
+}
+
+.installments-table tr:nth-child(even) {
+  background: #ebebeb;
+}
+
+.installments-table tfoot {
+  font-weight: bold;
+}
+
 /* == Content - Syllabus appendix */
 .syllabus--header {
   background: #e67a00;

--- a/src/backend/joanie/core/templates/issuers/contract_definition.html
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.html
@@ -119,30 +119,30 @@ this template as a base.
                   </dd>
               </dl>
           </section>
-          <section class="content-articles">
+          <article class="content-articles">
               {% if contract %}
                   {{ contract.body|safe }}
               {% endif %}
+              <section class="content-signatures">
+                  <div class="signature_zone">
+                      <p>{% translate "Learner's signature :" %}</p>
+                      <div class="signature-recipient">
+                          [SignatureField#1]
+                      </div>
+                  </div>
+                  <div class="signature_zone">
+                      <p>{% translate "University representative's signature :" %}</p>
+                      <div class="signature-recipient">
+                          [SignatureField#2]
+                      </div>
+                  </div>
+              </section>
               {% if syllabus %}
                 <h2>{% translate "Appendices" %}</h2>
                 <h3>{% translate "Catalog syllabus" %}</h3>
                 {% include "contract_definition/fragment_appendice_syllabus.html" with syllabus=syllabus %}
               {% endif %}
-          </section>
-          <footer class="content-signatures">
-              <div class="signature_zone">
-                  <p>{% translate "Learner's signature :" %}</p>
-                  <div class="signature-recipient">
-                      [SignatureField#1]
-                  </div>
-              </div>
-              <div class="signature_zone">
-                  <p>{% translate "University representative's signature :" %}</p>
-                  <div class="signature-recipient">
-                      [SignatureField#2]
-                  </div>
-              </div>
-          </footer>
+          </article>
       </main>
     </body>
 </html>

--- a/src/backend/joanie/core/templates/issuers/contract_definition.html
+++ b/src/backend/joanie/core/templates/issuers/contract_definition.html
@@ -137,8 +137,39 @@ this template as a base.
                       </div>
                   </div>
               </section>
-              {% if syllabus %}
+              {% if syllabus or student.payment_schedule %}
                 <h2>{% translate "Appendices" %}</h2>
+              {% endif %}
+              {% if student.payment_schedule %}
+                <h3>{% translate "Payment schedule" %}</h3>
+                <table class="installments-table">
+                    <thead>
+                        <tr>
+                            <th>{% translate "Due date" %}</th>
+                            <th>{% translate "Amount" %}</th>
+                        </tr>
+                    </thead>
+                    <tfoot>
+                        <tr>
+                            <td>
+                                {% translate "Total :" %}
+                            </td>
+                            <td>
+                                {{ course.price|floatformat:2 }}&nbsp;{{ course.currency }}
+                            </td>
+                        </tr>
+                    </tfoot>
+                    <tbody>
+                        {% for payment in student.payment_schedule %}
+                        <tr>
+                            <td>{{ payment.due_date|iso8601_to_date:"SHORT_DATE_FORMAT" }}</td>
+                            <td>{{ payment.amount|floatformat:2 }}&nbsp;{{ course.currency }}</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+              {% endif %}
+              {% if syllabus %}
                 <h3>{% translate "Catalog syllabus" %}</h3>
                 {% include "contract_definition/fragment_appendice_syllabus.html" with syllabus=syllabus %}
               {% endif %}

--- a/src/backend/joanie/tests/core/models/order/test_schedule.py
+++ b/src/backend/joanie/tests/core/models/order/test_schedule.py
@@ -66,7 +66,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         )
 
         signed_contract_date, course_start_date, course_end_date = (
-            contract.order._get_schedule_dates()
+            contract.order.get_schedule_dates()
         )
 
         self.assertEqual(signed_contract_date, student_signed_on_date)
@@ -92,7 +92,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
         mocked_now = datetime(2024, 1, 1, 14, tzinfo=ZoneInfo("UTC"))
         with mock.patch("django.utils.timezone.now", return_value=mocked_now):
             signed_contract_date, course_start_date, course_end_date = (
-                order._get_schedule_dates()
+                order.get_schedule_dates()
             )
 
         self.assertEqual(signed_contract_date, mocked_now)
@@ -112,7 +112,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase, ActivityLogMixingTestC
             self.assertRaises(ValidationError) as context,
             self.assertLogs("joanie") as logger,
         ):
-            contract.order._get_schedule_dates()
+            contract.order.get_schedule_dates()
 
         self.assertEqual(
             str(context.exception), "['Cannot retrieve start or end date for order']"

--- a/src/backend/joanie/tests/core/utils/test_contract_definition_generate_document_context.py
+++ b/src/backend/joanie/tests/core/utils/test_contract_definition_generate_document_context.py
@@ -107,15 +107,12 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
                 effort=timedelta(hours=10, minutes=30, seconds=12),
             ),
         )
-        order = factories.OrderFactory(
+        order = factories.OrderGeneratorFactory(
             owner=user,
             product=relation.product,
             course=relation.course,
             state=enums.ORDER_STATE_COMPLETED,
             main_invoice=InvoiceFactory(recipient_address=user_address),
-        )
-        factories.OrderTargetCourseRelationFactory(
-            course=relation.course, order=order, position=1
         )
 
         context = contract_definition.generate_document_context(
@@ -157,6 +154,13 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
                 },
                 "email": user.email,
                 "phone_number": str(user.phone_number),
+                "payment_schedule": [
+                    {
+                        "due_date": installment["due_date"].isoformat(),
+                        "amount": str(installment["amount"]),
+                    }
+                    for installment in order.payment_schedule
+                ],
             },
             "organization": {
                 "address": {
@@ -243,6 +247,7 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
                 },
                 "email": str(user.email),
                 "phone_number": str(user.phone_number),
+                "payment_schedule": None,
             },
             "organization": {
                 "address": {
@@ -319,6 +324,7 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
                 },
                 "email": "<STUDENT_EMAIL>",
                 "phone_number": "<STUDENT_PHONE_NUMBER>",
+                "payment_schedule": None,
             },
             "organization": {
                 "address": {


### PR DESCRIPTION
## Purpose

For legal purpose, we must display the order payment schedule in the training
contract that's why we bind this information into the contract template.

Furthermore, we move the signature fields before appendices section.

<img width="643" alt="Capture d’écran 2024-10-03 à 18 23 32" src="https://github.com/user-attachments/assets/385b6641-954e-4611-bea2-a80a58400cfe">

[contract-example.pdf](https://github.com/user-attachments/files/17248254/contract-example.pdf)
