### PR TITLE
✅(backend) fix flaky order model test

### DIFF
--- a/src/backend/joanie/tests/core/test_api_admin_orders.py
+++ b/src/backend/joanie/tests/core/test_api_admin_orders.py
@@ -431,10 +431,10 @@ class OrdersAdminApiTestCase(TestCase):
         )
         order = factories.OrderFactory(
             owner=factories.UserFactory(
-                username="jo_cun",
-                first_name="Joanie",
-                last_name="Cunningham",
-                email="jo_cun@example.com",
+                username="pi_mou",
+                first_name="Pimpolette",
+                last_name="Mouchardon",
+                email="pi_mou@example.com",
             ),
             product=product,
             course=course,
@@ -449,14 +449,14 @@ class OrdersAdminApiTestCase(TestCase):
         # Prepare queries to test
         # - Queries related to owner (username, first_name, last_name, email)
         queries = [
-            "jo_cun",
-            "jo_",
-            "Joanie",
-            "oani",
-            "Cunningham",
-            "nning",
-            "jo_cun@example.com",
-            "_cun@examp",
+            "pi_mou",
+            "pi_",
+            "Pimpolette",
+            "impolett",
+            "Mouchardon",
+            "uchard",
+            "pi_mou@example.com",
+            "_mou@examp",
         ]
         # - Queries related to product (title in any language))
         queries += [
@@ -482,11 +482,12 @@ class OrdersAdminApiTestCase(TestCase):
         ]
 
         for query in queries:
-            response = self.client.get(f"/api/v1.0/admin/orders/?query={query}")
-            self.assertEqual(response.status_code, HTTPStatus.OK)
-            content = response.json()
-            self.assertEqual(content["count"], 1)
-            self.assertEqual(content["results"][0]["id"], str(order.id))
+            with self.subTest(query=query):
+                response = self.client.get(f"/api/v1.0/admin/orders/?query={query}")
+                self.assertEqual(response.status_code, HTTPStatus.OK)
+                content = response.json()
+                self.assertEqual(content["count"], 1)
+                self.assertEqual(content["results"][0]["id"], str(order.id))
 
     def test_api_admin_orders_list_filter_by_id(self):
         """

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -506,7 +506,13 @@ class OrderModelsTestCase(TestCase, BaseLogMixinTestCase):
         """
         product = factories.ProductFactory(
             target_courses=factories.CourseFactory.create_batch(
-                2, course_runs=[CourseRunFactory()]
+                2,
+                course_runs=[
+                    CourseRunFactory(
+                        start=django_timezone.now() + timedelta(days=1),
+                        end=django_timezone.now() + timedelta(days=10),
+                    )
+                ],
             ),
         )
         order = factories.OrderFactory(product=product)


### PR DESCRIPTION


## Purpose

A target_course factory sometimes builds an archived one. This leads to a failing test.


## Proposal
Use future start and end dates.
