### PR TITLE
🐛(moodle) fix `get_grades` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to
 
 ### Fixed
 
+- Fix moodle `get_grades` method
 - Fix order filtering by creation date
 
 ### Changed

--- a/src/backend/joanie/lms_handler/backends/moodle.py
+++ b/src/backend/joanie/lms_handler/backends/moodle.py
@@ -199,7 +199,10 @@ class MoodleLMSBackend(BaseLMSBackend):
             completion = self.moodle.core.completion.get_course_completion_status(
                 course_id, user_id
             )
-            return {"passed": completion.completionstatus.completed}
+            # moodlepy cast boolean values returned by Moodle web services as int so we have
+            # to recast `completed` as a boolean value...
+            # (Until moodlepy there is a fix in moddlepy)
+            return {"passed": bool(completion.completionstatus.completed)}
 
         except (MoodleException, EmptyResponseException, NetworkMoodleException) as e:
             logger.error(


### PR DESCRIPTION
## Purpose

We expect that the method `get_grades` of an lms backend returns a dict with boolean property `passed`. Currently for moodle, due to a transformation made by
 moodlepy, the passed property has an integer value (0 or 1). We aim to fix
 that into moodlepy directly but to fix the issue as soon as possible we first
 cast the integer value as a bool.