### PR TITLE
Improvement/unicamp certificate layout

### DIFF
--- a/src/backend/joanie/core/enums.py
+++ b/src/backend/joanie/core/enums.py
@@ -161,6 +161,8 @@ CERTIFICATE = "certificate"
 DEGREE = "degree"
 UNICAMP_DEGREE = "unicamp-degree"
 
+VERIFIABLE_CERTIFICATES = (DEGREE, UNICAMP_DEGREE)
+
 CERTIFICATE_NAME_CHOICES = (
     (CERTIFICATE, _("Certificate")),
     (DEGREE, _("Degree")),

--- a/src/backend/joanie/core/models/certifications.py
+++ b/src/backend/joanie/core/models/certifications.py
@@ -235,10 +235,7 @@ class Certificate(BaseModel):
         Return the verification uri for the certificate if
         this one is a degree certificate.
         """
-        if self.certificate_definition.template not in [
-            enums.DEGREE,
-            enums.UNICAMP_DEGREE,
-        ]:
+        if self.certificate_definition.template not in enums.VERIFIABLE_CERTIFICATES:
             return None
 
         # - Retrieve the current language code or a fallback if the language is not available

--- a/src/backend/joanie/core/templates/issuers/unicamp-degree.css
+++ b/src/backend/joanie/core/templates/issuers/unicamp-degree.css
@@ -44,7 +44,7 @@
 :root {
   --padding-top: 50mm;
   --padding-left: 90mm;
-  --padding-right: 17mm;
+  --padding-right: 7mm;
   --padding-bottom: 5mm;
   --color-neutral-100: #FFF;
   --color-neutral-500: #6D6E70;
@@ -201,7 +201,8 @@ body {
 .content {
   display: flex;
   flex-direction: column;
-  height: 150mm;
+  height: 162mm;
+  margin-top: -7mm;
 }
 
 .content-object {
@@ -219,6 +220,7 @@ body {
   color: var(--color-accent);
   font-size: 26pt;
   font-weight: 700;
+  line-height: 1;
 }
 
 .content-issueDate {
@@ -234,11 +236,18 @@ body {
 }
 
 /* == Course details */
-.course-details {
-  margin-top: 8.7mm;
+.course-details__wrapper {
+  display: flex;
+  flex-direction: row;
   flex: 1;
+  margin-top: 8.7mm;
+}
+
+.course-details {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  height: 100%;
 }
 
 .course-details__teachers {
@@ -261,13 +270,16 @@ body {
   color: var(--color-neutral-800);
   font-size: 13pt;
   justify-content: space-between;
+  padding-right: 3mm;
+}
+
+.course-details__teachers + .course-details__signatory-wrapper {
+  justify-content: flex-end;
 }
 
 .course-details__signatory-wrapper {
-  flex: 1;
   display: flex;
-  justify-content: flex-start;
-  padding-left: 3mm;
+  flex: 1;
 }
 
 .course-details__signatory {
@@ -275,11 +287,11 @@ body {
 }
 
 .signatory__signature {
+  height: 15mm;
+  margin-top: 2mm;
   object-fit: contain;
   object-position: center;
   width: 35mm;
-  height: 12mm;
-  margin-top: 2mm;
 }
 
 .signatory__identity > em {
@@ -344,8 +356,16 @@ body {
 }
 
 /* Platform credits */
+.platform-credits__wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: flex-end;
+}
+
 .platform-credits {
   font-size: 7pt;
+  padding-left: 15mm;
   width: 52.3mm;
 }
 .platform-credits > p > strong {
@@ -356,10 +376,11 @@ body {
 }
 
 .platform-credits > img {
-  width: 39.7mm;
-  margin-top: 2.5mm;
-  margin-bottom: 0mm;
+  align-self: flex-end;
+  margin-bottom: 0;
   margin-left: -4mm; /* Avoid the margin of the image */
+  margin-top: 2.5mm;
+  width: 39.7mm;
 }
 
 /* == Skills */

--- a/src/backend/joanie/core/templates/issuers/unicamp-degree.html
+++ b/src/backend/joanie/core/templates/issuers/unicamp-degree.html
@@ -23,7 +23,7 @@ which is the course provider. So the organization is accessed with organizations
     <div class="header-logos">
         <img class="logo-unicamp" src="{% static "joanie/images/logo_unicamp.png" %}" />
         {% if organizations.0.logo %}
-        <img class="logo-organization" src="{{ organizations.0.logo }}"/>
+            <img class="logo-organization" src="{{ organizations.0.logo }}"/>
         {% endif %}
     </div>
 </header>
@@ -40,49 +40,65 @@ which is the course provider. So the organization is accessed with organizations
         Issued on {{ creation_date }} in France.
         {% endblocktranslate %}
     </p>
-    <div class="course-details">
-        <h2 class="course-details__organization">{{ organizations.0.name }}</h2>
-        <div class="course-details__persons flex-row">
-            <div class="course-details__teachers flex-column">
-                {% for teacher in teachers %}
-                <div class="teacher">
-                    <p class="fw-600">{{ teacher }}</p>
-                    <p class="fs-italic">{% translate "Educational coordinator " %}</p>
+    <div class="course-details__wrapper">
+        <div class="course-details">
+            <h2 class="course-details__organization">{{ organizations.0.name }}</h2>
+            <div class="course-details__persons flex-row">
+                {% if teachers %}
+                <div class="course-details__teachers flex-column">
+                    {% for teacher in teachers %}
+                    <div class="teacher">
+                        <p class="fw-600">{{ teacher }}</p>
+                        <p class="fs-italic">{% translate "Educational coordinator " %}</p>
+                    </div>
+                    {% endfor %}
                 </div>
-                {% endfor %}
+                {% endif %}
+                <div class="course-details__signatory-wrapper">
+                    <section class="course-details__signatory">
+                    <p class="text-spaced">
+                        {% trans "Issued by" %}
+                    </p>
+                    <img class="signatory__signature" src="{{ organizations.0.signature }}" />
+                    <p class="signatory__identity">
+                        <strong class="signatory__name fw-600">{{ organizations.0.representative|default:"" }}</strong>
+                        <em class="signatory__role fs-italic">{{ organizations.0.representative_profession|default:"" }}</em>
+                        <em class="signatory__organization fs-italic">{{ organizations.0.name }}</em>
+                    </p>
+                    </section>
+                </div>
             </div>
-            <div class="course-details__signatory-wrapper">
-                <section class="course-details__signatory">
-                <p class="text-spaced">Issued by</p>
-                <img class="signatory__signature" src="{{ organizations.0.signature }}" />
-                <p class="signatory__identity">
-                    <strong class="signatory__name fw-600">{{ organizations.0.representative|default:"" }}</strong>
-                    <em class="signatory__role fs-italic">{{ organizations.0.representative_profession|default:"" }}</em>
-                    <em class="signatory__organization fs-italic">{{ organizations.0.name }}</em>
-                </p>
-                </section>
-            </div>
-        </div>
-        <div class="course-details__rest flex-row">
-            <div>
-                <div class="certification-level__wrapper">
-                    <div class="certification-level">
-                        <p>{% translate "Certification level" %}</p>
-                        <strong>{{ certification_level }}</strong>
+            <div class="course-details__rest flex-row">
+                <div>
+                    <div class="certification-level__wrapper">
+                        {% if certification_level %}
+                            <div class="certification-level">
+                                <p>{% translate "Certification level" %}</p>
+                                <strong>{{ certification_level }}</strong>
+                            </div>
+                        {% endif %}
+                    </div>
+                    <div class="european-credits">
+                        <img src="{% static "joanie/images/flag_europe.svg" %}"/>
+                        <p>
+                            {% blocktranslate %}
+                            This micro-certification is issued in compliance with the common framework for micro-certifications:
+                            <br /><a href="{{ microcertification_terms_url }}">{{microcertification_terms_url}}</a>
+                            {% endblocktranslate %}
+                        </p>
                     </div>
                 </div>
-                <div class="european-credits">
-                    <img src="{% static "joanie/images/flag_europe.svg" %}"/>
-                    <p>
-                        {% blocktranslate %}
-                        This micro-certification is issued in compliance with the common framework for micro-certifications:
-                        <br /><a href="{{ microcertification_terms_url }}">{{microcertification_terms_url}}</a>
-                        {% endblocktranslate %}
-                    </p>
-                </div>
             </div>
+        </div>
+        <div class="platform-credits__wrapper">
             <div class="platform-credits">
-                <p><strong>This training<br/>is hosted by FUN</strong></p>
+                <p>
+                    <strong>
+                        {% blocktranslate trimmed %}
+                        This training<br/>is hosted by FUN
+                        {% endblocktranslate %}
+                    </strong>
+                </p>
                 {% if LANGUAGE_CODE == "fr-fr" %}
                 <img src="{% static "joanie/images/logo-fr.svg" %}" />
                 {% else %}

--- a/src/backend/joanie/core/views/certificate.py
+++ b/src/backend/joanie/core/views/certificate.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
 
 from joanie.core import models
-from joanie.core.enums import DEGREE
+from joanie.core.enums import VERIFIABLE_CERTIFICATES
 from joanie.core.utils import issuers
 
 
@@ -27,7 +27,7 @@ class CertificateVerificationView(TemplateView):
         certificate = get_object_or_404(
             models.Certificate,
             id=certificate_id,
-            certificate_definition__template=DEGREE,
+            certificate_definition__template__in=VERIFIABLE_CERTIFICATES,
         )
 
         certificate_context = certificate.get_document_context()

--- a/src/backend/joanie/tests/core/test_models_certificate.py
+++ b/src/backend/joanie/tests/core/test_models_certificate.py
@@ -184,7 +184,7 @@ class CertificateModelTestCase(LoggingTestCase):
             certificate = factories.EnrollmentCertificateFactory(
                 certificate_definition__template=template_name
             )
-            if template_name in [enums.DEGREE, enums.UNICAMP_DEGREE]:
+            if template_name in enums.VERIFIABLE_CERTIFICATES:
                 self.assertEqual(
                     certificate.verification_uri,
                     f"https://example.com/en-us/certificates/{certificate.id}",


### PR DESCRIPTION
## Purpose

- Add missing i18n texts
- Improve behavior with course title that goes on several lines
- Make the hosted by fun block floating on the right to allow the rest of the
content the stretch better

Allow the certificate verification view to retrieve Unicamp degree and
furthermore all certificate with templates declared within the
`VERIFIABLE_CERTIFICATES` enums.


[téléchargement (1).pdf](https://github.com/user-attachments/files/18400965/telechargement.1.pdf)

