### PR TITLE
✨(backend) Certificate API Endpoint - sort certificates by `issued_on` date field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 
 ### Changed
 
+- Update the model `Certificate` ordering to descending order
+  on the field `issued_on`
 - Update product endpoint to CRUD `teachers`, `skills`
   and `certification level` fields
 

--- a/src/backend/joanie/core/models/certifications.py
+++ b/src/backend/joanie/core/models/certifications.py
@@ -116,7 +116,7 @@ class Certificate(BaseModel):
         db_table = "joanie_certificate"
         verbose_name = _("Certificate")
         verbose_name_plural = _("Certificates")
-        ordering = ["-created_on"]
+        ordering = ["-issued_on"]
         constraints = [
             models.CheckConstraint(
                 check=(


### PR DESCRIPTION
## Purpose

Before, the Certificate API endpoint for client returns certificate sorted by creation date (created_on). 
Now, they are sorted by the field `issued_on` date in descending order (most recent first).

## Proposal

- [x] Update the Client API Certificate Viewset to sort by issued_on value.
