### PR TITLE
✨(backend) delete orders that are stuck in specific states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 
 ### Added
 
+- Add management command to delete orders stuck in signing states and orders
+  stuck in `to_save_payment_method` to purchase a product of type certificate
 - Add order export to CSV in back office
 - Branded Unicamp degrees
 

--- a/src/backend/joanie/core/management/commands/delete_stuck_orders.py
+++ b/src/backend/joanie/core/management/commands/delete_stuck_orders.py
@@ -1,0 +1,46 @@
+"""
+Management command to delete orders that have been stuck in the `to_sign` or `signing` states
+beyond the tolerated time limit.
+These stuck orders prevent the release of slots allocated for distributing students
+among organizations, particularly when the product is shared across multiple organizations.
+By deleteing these orders, we ensure that the slot allocation system remains efficient
+and available for other students.
+This command also deletes order where the product is type certificate and the state is
+in `to_save_payment_method` because that means that the student opened the sales tunnel but
+never entered his payment information to purchase the certificate.
+"""
+
+import logging
+
+from django.core.management import BaseCommand
+
+from joanie.core.utils.order import delete_stuck_orders
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    A command to delete all orders that are stucked in signing states for product with contracts
+    and delete all order that are stucked in to save payment method for product of type
+    certificate from the database.
+    """
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        """
+        Retrieve all orders that are stuck and delete them from the database.
+        """
+        deleted_orders_in_signing_states, deleted_order_in_to_save_payment_method = (
+            delete_stuck_orders()
+        )
+
+        logger.info(
+            "Deleted %s orders that were stucked in signing states.",
+            deleted_orders_in_signing_states,
+        )
+        logger.info(
+            "Deleted %s order that were stucked in to save payment method.",
+            deleted_order_in_to_save_payment_method,
+        )

--- a/src/backend/joanie/core/utils/order.py
+++ b/src/backend/joanie/core/utils/order.py
@@ -1,0 +1,57 @@
+"""Util to manage the deletion of Order depending the state and the product type"""
+
+from joanie.core import enums
+from joanie.core.models import Order
+
+
+def delete_stuck_signing_order(order):
+    """
+    Delete related objects and the Order itself when it is stuck in signing states.
+    This method handles orders in the `ORDER_STATE_TO_SIGN` or `ORDER_STATE_SIGNING` states,
+    which occur when users abandon the signing process in the sales tunnel.
+    These states indicate that the order required a signature on the contract but was never
+    completed by the user.
+    """
+    if order.state not in [enums.ORDER_STATE_TO_SIGN, enums.ORDER_STATE_SIGNING]:
+        return
+    order.contract.delete()
+    order.main_invoice.delete()
+    order.delete()
+
+
+def delete_stuck_certificate_order(order):
+    """
+    Delete related objects and the Order itself when it is stuck for a product type certificate
+    in the state `ORDER_STATE_TO_SAVE_PAYMENT_METHOD`.
+    These orders are created when a user starts but does not complete the payment process
+    for a certificate.
+    """
+    if order.state not in [
+        enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD
+    ] or order.product.type in [
+        enums.PRODUCT_TYPE_ENROLLMENT,
+        enums.PRODUCT_TYPE_CREDENTIAL,
+    ]:
+        return
+    order.main_invoice.delete()
+    order.delete()
+
+
+def delete_stuck_orders():
+    """
+    Delete all the orders that are considered as stuck.
+    For products with contract, it's all the orders that are stuck in signing states.
+    For product with certificate, it's all the order that are stuck in to save payment method.
+    """
+    deleted_orders_in_signing_states = 0
+    deleted_orders_in_to_save_payment_state = 0
+
+    for order in Order.objects.get_stuck_signing_orders():
+        delete_stuck_signing_order(order)
+        deleted_orders_in_signing_states += 1
+
+    for order in Order.objects.get_stuck_certificate_payment_orders():
+        delete_stuck_certificate_order(order)
+        deleted_orders_in_to_save_payment_state += 1
+
+    return deleted_orders_in_signing_states, deleted_orders_in_to_save_payment_state

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -464,6 +464,15 @@ class Base(Configuration):
         environ_prefix=None,
     )
 
+    # Minimum time authorized for order latest updates when the order are
+    # in the state `to_sign` or `signing`. It's also applied for order's of
+    # product type certificate that are in state `to_save_payment_method`
+    JOANIE_ORDER_UPDATE_DELAY_LIMIT_IN_SECONDS = values.Value(
+        60 * 60,  # 1 hour
+        environ_name="JOANIE_ORDER_UPDATE_DELAY_LIMIT_IN_SECONDS",
+        environ_prefix=None,
+    )
+
     # CORS
     CORS_ALLOW_CREDENTIALS = True
     CORS_ALLOW_ALL_ORIGINS = values.BooleanValue(False)

--- a/src/backend/joanie/tests/core/test_command_delete_stuck_orders.py
+++ b/src/backend/joanie/tests/core/test_command_delete_stuck_orders.py
@@ -1,0 +1,31 @@
+"""Tests for the `delete_stuck_orders` management command."""
+
+from unittest import mock
+
+from django.core.management import call_command
+
+from joanie.tests.base import LoggingTestCase
+
+
+class DeleteStuckOrdersCommandTestCase(LoggingTestCase):
+    """Test case for the management command `delete_stuck_orders`."""
+
+    @mock.patch("joanie.core.utils.order.delete_stuck_orders", return_value=(2, 10))
+    def test_commands_delete_stuck_orders(self, mock_delete_stuck_orders):
+        """
+        This command should call the method `delete_stuck_orders` util and
+        log the count of orders deleted.
+        """
+        expected_logs = [
+            ("INFO", "Deleted 2 orders that were stucked in signing states."),
+            (
+                "INFO",
+                "Deleted 10 order that were stucked in to save payment method.",
+            ),
+        ]
+
+        with self.assertLogs() as logger:
+            call_command("delete_stuck_orders")
+
+        self.assertTrue(mock_delete_stuck_orders.assert_called_once_with)
+        self.assertLogsEquals(logger.records, expected_logs)

--- a/src/backend/joanie/tests/core/utils/test_utils_order.py
+++ b/src/backend/joanie/tests/core/utils/test_utils_order.py
@@ -1,0 +1,149 @@
+"""Test suite for utils order methods"""
+
+from datetime import timedelta
+from unittest import mock
+
+from django.conf import settings
+from django.test import TestCase
+
+from joanie.core import enums, factories, models
+from joanie.core.utils.order import (
+    delete_stuck_certificate_order,
+    delete_stuck_orders,
+    delete_stuck_signing_order,
+)
+
+
+class UtilsOrderTestCase(TestCase):
+    """Test suite for utils order methods"""
+
+    def test_utils_delete_stuck_signing_order(self):
+        """
+        Calling the method `delete_stuck_signing_order` should only delete the order and the
+        related objects if the state is `to_sign` or `signing`.
+        """
+        for state, _ in enums.ORDER_STATE_CHOICES:
+            with self.subTest(state=state):
+                order = factories.OrderGeneratorFactory(state=state)
+                delete_stuck_signing_order(order)
+                if state in [enums.ORDER_STATE_TO_SIGN, enums.ORDER_STATE_SIGNING]:
+                    self.assertFalse(models.Order.objects.filter(pk=order.pk).exists())
+                else:
+                    self.assertTrue(models.Order.objects.filter(pk=order.pk).exists())
+
+    def test_utils_delete_stuck_certificate_order(self):
+        """
+        When we call the method `delete_stuck_certificate_order` it should only delete the orders
+        with a product type certificate that are in the state `to_save_payment_method`.
+        """
+        for state, _ in enums.ORDER_STATE_CHOICES:
+            with self.subTest(state=state):
+                enrollment = factories.EnrollmentFactory()
+                product = factories.ProductFactory(
+                    courses=[enrollment.course_run.course],
+                    price=100.00,
+                    type=enums.PRODUCT_TYPE_CERTIFICATE,
+                )
+                order = factories.OrderFactory(
+                    course=None,
+                    enrollment=enrollment,
+                    product=product,
+                    state=state,
+                )
+                delete_stuck_certificate_order(order)
+                if state == enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD:
+                    self.assertFalse(models.Order.objects.filter(pk=order.pk).exists())
+                else:
+                    self.assertTrue(models.Order.objects.filter(pk=order.pk).exists())
+
+    def test_utils_delete_stuck_certificate_order_should_not_delete_credential_orders(
+        self,
+    ):
+        """
+        No matter the state of the order, if the product type is credential, then the method
+        `delete_stuck_certificate_order` should not delete any orders.
+        """
+        for state, _ in enums.ORDER_STATE_CHOICES:
+            with self.subTest(state=state):
+                order = factories.OrderFactory(
+                    product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+                    state=state,
+                )
+                delete_stuck_certificate_order(order)
+                self.assertTrue(models.Order.objects.filter(pk=order.pk).exists())
+
+    def test_utils_delete_stuck_certificate_should_not_delete_enrollment_orders(self):
+        """
+        No matter the state of the order, if the product type is enrollment, then the method
+        `delete_stuck_certificate_order` should not delete any orders.
+        """
+        for state, _ in enums.ORDER_STATE_CHOICES:
+            with self.subTest(state=state):
+                enrollment_product = factories.ProductFactory(
+                    type=enums.PRODUCT_TYPE_ENROLLMENT
+                )
+                order = factories.OrderFactory(product=enrollment_product, state=state)
+                delete_stuck_certificate_order(order)
+                self.assertTrue(models.Order.objects.filter(pk=order.pk).exists())
+
+    def test_utils_delete_stuck_orders(self):
+        """
+        The method `delete_stuck_order` should delete only orders that are in signing
+        states and orders with product certificates in the state `to_save_payment_method`.
+        """
+        # Create orders that will be deleted
+        factories.OrderGeneratorFactory.create_batch(2, state=enums.ORDER_STATE_TO_SIGN)
+        factories.OrderGeneratorFactory.create_batch(2, state=enums.ORDER_STATE_SIGNING)
+        enrollments = factories.EnrollmentFactory.create_batch(2)
+        factories.OrderFactory(
+            course=None,
+            enrollment=enrollments[0],
+            product__courses=[enrollments[0].course_run.course],
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            state=enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
+        )
+        stuck_order = factories.OrderFactory(
+            course=None,
+            enrollment=enrollments[1],
+            product__courses=[enrollments[1].course_run.course],
+            product__type=enums.PRODUCT_TYPE_CERTIFICATE,
+            state=enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
+        )
+        # Prepare time tolerance of latest update of order objects for those specific states
+        beyond_tolerated_time = stuck_order.updated_on + timedelta(
+            seconds=settings.JOANIE_ORDER_UPDATE_DELAY_LIMIT_IN_SECONDS
+        )
+        within_time_tolerated = beyond_tolerated_time - timedelta(seconds=60)
+        # Create orders that will not be deleted
+        kept_orders = [
+            factories.OrderFactory(
+                product__type=enums.PRODUCT_TYPE_CREDENTIAL,
+                state=enums.ORDER_STATE_CANCELED,
+                updated_on=within_time_tolerated,
+            )
+        ]
+        kept_orders.extend(
+            factories.OrderGeneratorFactory.create_batch(
+                3, state=enums.ORDER_STATE_DRAFT, updated_on=within_time_tolerated
+            )
+        )
+        kept_orders.extend(
+            factories.OrderGeneratorFactory.create_batch(
+                3,
+                state=enums.ORDER_STATE_PENDING_PAYMENT,
+                updated_on=within_time_tolerated,
+            )
+        )
+
+        with mock.patch(
+            "django.utils.timezone.now", return_value=beyond_tolerated_time
+        ):
+            (
+                deleted_orders_in_signing_states,
+                deleted_orders_in_to_save_payment_state,
+            ) = delete_stuck_orders()
+
+        self.assertEqual(deleted_orders_in_signing_states, 4)
+        self.assertEqual(deleted_orders_in_to_save_payment_state, 2)
+        # Check that the orders we created to control still exists
+        self.assertListEqual(kept_orders, list(models.Order.objects.all().reverse()))


### PR DESCRIPTION
## Purpose
We have encountered some issues in the affectation of students to organization when they enroll. We have discovered that the orders in states `to_sign` and `signing` were causing that effect. Those orders exist because students have decided not to complete the process to sign the contract, and the order would stay in that state. The issue is that it takes one available seat on the session. We have added a django command that is responsible to clean up those orders that are considered as stuck. We also added the deletion of orders for product type certificate where the student opened the sales tunnel to purchase the certificate but never entered their payment information. To avoid this in the future, we have added a minimum time limit of tolerance on the latest update of those objects. If they reach this time limit, we now delete the order and the related objects.

## Proposal

- [x] create a django command to delete the orders
- [x] create utility method to erase related objects of an Order
- [x] update factory to create only the main invoice when the product is type certificate for an order
