### PR TITLE
:sparkles:(backend) Backoffice - Filter order list view per creation date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Add filters for the admin viewset through the field `created_on`
+  to search orders on exact date, before date, after date and range of dates.
 - Add filter for admin order viewset by product type
 - Add button in back office for refunding an order
 - Add `teachers`, `skills` and `certification_level` fields

--- a/src/backend/joanie/core/filters/admin/__init__.py
+++ b/src/backend/joanie/core/filters/admin/__init__.py
@@ -280,6 +280,8 @@ class OrderAdminFilterSet(filters.FilterSet):
         field_name="product__type",
         choices=enums.PRODUCT_TYPE_CHOICES,
     )
+    created_on = filters.DateFilter(field_name="created_on", lookup_expr="exact")
+    created_on_date_range = filters.DateFromToRangeFilter(field_name="created_on")
 
     def filter_by_query(self, queryset, _name, value):
         """

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -2833,6 +2833,30 @@
                     },
                     {
                         "in": "query",
+                        "name": "created_on",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_on_date_range_after",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_on_date_range_before",
+                        "schema": {
+                            "type": "string",
+                            "format": "date"
+                        }
+                    },
+                    {
+                        "in": "query",
                         "name": "ids",
                         "schema": {
                             "type": "string",


### PR DESCRIPTION
## Purpose

Staff user want to be able to filter the orders by created_on dates.
For now, the `OrderAdminFilterSet` has more filters on the field `created_on` :
- filter by **exact** date of creation
- filter with **date range** of creation : 
    - Use only the parameter `created_on_date_range_before` to query for dates equal or before
    - Use only the parameter `created_on_date_range_after` to query for dates equal or after
    - Use both parameters to filter within a date range.

## Proposal

- [x] Upgrade the `OrderAdminFilterSet` to filter through the field `created_on`