### PR TITLE
🐛(backend) fix order lifecycle issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
   # ---- mail jobs ----
   build-mails:
     docker:
-      - image: cimg/node:18.18
+      - image: cimg/node:18.20
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
@@ -275,7 +275,7 @@ jobs:
   # ---- frontend admin jobs ----
   build-test-front-admin:
     docker:
-      - image: cimg/node:18.18
+      - image: cimg/node:18.20
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
@@ -323,7 +323,7 @@ jobs:
 
   lint-front-admin:
     docker:
-      - image: cimg/node:18.18
+      - image: cimg/node:18.20
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
@@ -341,7 +341,7 @@ jobs:
 
   test-front-admin:
     docker:
-      - image: cimg/node:18.18
+      - image: cimg/node:18.20
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
@@ -362,7 +362,7 @@ jobs:
 
   test-e2e-front-admin:
     docker:
-      - image: cimg/node:18.18
+      - image: cimg/node:18.20
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
@@ -390,7 +390,7 @@ jobs:
 
   test-playwright-ct-front-admin:
     docker:
-      - image: cimg/node:18.18
+      - image: cimg/node:18.20
         auth:
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.9.2] - 2024-10-24
+
 ### Fixed
 
 - Update order flow to allow transition from `no_payment` to `completed`
@@ -475,7 +477,8 @@ and this project adheres to
 - First working version serving sellable micro-credentials for multiple
   organizations synchronized to a remote catalog
 
-[unreleased]: https://github.com/openfun/joanie/compare/v2.9.1...main
+[unreleased]: https://github.com/openfun/joanie/compare/v2.9.2...main
+[2.9.2]: https://github.com/openfun/joanie/compare/v2.9.0...v2.9.2
 [2.9.1]: https://github.com/openfun/joanie/compare/v2.9.0...v2.9.1
 [2.9.0]: https://github.com/openfun/joanie/compare/v2.8.0...v2.9.0
 [2.8.0]: https://github.com/openfun/joanie/compare/v2.7.1...v2.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Update order flow to allow transition from `no_payment` to `completed`
+
 ## [2.9.1] - 2024-10-23
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /install && \
 
 
 # ---- mails ----
-FROM node:16 AS mail-builder
+FROM node:18.20-slim AS mail-builder
 
 COPY ./src/mail /mail/app
 

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,6 +1,6 @@
 # arnold.yml
 metadata:
   name: joanie
-  version: 2.9.1
+  version: 2.9.2
 source:
   path: src/tray

--- a/docker/images/admin/Dockerfile
+++ b/docker/images/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19-slim as builder
+FROM node:18.20-slim as builder
 
 WORKDIR /app
 
@@ -14,6 +14,3 @@ FROM nginxinc/nginx-unprivileged:1.25 as production
 
 COPY docker/files/admin/etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/out /app/admin
-
-
-

--- a/src/backend/joanie/core/flows/order.py
+++ b/src/backend/joanie/core/flows/order.py
@@ -164,6 +164,7 @@ class OrderFlow:
     @state.transition(
         source=[
             enums.ORDER_STATE_ASSIGNED,
+            enums.ORDER_STATE_NO_PAYMENT,
             enums.ORDER_STATE_PENDING_PAYMENT,
             enums.ORDER_STATE_FAILED_PAYMENT,
             enums.ORDER_STATE_PENDING,

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "joanie"
-version = "2.9.1"
+version = "2.9.2"
 authors = [{ "name" = "Open FUN (France Université Numérique)", "email" = "fun.dev@fun-mooc.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -109,6 +109,6 @@
     "workerDirectory": "public"
   },
   "volta": {
-    "node": "18.18.2"
+    "node": "18.20.4"
   }
 }

--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8072",

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -14,7 +14,7 @@
     "build": "yarn build-mjml-to-html; yarn build-html-to-plain-text;"
   },
   "volta": {
-    "node": "16.15.1"
+    "node": "18.20.4"
   },
   "repository": "https://github.com/openfun/joanie",
   "author": "France Université Numérique",

--- a/src/openApiClientJs/package.json
+++ b/src/openApiClientJs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joanie-openapi-client-ts",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "private": true,
   "description": "Tool to generate Typescript api client for joanie",
   "scripts": {

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: joanie
-  version: 2.9.1
+  version: 2.9.2

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -21,7 +21,7 @@ joanie_nginx_static_cache_expires: "1M"
 
 # -- admin nginx
 joanie_admin_nginx_image_name: "fundocker/joanie-admin"
-joanie_admin_nginx_image_tag: "2.9.1"
+joanie_admin_nginx_image_tag: "2.9.2"
 joanie_admin_nginx_port: 8061
 joanie_admin_nginx_replicas: 1
 joanie_admin_nginx_healthcheck_port: 5000
@@ -41,7 +41,7 @@ joanie_database_secret_name: "joanie-postgresql-{{ joanie_vault_checksum | defau
 
 # -- joanie
 joanie_image_name: "fundocker/joanie"
-joanie_image_tag: "2.9.1"
+joanie_image_tag: "2.9.2"
 # The image pull secret name should match the name of your secret created to
 # login to your private docker registry
 joanie_image_pull_secret_name: ""


### PR DESCRIPTION
## Purpose

Currently, it is not possible to transition from `no_payment` state to
`completed` state. But this should be possible to manage orders with a single
installment which was refused and has been fixed.

Then release joanie 2.9.2.