### PR TITLE
✨(backend) make backend request timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to
 - Add `appendix` field on `ContractDefinition` model
 - Allow to edit `appendix` `ContractDefinition` field through the back office
 
+### Changed
+
+- Make payment backend request timeout configurable
+
 ## [2.8.0] - 2024-10-16
 
 ### Added

--- a/src/backend/joanie/payment/backends/base.py
+++ b/src/backend/joanie/payment/backends/base.py
@@ -27,6 +27,11 @@ class BasePaymentBackend:
 
     name = "base"
 
+    @property
+    def timeout(self):
+        """A class property to get the request timeout value from the settings"""
+        return settings.JOANIE_PAYMENT_BACKEND["timeout"]
+
     def __init__(self, configuration=None):
         self.configuration = configuration
 

--- a/src/backend/joanie/payment/backends/lyra/__init__.py
+++ b/src/backend/joanie/payment/backends/lyra/__init__.py
@@ -118,7 +118,9 @@ class LyraBackend(BasePaymentBackend):
         logger.info("Calling Lyra API %s", url, extra={"context": context})
 
         try:
-            response = requests.post(url, json=payload, headers=self.headers, timeout=5)
+            response = requests.post(
+                url, json=payload, headers=self.headers, timeout=self.timeout
+            )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             context = context.copy()

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -414,6 +414,9 @@ class Base(Configuration):
             environ_name="JOANIE_PAYMENT_BACKEND",
             environ_prefix=None,
         ),
+        "timeout": values.PositiveIntegerValue(
+            5, environ_name="JOANIE_PAYMENT_TIMEOUT", environ_prefix=None
+        ),
         # Check the docstring of the related payment backend to know
         # which dict to pass here.
         "configuration": values.DictValue(
@@ -745,6 +748,7 @@ class Test(Base):
 
     JOANIE_PAYMENT_BACKEND = {
         "backend": "joanie.payment.backends.dummy.DummyPaymentBackend",
+        "timeout": 5,
     }
 
     JOANIE_SIGNATURE_BACKEND = "joanie.signature.backends.dummy.DummySignatureBackend"

--- a/src/backend/joanie/tests/payment/test_backend_base.py
+++ b/src/backend/joanie/tests/payment/test_backend_base.py
@@ -88,6 +88,19 @@ class BasePaymentBackendTestCase(BasePaymentTestCase, ActivityLogMixingTestCase)
 
         self.assertEqual(backend.configuration, {"secret": "aDummyPassphraseForTest"})
 
+    @override_settings(
+        JOANIE_PAYMENT_BACKEND={
+            "backend": "joanie.core.payment.backends.dummy.DummyPaymentBackend",
+            "timeout": 42,
+        },
+    )
+    def test_payment_backend_base_request_timeout_is_configurable(self):
+        """
+        The request timeout should be configurable in the settings.
+        """
+        backend = BasePaymentBackend()
+        self.assertEqual(backend.timeout, 42)
+
     def test_payment_backend_base_create_payment_not_implemented(self):
         """Invoke create_payment should raise a Not ImplementedError"""
         backend = BasePaymentBackend()


### PR DESCRIPTION
## Purpose

Sometime error can be raised as our payment backend reached the request timeout sets to 5s. So we make this value configurable to be able to increase it with ease.