### PR TITLE
✨(backend) Authorize enrollment creation/update by admin on closed course runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 ### Added
 
+- Allow staff user to create and update an enrollment for a user
+  on closed course runs and opened course runs
 - Add link to back office in Django admin topbar
 - Add boolean field `has_waived_withdrawal_right` to the `Order` model
 - Add `is_withdrawable` to `CourseProductRelation` model

--- a/src/backend/joanie/core/api/admin/enrollment.py
+++ b/src/backend/joanie/core/api/admin/enrollment.py
@@ -19,6 +19,7 @@ from joanie.core.authentication import SessionAuthenticationWithAuthenticateHead
 class EnrollmentViewSet(
     SerializerPerActionMixin,
     mixins.ListModelMixin,
+    mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     viewsets.GenericViewSet,

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -2632,6 +2632,45 @@
                         "description": ""
                     }
                 }
+            },
+            "post": {
+                "operationId": "enrollments_create",
+                "description": "Admin Enrollment ViewSet",
+                "tags": [
+                    "enrollments"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminEnrollmentRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminEnrollmentRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AdminEnrollment"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
             }
         },
         "/api/v1.0/admin/enrollments/{id}/": {


### PR DESCRIPTION
Previously, admin (staff) users couldn't create or update enrollments for closed course runs. Now, they can because we've enhanced the admin API to allow this. The client API's serializers (student side) still enforce the old logic, blocking enrollments on closed course runs for regular users, while granting admin users this new capability.

## Purpose
Staff users should be able to create/update enrollment on closed runs. Regular users should still be blocked if they try to enroll to this kind of runs.

## Proposal

- [x] Move away logic from the model by placing it to the serializers (client and admin)

