### PR TITLE
🐛(backend) fix auto organization assignment to order logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 - Allow a user to create a new order when the previous order already
   exists but it is in `refunding` or `refunded` state
 - Prevent multiple payments if the provider server has a problem
+- Fix the logic to get the organization with the least active orders
+  to assign which could have duplicated orders in its sum.
 
 ### Added
 


### PR DESCRIPTION
## Purpose

In some case, it appears that the organization with the least orders count is not the one assigned. It appears that the queryset to count the order may return wrong results according if the related organization is implied as author is other course product relations with active orders.