### PR TITLE
🐛(backoffice) fix an issue on target course creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- BO: Set properly the `is_graded` property on target course creation
+
 ## [2.13.0] - 2025-01-15
 
 ### Added

--- a/src/frontend/admin/src/components/templates/products/form/sections/target-courses/ProductFormTargetCoursesSection.tsx
+++ b/src/frontend/admin/src/components/templates/products/form/sections/target-courses/ProductFormTargetCoursesSection.tsx
@@ -110,6 +110,7 @@ export function ProductFormTargetCoursesSection(props: Props) {
       course: values.course,
       course_runs: values.course_runs ?? [],
       position: targetCourses.fields.length,
+      is_graded: values.is_graded,
     };
     const payload = transformProductTargetCourseRelationToDTO(newValue);
 

--- a/src/frontend/admin/src/tests/product/product.test.e2e.ts
+++ b/src/frontend/admin/src/tests/product/product.test.e2e.ts
@@ -283,6 +283,13 @@ test.describe("Product form", () => {
     await page.getByLabel("Course search").fill(course.title);
     await page.getByRole("option", { name: course.title }).click();
 
+    // By default the course is marked as graded
+    await expect(
+      page.getByRole("checkbox", {
+        name: "Taken into account for certification",
+      }),
+    ).toBeChecked();
+
     await expect(
       addTargetCourseModal
         .getByTestId("product-target-course-runs-selection-alert")
@@ -303,6 +310,7 @@ test.describe("Product form", () => {
       .getByLabel("Select row")
       .check();
     await page.getByTestId("submit-button-product-target-course-form").click();
+
     await expect(
       page.getByText("Operation completed successfully."),
     ).toBeVisible();


### PR DESCRIPTION
## Purpose

Currently, when a target course is created, the `is_graded` field is not bound so no matter the value of this field, the target course is never graded by default and the editor has to edit the target course to change that...