### PR TITLE
🚑(backend) manage refused zero click payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Manage zero click refused payment
+
 ## [2.9.0] - 2024-10-22
 
 ### Added

--- a/src/backend/joanie/payment/backends/lyra/__init__.py
+++ b/src/backend/joanie/payment/backends/lyra/__init__.py
@@ -288,12 +288,13 @@ class LyraBackend(BasePaymentBackend):
             }
 
         response_json = self._call_api(url, payload)
-        if response_json.get("status") != "SUCCESS":
+        answer = response_json.get("answer")
+
+        if answer["orderStatus"] != "PAID":
+            self._do_on_payment_failure(order, installment["id"])
             return False
 
-        answer = response_json.get("answer")
         billing_details = answer["customer"]["billingDetails"]
-
         payment = {
             "id": answer["transactions"][0]["uuid"],
             "installment_id": installment["id"],
@@ -312,6 +313,7 @@ class LyraBackend(BasePaymentBackend):
             order=order,
             payment=payment,
         )
+
         return True
 
     def _check_hash(self, post_data):


### PR DESCRIPTION
## Purpose

Currently, if a zero click payment is refused, our logic can consider this one as accepted as we are checking the wrong response attribute...