### PR TITLE
✨(backend) Backoffice - Filter order list view per product type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add filter for admin order viewset by product type
 - Add button in back office for refunding an order
 - Add `teachers`, `skills` and `certification_level` fields
   to `Product`model

--- a/src/backend/joanie/core/filters/admin/__init__.py
+++ b/src/backend/joanie/core/filters/admin/__init__.py
@@ -276,6 +276,10 @@ class OrderAdminFilterSet(filters.FilterSet):
     )
     state = filters.ChoiceFilter(choices=enums.ORDER_STATE_CHOICES)
     ids = MultipleValueFilter(field_class=fields.UUIDField, field_name="id")
+    product_type = filters.MultipleChoiceFilter(
+        field_name="product__type",
+        choices=enums.PRODUCT_TYPE_CHOICES,
+    )
 
     def filter_by_query(self, queryset, _name, value):
         """

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -2911,6 +2911,24 @@
                     },
                     {
                         "in": "query",
+                        "name": "product_type",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "certificate",
+                                    "credential",
+                                    "enrollment"
+                                ]
+                            }
+                        },
+                        "description": "* `credential` - Credential\n* `enrollment` - Enrollment\n* `certificate` - Certificate",
+                        "explode": true,
+                        "style": "form"
+                    },
+                    {
+                        "in": "query",
                         "name": "query",
                         "schema": {
                             "type": "string"


### PR DESCRIPTION

## Purpose

The purpose is to allow the the admin users to filter the order list by product type. They can choose one product type, or apply multiple product types to limit their order list.

## Proposal

- [x] Add new filter entry in the `OrderAdminFilterSet`
