### PR TITLE
🔍(backend) prevent cert verification page indexation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Prevent to index certificate verification page
+
 ## [2.11.0] - 2024-12-11
 
 ### Added

--- a/src/backend/joanie/core/templates/certificate/verify.html
+++ b/src/backend/joanie/core/templates/certificate/verify.html
@@ -3,6 +3,7 @@
     <head>
         <title>🎓 Certificate validation</title>
         <link rel="stylesheet" type="text/css" href="{% static 'joanie/css/certificate/verify.css' %}" />
+        <meta name="robots" content="noindex">
     </head>
     <body>
         <header class="header">


### PR DESCRIPTION
## Purpose

Currently, Certificate verification page are indexed, we don't want that so we had a meta tag to explicit ask crawler to ignore those pages.