### PR TITLE
👔(backend) update `handle_notification` signature backend logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to
   payments of installments that are in the past
 - Deprecated field `has_consent_to_terms` for `Order` model
 - Move signature fields before appendices in contract definition template
+- Update `handle_notification` signature backend to confirm signature 
 
 ### Fixed
 

--- a/docs/explanation/lex-persona.md
+++ b/docs/explanation/lex-persona.md
@@ -200,7 +200,7 @@ ___
     "hideAttachments" : false,
     "hideWorkflowRecipients" : true
   } ],
-  "notifiedEvents" : [ "recipientRefused", "recipientFinished", "workflowStopped", "workflowFinished" ],
+  "notifiedEvents" : [ "recipientRefused", "recipientFinished" ],
   "watchers" : []
 }
 ```
@@ -221,9 +221,7 @@ ___
     "name": "Aerodynamic Silk Bottle",
     "notifiedEvents": [
         "recipientRefused",
-        "recipientFinished",
-        "workflowStopped",
-        "workflowFinished"
+        "recipientFinished"
     ],
     "progress": 0,
     "steps": [
@@ -523,9 +521,7 @@ ___
     "name": "Aerodynamic Silk Bottle",
     "notifiedEvents": [
         "recipientRefused",
-        "recipientFinished",
-        "workflowStopped",
-        "workflowFinished"
+        "recipientFinished"
     ],
     "progress": 0,
     "started": 1688994896088,
@@ -629,7 +625,7 @@ If you prefer to **send invitation link from your business application**, you ca
     "hideAttachments" : false,
     "hideWorkflowRecipients" : true
   } ],
-  "notifiedEvents" : [ "recipientRefused", "recipientFinished", "workflowStopped", "workflowFinished" ],
+  "notifiedEvents" : [ "recipientRefused", "recipientFinished" ],
   "watchers" : []
 }
 ```
@@ -675,9 +671,7 @@ Once those steps through the user are finished, we can now check our `workflowSt
     "name": "Aerodynamic Silk Bottle",
     "notifiedEvents": [
         "recipientRefused",
-        "recipientFinished",
-        "workflowStopped",
-        "workflowFinished"
+        "recipientFinished"
     ],
     "progress": 100,
     "started": 1689092760018,
@@ -921,8 +915,7 @@ otherwise, you need to update both steps. (**example 2**)
     "name": "Some title of signature procedure",
     "notifiedEvents": [
         "recipientFinished",
-        "workflowStopped",
-        "workflowFinished"
+        "workflowStopped"
     ],
     "progress": 50,
     "started": 1713365343105,
@@ -1108,8 +1101,7 @@ otherwise, you need to update both steps. (**example 2**)
     "name": "Title of the signature procedure",
     "notifiedEvents": [
         "recipientFinished",
-        "workflowStopped",
-        "workflowFinished"
+        "workflowStopped"
     ],
     "progress": 0,
     "started": 1713362011673,

--- a/docs/explanation/signature_backend.md
+++ b/docs/explanation/signature_backend.md
@@ -110,7 +110,7 @@ payload = {
     ],
     "notifiedEvents": [
         "recipientRefused",
-        "workflowFinished",
+        "recipientFinished",
     ],
     "watchers": [],
 }

--- a/src/backend/joanie/signature/backends/dummy.py
+++ b/src/backend/joanie/signature/backends/dummy.py
@@ -75,10 +75,8 @@ class DummySignatureBackend(BaseSignatureBackend):
         event_type = request.data.get("event_type")
         reference_id = request.data.get("reference")
 
-        if event_type == "signed":
-            self.confirm_student_signature(reference_id)
-        elif event_type == "finished":
-            self.confirm_organization_signature(reference_id)
+        if event_type in ["signed", "finished"]:
+            self.confirm_signature(reference_id)
         else:
             logger.error("'%s' is not an event type that we handle.")
             raise ValidationError(

--- a/src/backend/joanie/signature/backends/lex_persona.py
+++ b/src/backend/joanie/signature/backends/lex_persona.py
@@ -150,7 +150,6 @@ class LexPersonaBackend(BaseSignatureBackend):
             "notifiedEvents": [
                 "recipientRefused",
                 "recipientFinished",
-                "workflowFinished",
             ],
             "watchers": [],
         }
@@ -473,10 +472,8 @@ class LexPersonaBackend(BaseSignatureBackend):
         try:
             # ruff : noqa : BLE001
             # pylint: disable=broad-exception-caught
-            if event_type == "workflowFinished":
-                self.confirm_organization_signature(reference_id)
-            elif event_type == "recipientFinished":
-                self.confirm_student_signature(reference_id)
+            if event_type == "recipientFinished":
+                self.confirm_signature(reference_id)
             elif event_type == "recipientRefused":
                 self.reset_contract(reference_id)
             else:

--- a/src/backend/joanie/tests/core/api/order/test_lifecycle.py
+++ b/src/backend/joanie/tests/core/api/order/test_lifecycle.py
@@ -58,9 +58,7 @@ class OrderLifecycle(BaseAPITestCase):
         self.assertEqual(order.state, enums.ORDER_STATE_SIGNING)
 
         backend = get_signature_backend()
-        backend.confirm_student_signature(
-            reference=order.contract.signature_backend_reference
-        )
+        backend.confirm_signature(reference=order.contract.signature_backend_reference)
 
         order.refresh_from_db()
         self.assertEqual(order.state, enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD)

--- a/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/core/api/order/test_submit_for_signature.py
@@ -182,9 +182,7 @@ class OrderSubmitForSignatureApiTest(BaseAPITestCase):
         self.assertIn(expected_substring_invite_url, invitation_url)
 
         backend = get_signature_backend()
-        backend.confirm_student_signature(
-            reference=order.contract.signature_backend_reference
-        )
+        backend.confirm_signature(reference=order.contract.signature_backend_reference)
         order.refresh_from_db()
         self.assertIsNotNone(order.contract.student_signed_on)
 

--- a/src/backend/joanie/tests/core/models/order/test_factory.py
+++ b/src/backend/joanie/tests/core/models/order/test_factory.py
@@ -36,7 +36,7 @@ from joanie.payment.models import Invoice, Transaction
 class TestOrderGeneratorFactory(TestCase):
     """Test suite for the OrderGeneratorFactory."""
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     # ruff: noqa: PLR0913
     def check_order(
         self,

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -654,9 +654,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         self.assertNotIn("logo_id", context_with_images["organization"])
 
         backend = get_signature_backend()
-        backend.confirm_student_signature(
-            reference=order.contract.signature_backend_reference
-        )
+        backend.confirm_signature(reference=order.contract.signature_backend_reference)
         order.refresh_from_db()
         self.assertIsNotNone(order.contract.student_signed_on)
 
@@ -728,9 +726,7 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         self.assertIsNone(contract.student_signed_on)
 
         backend = get_signature_backend()
-        backend.confirm_student_signature(
-            reference=order.contract.signature_backend_reference
-        )
+        backend.confirm_signature(reference=order.contract.signature_backend_reference)
         order.refresh_from_db()
         self.assertIsNotNone(order.contract.student_signed_on)
 

--- a/src/backend/joanie/tests/signature/backends/lex_persona/__init__.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/__init__.py
@@ -19,8 +19,6 @@ def get_expected_workflow_payload(workflow_status):
         "notifiedEvents": [
             "recipientRefused",
             "recipientFinished",
-            "workflowStopped",
-            "workflowFinished",
         ],
         "progress": 0,
         "steps": [

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_handle_notification.py
@@ -347,7 +347,7 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase
         )
 
     @responses.activate
-    def test_backend_lex_persona_handle_notification_workflow_finished_event(self):
+    def test_backend_lex_persona_handle_notification_recipient_finished_event(self):
         """
         When an incoming event type is 'recipientFinished', and the event has been verified,
         then the contract which has the signature backend reference should get updated
@@ -421,7 +421,7 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase
         JOANIE_SIGNATURE_VALIDITY_PERIOD_IN_SECONDS=60 * 60 * 24 * 15,
     )
     @responses.activate
-    def test_backend_lex_persona_handle_notification_workflow_finished_event_but_signature_expired(
+    def test_backend_lex_persona_handle_notification_recipent_finished_event_but_signature_expired(
         self,
     ):
         """
@@ -439,7 +439,7 @@ class LexPersonaBackendHandleNotificationTestCase(TestCase, BaseLogMixinTestCase
             definition=order.product.contract_definition,
             signature_backend_reference="wfl_id_fake",
             definition_checksum="fake_test_file_hash",
-            context="content",
+            context={"body": "content"},
             submitted_for_signature_on=django_timezone.now() - timedelta(days=16),
         )
         request_data = {

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_submit_for_signature.py
@@ -61,8 +61,6 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
             "notifiedEvents": [
                 "recipientRefused",
                 "recipientFinished",
-                "workflowStopped",
-                "workflowFinished",
             ],
             "progress": 0,
             "steps": [
@@ -169,7 +167,6 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
                         "notifiedEvents": [
                             "recipientRefused",
                             "recipientFinished",
-                            "workflowFinished",
                         ],
                         "watchers": [],
                     }
@@ -357,8 +354,6 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
             "notifiedEvents": [
                 "recipientRefused",
                 "recipientFinished",
-                "workflowStopped",
-                "workflowFinished",
             ],
             "progress": 0,
             "steps": [
@@ -487,8 +482,6 @@ class LexPersonaBackendSubmitForSignatureTestCase(TestCase):
             "notifiedEvents": [
                 "recipientRefused",
                 "recipientFinished",
-                "workflowStopped",
-                "workflowFinished",
             ],
             "progress": 0,
             "steps": [

--- a/src/backend/joanie/tests/signature/backends/lex_persona/test_update_organization_signatories.py
+++ b/src/backend/joanie/tests/signature/backends/lex_persona/test_update_organization_signatories.py
@@ -94,7 +94,6 @@ class LexPersonaBackendUpdateSignatoriesTestCase(TestCase):
             "notifiedEvents": [
                 "recipientRefused",
                 "recipientFinished",
-                "workflowFinished",
             ],
             "progress": 50,
             "started": 1712739520954,
@@ -316,11 +315,7 @@ class LexPersonaBackendUpdateSignatoriesTestCase(TestCase):
             "lastName": ".",
             "logs": [],
             "name": title,
-            "notifiedEvents": [
-                "recipientRefused",
-                "recipientFinished",
-                "workflowFinished",
-            ],
+            "notifiedEvents": ["recipientRefused", "recipientFinished"],
             "progress": 0,
             "started": 1712739520954,
             "steps": [


### PR DESCRIPTION
## Purpose

Currently, on LexPersona backend, we validate student signature on `recipientFinished` event and organization signature on `workflowFinished` event. This is weird as when an organization signs, two events are sent by LexPersona (`recipientFinished` + `workflowFinished`). As consequence, when the organization signs, `student_signed_on` is updated on `recipientFinished` event and `organization_signed_on` is set on `workflowFinished`. So in order to fix that, we do not use anymore the `workflowFinished` event. Instead, as our workflow is static, we can assume to set `student_signed_on` on the first `recipientFinished` event then set `organization_signed_on` the second time we receive a `recipientFinished` event for the related contract.
