### PR TITLE
Fix order filter date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix order filtering by creation date
+
 ## [2.12.0] - 2024-12-18
 
 ### Added

--- a/src/backend/joanie/core/filters/admin/__init__.py
+++ b/src/backend/joanie/core/filters/admin/__init__.py
@@ -280,7 +280,7 @@ class OrderAdminFilterSet(filters.FilterSet):
         field_name="product__type",
         choices=enums.PRODUCT_TYPE_CHOICES,
     )
-    created_on = filters.DateFilter(field_name="created_on", lookup_expr="exact")
+    created_on = filters.DateFilter(field_name="created_on", lookup_expr="date")
     created_on_date_range = filters.DateFromToRangeFilter(field_name="created_on")
 
     def filter_by_query(self, queryset, _name, value):

--- a/src/backend/joanie/tests/core/api/admin/orders/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_list.py
@@ -22,12 +22,20 @@ class OrdersAdminApiListTestCase(TestCase):
     @staticmethod
     def generate_orders_created_on(number: int, created_on=None):
         """Generate a batch of orders with a specific creation date."""
-        if created_on:
-            created_on = datetime.combine(created_on, datetime.min.time(), tzinfo=timezone.utc)
-        with mock.patch(
-            "django.utils.timezone.now", return_value=created_on or datetime.now()
-        ):
-            return factories.OrderGeneratorFactory.create_batch(number)
+        orders = []
+        for _ in range(number):
+            if created_on:
+                created_on = datetime.combine(
+                    created_on, datetime.now().time(), tzinfo=timezone.utc
+                )
+            with mock.patch(
+                "django.utils.timezone.now",
+                return_value=created_on or datetime.now(),
+            ):
+                orders.append(factories.OrderFactory())
+        # orders default orderings are by creation date
+        orders.sort(key=lambda x: x.created_on, reverse=True)
+        return orders
 
     def test_api_admin_orders_request_without_authentication(self):
         """


### PR DESCRIPTION
## Purpose
A test about order filtering on creation date was flaky, it was about results ordering. 
While digging for a fix, it appears that when we filter on a date, only orders created at 0:00 were found.

Also, a Django deprecation about datetime_safe was raised.

## Proposal

- [x] Remove datetime_safe usage
- [x] Filter created_on by date instead of exact string
