### PR TITLE
🐛(backoffice) allow to use nested TranslatableForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - BO: Set properly the `is_graded` property on target course creation
+- BO: Allow to use nested TranslatableForms
 
 ## [2.13.0] - 2025-01-15
 

--- a/src/frontend/admin/src/components/presentational/dnd/DndDefaultRow.tsx
+++ b/src/frontend/admin/src/components/presentational/dnd/DndDefaultRow.tsx
@@ -3,9 +3,9 @@ import { ReactNode } from "react";
 import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Typography from "@mui/material/Typography";
-import { grey } from "@mui/material/colors";
 import DeleteOutlineRoundedIcon from "@mui/icons-material/DeleteOutlineRounded";
 import ModeEditOutlineTwoToneIcon from "@mui/icons-material/ModeEditOutlineTwoTone";
+import { useTheme } from "@mui/material/styles";
 
 export interface DndDefaultRowProps {
   mainTitle: string | ReactNode;
@@ -23,6 +23,7 @@ export function DndDefaultRow({
   enableEdit = false,
   ...props
 }: DndDefaultRowProps) {
+  const theme = useTheme();
   return (
     <Box
       display="flex"
@@ -32,12 +33,15 @@ export function DndDefaultRow({
         px: 2,
         py: 1,
         borderRadius: 1,
-        backgroundColor: grey[100],
         "&:hover": {
           ".right-actions": {
             opacity: 1,
           },
         },
+        backgroundColor: theme.palette.grey[100],
+        ...theme.applyStyles("dark", {
+          backgroundColor: theme.palette.grey[700],
+        }),
       }}
     >
       <Box>

--- a/src/frontend/admin/src/components/testing/presentational/translatable-content/TranslatableContent.spec.e2e.tsx
+++ b/src/frontend/admin/src/components/testing/presentational/translatable-content/TranslatableContent.spec.e2e.tsx
@@ -1,14 +1,17 @@
 import { expect, test } from "@playwright/experimental-ct-react";
 import { Maybe } from "@/types/utils";
 import { TranslatableForm } from "@/components/presentational/translatable-content/TranslatableForm";
+import TranslatableFormProvider from "@/contexts/i18n/TranslatableFormProvider";
 
 test.describe("<TranslatableForm/>", () => {
   test("Check onSelectLang call", async ({ mount }) => {
     let lang: Maybe<string> = "";
     const component = await mount(
-      <TranslatableForm onSelectLang={(newLang) => (lang = newLang)}>
-        John Doe
-      </TranslatableForm>,
+      <TranslatableFormProvider>
+        <TranslatableForm onSelectLang={(newLang) => (lang = newLang)}>
+          John Doe
+        </TranslatableForm>
+      </TranslatableFormProvider>,
     );
     await expect(component.getByText("John Doe")).toBeVisible();
     expect(lang).toEqual("");
@@ -20,7 +23,9 @@ test.describe("<TranslatableForm/>", () => {
 
   test("Check local storage values", async ({ mount, page }) => {
     const component = await mount(
-      <TranslatableForm onSelectLang={() => {}}>John Doe</TranslatableForm>,
+      <TranslatableFormProvider>
+        <TranslatableForm onSelectLang={() => {}}>John Doe</TranslatableForm>
+      </TranslatableFormProvider>,
     );
 
     let states = await page.context().storageState();
@@ -55,11 +60,113 @@ test.describe("<TranslatableForm/>", () => {
     ).toBe(true);
   });
 
+  test("Check local storage values with several translatable forms", async ({
+    mount,
+    page,
+  }) => {
+    // Until there is a TranslatableForm mounted, language settings should be saved
+    // into the localstorage, then when all the stuff is unmounted, the cookie `django_language`
+    // should be restored.
+
+    let mountedForms = [true, true];
+    // Mount both TranslatableForms
+    const component = await mount(
+      <TranslatableFormProvider>
+        {mountedForms[0] === true && (
+          <TranslatableForm onSelectLang={() => {}} />
+        )}
+        {mountedForms[1] === true && (
+          <TranslatableForm onSelectLang={() => {}} />
+        )}
+      </TranslatableFormProvider>,
+    );
+    let states = await page.context().storageState();
+    let storage = states.origins[0].localStorage;
+    expect(
+      storage.some(
+        (entry) =>
+          entry.name === "translateContentLanguage" && entry.value === "en-us",
+      ),
+    ).toBe(true);
+    expect(
+      storage.some(
+        (entry) =>
+          entry.name === "django_language_saved" && entry.value === "en-us",
+      ),
+    ).toBe(true);
+    let cookie = states.cookies.find(
+      (entry) => entry.name === "django_language",
+    );
+    expect(cookie).toBe(undefined);
+
+    // Only unmount one TranslatableForm
+    mountedForms = [false, true];
+    // Mount both TranslatableForms
+    await component.update(
+      <TranslatableFormProvider>
+        {mountedForms[0] === true && (
+          <TranslatableForm onSelectLang={() => {}} />
+        )}
+        {mountedForms[1] === true && (
+          <TranslatableForm onSelectLang={() => {}} />
+        )}
+      </TranslatableFormProvider>,
+    );
+    states = await page.context().storageState();
+    storage = states.origins[0].localStorage;
+    expect(
+      storage.some(
+        (entry) =>
+          entry.name === "translateContentLanguage" && entry.value === "en-us",
+      ),
+    ).toBe(true);
+    expect(
+      storage.some(
+        (entry) =>
+          entry.name === "django_language_saved" && entry.value === "en-us",
+      ),
+    ).toBe(true);
+    cookie = states.cookies.find((entry) => entry.name === "django_language");
+    expect(cookie).toBe(undefined);
+
+    // Unmount both TranslatableForms
+    mountedForms = [false, false];
+    await component.update(
+      <TranslatableFormProvider>
+        {mountedForms[0] === true && (
+          <TranslatableForm onSelectLang={() => {}} />
+        )}
+        {mountedForms[1] === true && (
+          <TranslatableForm onSelectLang={() => {}} />
+        )}
+      </TranslatableFormProvider>,
+    );
+    states = await page.context().storageState();
+    storage = states.origins[0].localStorage;
+    expect(
+      storage.some(
+        (entry) =>
+          entry.name === "translateContentLanguage" && entry.value === "en-us",
+      ),
+    ).toBe(false);
+    expect(
+      storage.some(
+        (entry) =>
+          entry.name === "django_language_saved" && entry.value === "en-us",
+      ),
+    ).toBe(false);
+    cookie = states.cookies.find((entry) => entry.name === "django_language");
+    expect(cookie).toBeDefined();
+    expect(cookie!.value).toBe("en-us");
+  });
+
   test("Check that the loader is displayed", async ({ mount }) => {
     const component = await mount(
-      <TranslatableForm isLoading={true} onSelectLang={() => {}}>
-        John Doe
-      </TranslatableForm>,
+      <TranslatableFormProvider>
+        <TranslatableForm isLoading={true} onSelectLang={() => {}}>
+          John Doe
+        </TranslatableForm>
+      </TranslatableFormProvider>,
     );
 
     await expect(component.getByRole("progressbar")).toBeVisible();

--- a/src/frontend/admin/src/contexts/i18n/TranslatableFormProvider/index.tsx
+++ b/src/frontend/admin/src/contexts/i18n/TranslatableFormProvider/index.tsx
@@ -1,0 +1,102 @@
+import {
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  deleteDjangoLang,
+  getSavedDjangoLanguage,
+  setDjangoLang,
+} from "@/utils/lang";
+import { TRANSLATE_CONTENT_LANGUAGE } from "@/utils/constants";
+import usePrevious from "@/hooks/usePrevious";
+
+const TranslatableFormContext = createContext({
+  register: () => {},
+  unregister: () => {},
+  registeredForms: 0,
+});
+
+/**
+ * The TranslatableFormProvider aims to monitor the use of TranslatableForms.
+ * Actually, we need to be sure that there is no TranslatableForm mounted in the page
+ * to restore the cookie `django_language` to its previous value. Otherwise, we manage
+ * locale settings in the local storage to not send locale information in the headers through
+ * cookies as if this the case, the Django middleware in charge to activate the locale will give
+ * priority to the cookie value over the header `Accept-Language`...
+ *
+ * So this provider registers all TranslableForms mounted and when last one is unmounted, it is
+ * in charge to restore the cookie `django_language` to its previous value.
+ */
+function TranslatableFormProvider({ children }: PropsWithChildren<{}>) {
+  const [registeredForms, setRegisteredForms] = useState<number>(0);
+  const previousRegisteredForms = usePrevious(registeredForms);
+  const register = () => {
+    setRegisteredForms((prev) => prev + 1);
+  };
+  const unregister = () => {
+    setRegisteredForms((prev) => Math.max(0, prev - 1));
+  };
+
+  const context = useMemo(
+    () => ({ register, unregister, registeredForms }),
+    [register, unregister, registeredForms],
+  );
+
+  useEffect(() => {
+    // A first TranslatableForm has been mounted, we remove the cookie `django_language`
+    // and save its value in the local storage
+    if (previousRegisteredForms === 0 && registeredForms > 0) {
+      const old = deleteDjangoLang();
+      localStorage.setItem(TRANSLATE_CONTENT_LANGUAGE, old);
+
+      const resetTranslateContentLanguage = () => {
+        const oldDjangoLanguage = getSavedDjangoLanguage();
+        if (oldDjangoLanguage) {
+          localStorage.removeItem(TRANSLATE_CONTENT_LANGUAGE);
+          setDjangoLang(oldDjangoLanguage);
+        }
+      };
+
+      /*
+      The translation of content and the retrieval of an object according to a given language are done via the same
+      header on a GET / POST request. We play on the priorities in the "getAcceptLanguage" method of HttpService.
+      We add this event because if we are on a page with translatable content, we need to reset the
+      TRANSLATE_CONTENT_LANGUAGE key in localStorage when we leave or refresh the page so that the object is retrieved
+      in the current language and not in the current language forced. by the TranslatableContent component
+     */
+      window.addEventListener("beforeunload", resetTranslateContentLanguage, {
+        once: true,
+      });
+
+      return () => {
+        window.removeEventListener(
+          "beforeunload",
+          resetTranslateContentLanguage,
+        );
+      };
+    }
+
+    // The last TranslatableForm has been unmounted, we restore the cookie `django_language`
+    if (previousRegisteredForms > 0 && registeredForms === 0) {
+      const oldDjangoLanguage = getSavedDjangoLanguage();
+      localStorage.removeItem(TRANSLATE_CONTENT_LANGUAGE);
+      setDjangoLang(oldDjangoLanguage);
+    }
+  }, [registeredForms]);
+
+  return (
+    <TranslatableFormContext.Provider value={context}>
+      {children}
+    </TranslatableFormContext.Provider>
+  );
+}
+
+export const useTranslatableForm = () => {
+  return useContext(TranslatableFormContext);
+};
+
+export default TranslatableFormProvider;

--- a/src/frontend/admin/src/contexts/i18n/TranslationsProvider/TranslationsProvider.tsx
+++ b/src/frontend/admin/src/contexts/i18n/TranslationsProvider/TranslationsProvider.tsx
@@ -16,6 +16,7 @@ import {
 import { useAllLanguages } from "@/hooks/useAllLanguages/useAllLanguages";
 import { getLocaleFromDjangoLang, setDjangoLangFromLocale } from "@/utils/lang";
 import { FORCE_TRANSLATE_CONTENT_LANGUAGE } from "@/utils/constants";
+import TranslatableFormProvider from "@/contexts/i18n/TranslatableFormProvider";
 
 export function TranslationsProvider({ children }: PropsWithChildren<{}>) {
   const queryClient = useQueryClient();
@@ -73,7 +74,9 @@ export function TranslationsProvider({ children }: PropsWithChildren<{}>) {
           messages={translations}
           defaultLocale={LocalesEnum.ENGLISH}
         >
-          {allLanguages && <div>{children}</div>}
+          {allLanguages && (
+            <TranslatableFormProvider>{children}</TranslatableFormProvider>
+          )}
         </IntlProvider>
       </LocalizationProvider>
     </LocaleContext.Provider>


### PR DESCRIPTION
## Purpose

In order to make internationalized request to our API, we can't keep the `django_language` cookie as this one, once send in the request has the priority over the header 'Accept-Language'. So that's why when we need to make internationalized request, we have to remove this cookie, make the request then restore it. Our mechanims currently works pretty well until we have several TranslatableForms rendered on the same page. As when this kind of component is unmount we restore the cookie value, when there were several all was messed up! So we had a new TranstableFormProvider in charge to register all TranslatableForm mounted and restore/backup cookie value only when it's needed.