### PR TITLE
👔(backend) ignore archived runs to process payment schedule and withdraw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to
   if the user has not waived his withdrawal right
 - Display `has_waived_withdrawal_right` in back office Order view
 
+### Changed
+
+- Ignore archived course runs to process payment schedule and withdrawable state
+
 ## [2.9.2] - 2024-10-24
 
 ### Fixed

--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -220,7 +220,9 @@ class CourseProductRelationViewSet(
             instance = course_product_relation.course
         else:
             instance = course_product_relation.product
-        course_run_dates = instance.get_equivalent_course_run_dates()
+        course_run_dates = instance.get_equivalent_course_run_dates(
+            ignore_archived=True
+        )
 
         payment_schedule = generate_payment_schedule(
             course_product_relation.product.price,

--- a/src/backend/joanie/core/utils/course_run/__init__.py
+++ b/src/backend/joanie/core/utils/course_run/__init__.py
@@ -1,0 +1,4 @@
+"""Course run utils module"""
+
+from .aggregate_course_runs_dates import aggregate_course_runs_dates
+from .get_course_run_metrics import get_course_run_metrics

--- a/src/backend/joanie/core/utils/course_run/aggregate_course_runs_dates.py
+++ b/src/backend/joanie/core/utils/course_run/aggregate_course_runs_dates.py
@@ -1,0 +1,35 @@
+"""
+Utility methods for Course Run to aggregate dates from a course run queryset.
+"""
+
+from django.db import models as django_models
+from django.utils import timezone as django_timezone
+
+
+def aggregate_course_runs_dates(
+    course_runs: django_models.QuerySet, ignore_archived: bool = False
+):
+    """
+    Return a dict of dates equivalent to course run dates
+    by aggregating dates of all course runs as follows:
+    - start: Pick the earliest start date
+    - end: Pick the latest end date
+    - enrollment_start: Pick the latest enrollment start date
+    - enrollment_end: Pick the earliest enrollment end date
+
+    It is possible to ignore archived course runs by setting ignore_archived to True.
+    """
+
+    qs = course_runs
+
+    if ignore_archived:
+        qs = course_runs.filter(end__gt=django_timezone.now())
+
+    aggregate = qs.aggregate(
+        django_models.Min("start"),
+        django_models.Max("end"),
+        django_models.Max("enrollment_start"),
+        django_models.Min("enrollment_end"),
+    )
+
+    return {key.split("__")[0]: value for key, value in aggregate.items()}

--- a/src/backend/joanie/core/utils/course_run/get_course_run_metrics.py
+++ b/src/backend/joanie/core/utils/course_run/get_course_run_metrics.py
@@ -7,8 +7,7 @@ import logging
 from django.core.exceptions import ValidationError
 from django.utils import timezone as django_timezone
 
-from joanie.core import enums
-from joanie.core.models import CourseRun, Enrollment, Order
+from joanie.core import enums, models
 
 logger = logging.getLogger(__name__)
 
@@ -20,10 +19,10 @@ def get_course_run_metrics(resource_link: str):
         - amount of validated certificate orders.
     """
     try:
-        course_run = CourseRun.objects.get(
+        course_run = models.CourseRun.objects.get(
             resource_link=resource_link, end__lte=django_timezone.now()
         )
-    except CourseRun.DoesNotExist as exception:
+    except models.CourseRun.DoesNotExist as exception:
         error_message = (
             "Make sure to give an existing resource link from an ended course run."
         )
@@ -31,11 +30,11 @@ def get_course_run_metrics(resource_link: str):
         raise ValidationError(error_message) from exception
 
     return {
-        "nb_active_enrollments": Enrollment.objects.filter(
+        "nb_active_enrollments": models.Enrollment.objects.filter(
             course_run=course_run,
             is_active=True,
         ).count(),
-        "nb_validated_certificate_orders": Order.objects.filter(
+        "nb_validated_certificate_orders": models.Order.objects.filter(
             enrollment__course_run=course_run,
             product__type=enums.PRODUCT_TYPE_CERTIFICATE,
             state=enums.ORDER_STATE_COMPLETED,

--- a/src/backend/joanie/tests/core/test_models_course_product_relation.py
+++ b/src/backend/joanie/tests/core/test_models_course_product_relation.py
@@ -2,13 +2,19 @@
 Test suite for CourseProductRelation model
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
+from unittest import mock
+from zoneinfo import ZoneInfo
 
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from joanie.core import factories
-from joanie.core.enums import PRODUCT_TYPE_CERTIFICATE, PRODUCT_TYPE_CREDENTIAL
+from joanie.core.enums import (
+    PRODUCT_TYPE_CERTIFICATE,
+    PRODUCT_TYPE_CHOICES,
+    PRODUCT_TYPE_CREDENTIAL,
+)
 
 
 class CourseProductRelationModelTestCase(TestCase):
@@ -57,7 +63,9 @@ class CourseProductRelationModelTestCase(TestCase):
                 product__type=PRODUCT_TYPE_CREDENTIAL,
                 product__target_courses=[course_run.course],
             )
-            product_dates = relation.product.get_equivalent_course_run_dates()
+            product_dates = relation.product.get_equivalent_course_run_dates(
+                ignore_archived=True
+            )
             start_date = (
                 product_dates["start"].date() if product_dates["start"] else None
             )
@@ -82,7 +90,9 @@ class CourseProductRelationModelTestCase(TestCase):
             relation = factories.CourseProductRelationFactory(
                 product__type=PRODUCT_TYPE_CERTIFICATE, course=course_run.course
             )
-            course_dates = relation.course.get_equivalent_course_run_dates()
+            course_dates = relation.course.get_equivalent_course_run_dates(
+                ignore_archived=True
+            )
             start_date = course_dates["start"].date() if course_dates["start"] else None
 
             with self.subTest(f"CourseState {priority}", start_date=start_date):
@@ -91,3 +101,40 @@ class CourseProductRelationModelTestCase(TestCase):
                     relation.is_withdrawable,
                     withdrawal_date < start_date if start_date else True,
                 )
+
+    @override_settings(JOANIE_WITHDRAWAL_PERIOD_DAYS=7)
+    def test_model_course_product_relation_is_withdrawable_ignore_archived(self):
+        """
+        Archived course runs should not be taken into account when checking if a relation is
+        withdrawable.
+        """
+        mocked_now = datetime(2024, 12, 1, tzinfo=ZoneInfo("UTC"))
+        withdrawal_date = mocked_now + timedelta(days=8)
+
+        archived_run = factories.CourseRunFactory(
+            start=mocked_now - timedelta(days=30), end=mocked_now - timedelta(days=1)
+        )
+        future_run = factories.CourseRunFactory(
+            start=withdrawal_date + timedelta(days=1),
+            end=withdrawal_date + timedelta(days=30),
+        )
+        course = factories.CourseFactory(course_runs=[archived_run, future_run])
+
+        for product_type, _ in PRODUCT_TYPE_CHOICES:
+            relation = factories.CourseProductRelationFactory(
+                product__type=product_type,
+                course=course,
+                product__target_courses=[course]
+                if product_type == PRODUCT_TYPE_CREDENTIAL
+                else None,
+            )
+
+            with self.subTest(f"Product {product_type}"):
+                with (
+                    mock.patch("django.utils.timezone.now", return_value=mocked_now),
+                    mock.patch(
+                        "django.utils.timezone.localdate",
+                        return_value=mocked_now.date(),
+                    ),
+                ):
+                    self.assertEqual(relation.is_withdrawable, True)

--- a/src/backend/joanie/tests/core/utils/course_run/test_aggregate_course_run_dates.py
+++ b/src/backend/joanie/tests/core/utils/course_run/test_aggregate_course_run_dates.py
@@ -1,0 +1,104 @@
+"""Test case for the course run utility `aggregate_course_runs_dates` method."""
+
+from datetime import datetime
+from unittest import mock
+from zoneinfo import ZoneInfo
+
+from django.test import TestCase
+
+from joanie.core import factories
+from joanie.core.factories import CourseFactory
+from joanie.core.utils.course_run import aggregate_course_runs_dates
+
+
+class UtilsCourseRunAggregateDatesTestCase(TestCase):
+    """Test suite for the course run utility `aggregate_course_runs_dates` method."""
+
+    maxDiff = None
+
+    def test_utils_course_run_aggregate_dates(self):
+        """
+        It should aggregate the dates of all course runs provided. By default, archived
+        course runs are included.
+        """
+        mocked_now = datetime(2024, 12, 1, tzinfo=ZoneInfo("UTC"))
+        archived_run = factories.CourseRunFactory(
+            start=datetime(2024, 11, 1, tzinfo=ZoneInfo("UTC")),
+            end=datetime(2024, 11, 30, tzinfo=ZoneInfo("UTC")),
+            enrollment_start=datetime(2024, 10, 1, tzinfo=ZoneInfo("UTC")),
+            enrollment_end=datetime(2024, 10, 31, tzinfo=ZoneInfo("UTC")),
+        )
+        ongoing_run = factories.CourseRunFactory(
+            start=datetime(2024, 12, 1, tzinfo=ZoneInfo("UTC")),
+            end=datetime(2024, 12, 31, tzinfo=ZoneInfo("UTC")),
+            enrollment_start=datetime(2024, 11, 1, tzinfo=ZoneInfo("UTC")),
+            enrollment_end=datetime(2024, 11, 30, tzinfo=ZoneInfo("UTC")),
+        )
+
+        course = factories.CourseFactory(course_runs=[archived_run, ongoing_run])
+
+        with mock.patch("django.utils.timezone.now", return_value=mocked_now):
+            dates = aggregate_course_runs_dates(course.course_runs)
+
+        self.assertDictEqual(
+            dates,
+            {
+                "start": archived_run.start,
+                "end": ongoing_run.end,
+                "enrollment_start": ongoing_run.enrollment_start,
+                "enrollment_end": archived_run.enrollment_end,
+            },
+        )
+
+    def test_utils_course_run_aggregate_dates_ignore_archived(self):
+        """
+        It should aggregate the dates of all course runs provided and ignore the archived ones.
+        """
+        mocked_now = datetime(2024, 12, 1, tzinfo=ZoneInfo("UTC"))
+        archived_run = factories.CourseRunFactory(
+            start=datetime(2024, 11, 1, tzinfo=ZoneInfo("UTC")),
+            end=datetime(2024, 11, 30, tzinfo=ZoneInfo("UTC")),
+            enrollment_start=datetime(2024, 10, 1, tzinfo=ZoneInfo("UTC")),
+            enrollment_end=datetime(2024, 10, 31, tzinfo=ZoneInfo("UTC")),
+        )
+        ongoing_run = factories.CourseRunFactory(
+            start=datetime(2024, 12, 1, tzinfo=ZoneInfo("UTC")),
+            end=datetime(2024, 12, 31, tzinfo=ZoneInfo("UTC")),
+            enrollment_start=datetime(2024, 11, 1, tzinfo=ZoneInfo("UTC")),
+            enrollment_end=datetime(2024, 11, 30, tzinfo=ZoneInfo("UTC")),
+        )
+        course = factories.CourseFactory(course_runs=[archived_run, ongoing_run])
+
+        with mock.patch("django.utils.timezone.now", return_value=mocked_now):
+            dates = aggregate_course_runs_dates(
+                course.course_runs, ignore_archived=True
+            )
+
+        self.assertDictEqual(
+            dates,
+            {
+                "start": ongoing_run.start,
+                "end": ongoing_run.end,
+                "enrollment_start": ongoing_run.enrollment_start,
+                "enrollment_end": ongoing_run.enrollment_end,
+            },
+        )
+
+    def test_utils_course_run_aggregate_dates_empty_queryset(self):
+        """
+        It should return a dict with `None` values if the course run queryset is empty.
+        """
+        course = CourseFactory()
+
+        dates = aggregate_course_runs_dates(course.course_runs)
+
+        self.assertEqual(course.course_runs.count(), 0)
+        self.assertEqual(
+            dates,
+            {
+                "start": None,
+                "end": None,
+                "enrollment_start": None,
+                "enrollment_end": None,
+            },
+        )

--- a/src/backend/joanie/tests/core/utils/course_run/test_get_course_run_metrics.py
+++ b/src/backend/joanie/tests/core/utils/course_run/test_get_course_run_metrics.py
@@ -1,4 +1,4 @@
-"""Test suite for course run utility methods."""
+"""Test suite for the course run utility `get_course_run_metrics` method."""
 
 from datetime import timedelta
 
@@ -10,10 +10,12 @@ from joanie.core import enums, factories, models
 from joanie.core.utils.course_run import get_course_run_metrics
 
 
-class UtilsCourseRunTestCase(TestCase):
-    """Test suite for course run utility methods."""
+class UtilsCourseRunGetMetricsTestCase(TestCase):
+    """Test suite for the course run utility `get_course_run_metrics` method."""
 
-    def test_utils_course_run_with_non_existing_resource_link_parameter(self):
+    def test_utils_course_run_get_metrics_with_non_existing_resource_link_parameter(
+        self,
+    ):
         """
         Test the scenario when a non existent `resource_link` is parsed as input.
         It should raise a 'ValidationError' mentionning to provide an existing `resource_link`
@@ -27,7 +29,7 @@ class UtilsCourseRunTestCase(TestCase):
             "['Make sure to give an existing resource link from an ended course run.']",
         )
 
-    def test_utils_course_run_where_student_enrolls_and_does_not_make_an_order_to_get_certificate(
+    def test_utils_course_run_get_metrics_where_student_enrolls_and_does_not_make_an_order_to_get_certificate(  # pylint: disable=line-too-long
         self,
     ):
         """
@@ -59,7 +61,7 @@ class UtilsCourseRunTestCase(TestCase):
             },
         )
 
-    def test_utils_course_run_where_student_enrolls_and_makes_an_order_to_access_to_certificate(
+    def test_utils_course_run_get_metrics_where_student_enrolls_and_makes_an_order_to_access_to_certificate(  # pylint: disable=line-too-long
         self,
     ):
         """

--- a/src/backend/joanie/tests/core/utils/test_contract_definition_generate_document_context.py
+++ b/src/backend/joanie/tests/core/utils/test_contract_definition_generate_document_context.py
@@ -11,7 +11,7 @@ from django.utils import timezone as django_timezone
 from pdfminer.high_level import extract_text as pdf_extract_text
 
 from joanie.core import enums, factories
-from joanie.core.models import DocumentImage
+from joanie.core.models import CourseState, DocumentImage
 from joanie.core.utils import contract_definition, image_to_base64, issuers
 from joanie.core.utils.contract_definition import ORGANIZATION_FALLBACK_LOGO
 from joanie.payment.factories import InvoiceFactory
@@ -78,6 +78,7 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
             is_main=True,
             is_reusable=True,
         )
+        run = factories.CourseRunFactory(state=CourseState.ONGOING_OPEN)
         relation = factories.CourseProductRelationFactory(
             organizations=[organization],
             product=factories.ProductFactory(
@@ -90,18 +91,7 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
                 ),
                 title="You will know that you know you don't know",
                 price="999.99",
-                target_courses=[
-                    factories.CourseFactory(
-                        course_runs=[
-                            factories.CourseRunFactory(
-                                start="2024-01-01T09:00:00+00:00",
-                                end="2024-03-31T18:00:00+00:00",
-                                enrollment_start="2024-01-01T12:00:00+00:00",
-                                enrollment_end="2024-02-01T12:00:00+00:00",
-                            )
-                        ]
-                    )
-                ],
+                target_courses=[run.course],
             ),
             course=factories.CourseFactory(
                 organizations=[organization],
@@ -135,8 +125,8 @@ class UtilsGenerateDocumentContextTestCase(TestCase):
             "course": {
                 "name": order.product.title,
                 "code": relation.course.code,
-                "start": "2024-01-01T09:00:00+00:00",
-                "end": "2024-03-31T18:00:00+00:00",
+                "start": run.start.isoformat(),
+                "end": run.end.isoformat(),
                 "effort": "P0DT10H30M12S",
                 "price": "999.99",
                 "currency": "€",


### PR DESCRIPTION
## Purpose

Currently, when processing product payment schedule or withdrawable state, under
 the hood, we aggregate all related course runs no matter its state. In some
 case, this could lead to wrong computation particularly for certificate product
  as user are purchasing this kind of product for a given enrollment. So
  including archived runs in this case were weird. In order to fix, we improve
  the method to aggregate course run dates of a product / course by adding an
  argument to allow to ignore archived runs during aggregation.