### PR TITLE
👔(backend) move `is_withdrawable` to course product relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to
 
 - Add link to back office in Django admin topbar
 - Add boolean field `has_waived_withdrawal_right` to the `Order` model
-- Add `is_withdrawable` to `Product` model
+- Add `is_withdrawable` to `CourseProductRelation` model
 - Prevent a user to create an order for a product without withdrawal period
   if the user has not waived his withdrawal right
 - Display `has_waived_withdrawal_right` in back office Order view

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -42,11 +42,7 @@ from joanie.core.models.courses import (
 from joanie.core.utils import (
     contract_definition as contract_definition_utility,
 )
-from joanie.core.utils import (
-    issuers,
-    payment_schedule,
-    webhooks,
-)
+from joanie.core.utils import issuers, webhooks
 from joanie.core.utils.contract_definition import embed_images_in_context
 from joanie.core.utils.payment_schedule import generate as generate_payment_schedule
 from joanie.signature.backends import get_signature_backend
@@ -253,23 +249,6 @@ class Product(parler_models.TranslatableModel, BaseModel):
         """
         dates = self.get_equivalent_course_run_dates()
         return CourseRun.compute_state(**dates)
-
-    @property
-    def is_withdrawable(self):
-        """
-        Return True if the product has a withdrawal period.
-
-        Read the docstring of core.utils.payment_schedule.has_withdrawal_period method
-        for further information.
-        """
-        start_date = self.get_equivalent_course_run_dates().get("start")
-
-        if not start_date:
-            return True
-
-        return payment_schedule.has_withdrawal_period(
-            timezone.localdate(), start_date.date()
-        )
 
     def clean(self):
         """

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -11,7 +11,6 @@ from django.utils.translation import gettext_lazy as _
 import markdown
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import exceptions, serializers
-from rest_framework.fields import BooleanField
 from rest_framework.generics import get_object_or_404
 
 from joanie.core import enums, models
@@ -800,14 +799,12 @@ class ProductSerializer(serializers.ModelSerializer):
         read_only=True, many=True, source="target_course_relations"
     )
     contract_definition = ContractDefinitionSerializer(read_only=True)
-    is_withdrawable = BooleanField(read_only=True)
 
     class Meta:
         model = models.Product
         fields = [
             "call_to_action",
             "certificate_definition",
-            "is_withdrawable",
             "contract_definition",
             "id",
             "instructions",
@@ -867,9 +864,9 @@ class CourseSerializer(AbilitiesModelSerializer):
         read_only_fields = fields
 
 
-class CourseProductRelationSerializer(CachedModelSerializer):
+class CourseProductRelationLightSerializer(CachedModelSerializer):
     """
-    Serialize a course product relation.
+    Serialize a course product relation in its minimal format.
     """
 
     course = CourseLightSerializer(read_only=True, exclude_abilities=True)
@@ -877,7 +874,6 @@ class CourseProductRelationSerializer(CachedModelSerializer):
     organizations = OrganizationSerializer(
         many=True, read_only=True, exclude_abilities=True
     )
-    order_groups = OrderGroupSerializer(many=True, read_only=True)
 
     class Meta:
         model = models.CourseProductRelation
@@ -888,6 +884,23 @@ class CourseProductRelationSerializer(CachedModelSerializer):
             "order_groups",
             "organizations",
             "product",
+            "is_withdrawable",
+        ]
+        read_only_fields = fields
+
+
+class CourseProductRelationSerializer(CourseProductRelationLightSerializer):
+    """
+    Serialize a course product relation.
+    """
+
+    order_groups = OrderGroupSerializer(many=True, read_only=True)
+    is_withdrawable = serializers.BooleanField(read_only=True)
+
+    class Meta(CourseProductRelationLightSerializer.Meta):
+        fields = CourseProductRelationLightSerializer.Meta.fields + [
+            "order_groups",
+            "is_withdrawable",
         ]
         read_only_fields = fields
 
@@ -905,6 +918,7 @@ class ProductRelationSerializer(CachedModelSerializer):
             "id",
             "order_groups",
             "product",
+            "is_withdrawable",
         ]
         read_only_fields = fields
 

--- a/src/backend/joanie/tests/core/api/order/test_create.py
+++ b/src/backend/joanie/tests/core/api/order/test_create.py
@@ -981,7 +981,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             {
                 "__all__": [
                     'This order cannot be linked to the product "balançoire", '
-                    'the course "mathématiques" and the organization "fun".'
+                    'the course "mathématiques".'
                 ]
             },
         )
@@ -1185,7 +1185,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             "has_waived_withdrawal_right": True,
         }
 
-        with self.assertNumQueries(62):
+        with self.assertNumQueries(64):
             response = self.client.post(
                 "/api/v1.0/orders/",
                 data=data,
@@ -1335,7 +1335,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         }
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(24):
             response = self.client.post(
                 "/api/v1.0/orders/",
                 data=data,
@@ -1385,7 +1385,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         }
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(113):
+        with self.assertNumQueries(115):
             response = self.client.post(
                 "/api/v1.0/orders/",
                 data=data,
@@ -1483,7 +1483,7 @@ class OrderCreateApiTest(BaseAPITestCase):
         }
         token = self.generate_token_from_user(user)
 
-        with self.assertNumQueries(18):
+        with self.assertNumQueries(20):
             response = self.client.post(
                 "/api/v1.0/orders/",
                 data=data,
@@ -1644,7 +1644,7 @@ class OrderCreateApiTest(BaseAPITestCase):
             models.Order.objects.filter(course=course, product=product).count(), 1
         )
 
-    @mock.patch("joanie.core.models.Product.is_withdrawable")
+    @mock.patch("joanie.core.models.CourseProductRelation.is_withdrawable")
     def test_api_order_create_for_product_without_withdrawal_period(
         self, mock_is_withdrawable
     ):

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -118,6 +118,7 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                     "title": course.title,
                 },
                 "order_groups": [],
+                "is_withdrawable": True,
                 "product": {
                     "instructions": (
                         "<h1>An h1 header</h1>\n"
@@ -216,7 +217,6 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                     ],
                     "title": relation.product.title,
                     "type": relation.product.type,
-                    "is_withdrawable": relation.product.is_withdrawable,
                 },
                 "organizations": [
                     {
@@ -653,10 +653,10 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                     "title": course.title,
                 },
                 "order_groups": [],
+                "is_withdrawable": True,
                 "product": {
                     "instructions": "",
                     "call_to_action": relation.product.call_to_action,
-                    "is_withdrawable": relation.product.is_withdrawable,
                     "certificate_definition": {
                         "description": relation.product.certificate_definition.description,
                         "name": relation.product.certificate_definition.name,

--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -320,6 +320,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 {
                     "id": str(product2.course_relations.last().id),
                     "order_groups": [],
+                    "is_withdrawable": product2.course_relations.last().is_withdrawable,
                     "product": {
                         "instructions": "",
                         "call_to_action": "let's go!",
@@ -345,12 +346,12 @@ class EnrollmentApiTest(BaseAPITestCase):
                         "target_courses": [],
                         "title": product2.title,
                         "type": "certificate",
-                        "is_withdrawable": product2.is_withdrawable,
                     },
                 },
                 {
                     "id": str(product1.course_relations.last().id),
                     "order_groups": [],
+                    "is_withdrawable": product1.course_relations.last().is_withdrawable,
                     "product": {
                         "instructions": "",
                         "call_to_action": "let's go!",
@@ -376,7 +377,6 @@ class EnrollmentApiTest(BaseAPITestCase):
                         "target_courses": [],
                         "title": product1.title,
                         "type": "certificate",
-                        "is_withdrawable": product1.is_withdrawable,
                     },
                 },
             ],
@@ -807,6 +807,7 @@ class EnrollmentApiTest(BaseAPITestCase):
                 {
                     "id": str(product.course_relations.first().id),
                     "order_groups": [],
+                    "is_withdrawable": product.course_relations.first().is_withdrawable,
                     "product": {
                         "call_to_action": "let's go!",
                         "certificate_definition": {
@@ -828,7 +829,6 @@ class EnrollmentApiTest(BaseAPITestCase):
                         "target_courses": [],
                         "title": product.title,
                         "type": "certificate",
-                        "is_withdrawable": product.is_withdrawable,
                     },
                 },
             ],

--- a/src/backend/joanie/tests/core/test_models_course_product_relation.py
+++ b/src/backend/joanie/tests/core/test_models_course_product_relation.py
@@ -2,9 +2,13 @@
 Test suite for CourseProductRelation model
 """
 
-from django.test import TestCase
+from datetime import timedelta
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from joanie.core import factories
+from joanie.core.enums import PRODUCT_TYPE_CERTIFICATE, PRODUCT_TYPE_CREDENTIAL
 
 
 class CourseProductRelationModelTestCase(TestCase):
@@ -38,3 +42,52 @@ class CourseProductRelationModelTestCase(TestCase):
             course=relation.course,
         )
         self.assertFalse(relation.can_edit)
+
+    @override_settings(JOANIE_WITHDRAWAL_PERIOD_DAYS=7)
+    def test_model_course_product_relation_is_withdrawable_credential(self):
+        """
+        Course Product relation linked to a credential product should be withdrawable or
+        not according to the product start date and the withdrawal period (7 days for this test)
+        """
+        withdrawal_period = timedelta(days=7)
+
+        for priority in range(8):
+            course_run = factories.CourseRunFactory(state=priority)
+            relation = factories.CourseProductRelationFactory(
+                product__type=PRODUCT_TYPE_CREDENTIAL,
+                product__target_courses=[course_run.course],
+            )
+            product_dates = relation.product.get_equivalent_course_run_dates()
+            start_date = (
+                product_dates["start"].date() if product_dates["start"] else None
+            )
+
+            with self.subTest(f"CourseState {priority}", start_date=start_date):
+                withdrawal_date = timezone.localdate() + withdrawal_period
+                self.assertEqual(
+                    relation.is_withdrawable,
+                    withdrawal_date < start_date if start_date else True,
+                )
+
+    @override_settings(JOANIE_WITHDRAWAL_PERIOD_DAYS=7)
+    def test_model_course_product_relation_is_withdrawable_certificate(self):
+        """
+        Course Product relation linked to a certificate product should be withdrawable or
+        not according to the course start date and the withdrawal period (7 days for this test)
+        """
+        withdrawal_period = timedelta(days=7)
+
+        for priority in range(8):
+            course_run = factories.CourseRunFactory(state=priority)
+            relation = factories.CourseProductRelationFactory(
+                product__type=PRODUCT_TYPE_CERTIFICATE, course=course_run.course
+            )
+            course_dates = relation.course.get_equivalent_course_run_dates()
+            start_date = course_dates["start"].date() if course_dates["start"] else None
+
+            with self.subTest(f"CourseState {priority}", start_date=start_date):
+                withdrawal_date = timezone.localdate() + withdrawal_period
+                self.assertEqual(
+                    relation.is_withdrawable,
+                    withdrawal_date < start_date if start_date else True,
+                )

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -904,7 +904,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedCourseProductRelationList"
+                                    "$ref": "#/components/schemas/PaginatedCourseProductRelationLightList"
                                 }
                             }
                         },
@@ -1911,7 +1911,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedCourseProductRelationList"
+                                    "$ref": "#/components/schemas/PaginatedCourseProductRelationLightList"
                                 }
                             }
                         },
@@ -3830,7 +3830,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/PaginatedCourseProductRelationList"
+                                    "$ref": "#/components/schemas/PaginatedCourseProductRelationLightList"
                                 }
                             }
                         },
@@ -5291,12 +5291,80 @@
                             }
                         ],
                         "readOnly": true
+                    },
+                    "is_withdrawable": {
+                        "type": "boolean",
+                        "readOnly": true
                     }
                 },
                 "required": [
                     "course",
                     "created_on",
                     "id",
+                    "is_withdrawable",
+                    "order_groups",
+                    "organizations",
+                    "product"
+                ]
+            },
+            "CourseProductRelationLight": {
+                "type": "object",
+                "description": "Serialize a course product relation in its minimal format.",
+                "properties": {
+                    "course": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/CourseLight"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "created_on": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "date and time at which a record was created"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "primary key for the record as UUID"
+                    },
+                    "order_groups": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "readOnly": true
+                    },
+                    "organizations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Organization"
+                        },
+                        "readOnly": true
+                    },
+                    "product": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/Product"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "is_withdrawable": {
+                        "type": "string",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "course",
+                    "created_on",
+                    "id",
+                    "is_withdrawable",
                     "order_groups",
                     "organizations",
                     "product"
@@ -6631,7 +6699,7 @@
                     }
                 }
             },
-            "PaginatedCourseProductRelationList": {
+            "PaginatedCourseProductRelationLightList": {
                 "type": "object",
                 "required": [
                     "count",
@@ -6657,7 +6725,7 @@
                     "results": {
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/CourseProductRelation"
+                            "$ref": "#/components/schemas/CourseProductRelationLight"
                         }
                     }
                 }
@@ -7004,10 +7072,6 @@
                         ],
                         "readOnly": true
                     },
-                    "is_withdrawable": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
                     "contract_definition": {
                         "allOf": [
                             {
@@ -7069,7 +7133,6 @@
                     "contract_definition",
                     "id",
                     "instructions",
-                    "is_withdrawable",
                     "price",
                     "price_currency",
                     "state",


### PR DESCRIPTION
## Purpose

We recently add a property `is_withdrawable` to the `Product` model. But for certificate product, this property is only computable from a CourseProductRelation point of view. So we revamp this feature to move this property from the `Product` model to the `CourseProductRelation`.