### PR TITLE
🔧(tray) add cronjob for delete_stuck_orders management command

### DIFF
--- a/src/tray/templates/services/app/cronjob_delete_stuck_orders.yml.j2
+++ b/src/tray/templates/services/app/cronjob_delete_stuck_orders.yml.j2
@@ -1,0 +1,81 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app: joanie
+    service: app
+    version: "{{ joanie_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "joanie-delete-stuck-orders-{{ deployment_stamp }}"
+  namespace: "{{ namespace_name }}"
+spec:
+  schedule: "{{ joanie_delete_stuck_orders_cronjob_schedule }}"
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "joanie-delete-stuck-orders-{{ deployment_stamp }}"
+          labels:
+            app: joanie
+            service: app
+            version: "{{ joanie_image_tag }}"
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+{% set image_pull_secret_name = joanie_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
+{% if image_pull_secret_name is not none %}
+          imagePullSecrets:
+            - name: "{{ image_pull_secret_name }}"
+{% endif %}
+          containers:
+            - name: "joanie-delete-stuck-orders"
+              image: "{{ joanie_image_name }}:{{ joanie_image_tag }}"
+              imagePullPolicy: Always
+              command:
+                - "/bin/bash"
+                - "-c"
+                - python manage.py delete_stuck_orders
+              env:
+                - name: DB_HOST
+                  value: "joanie-{{ joanie_database_host }}-{{ deployment_stamp }}"
+                - name: DB_NAME
+                  value: "{{ joanie_database_name }}"
+                - name: DB_PORT
+                  value: "{{ joanie_database_port }}"
+                - name: DJANGO_ALLOWED_HOSTS
+                  value: "{{ joanie_host | blue_green_hosts }},{{ joanie_admin_host | blue_green_hosts }}"
+                - name: DJANGO_CSRF_TRUSTED_ORIGINS
+                  value: "{{ joanie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},{{ joanie_admin_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+                - name: DJANGO_CONFIGURATION
+                  value: "{{ joanie_django_configuration }}"
+                - name: DJANGO_CORS_ALLOWED_ORIGINS
+                  value: "{{ richie_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }},{{ joanie_admin_host | blue_green_hosts | split(',') | map('regex_replace', '^(.*)$', 'https://\\1') | join(',') }}"
+                - name: DJANGO_CSRF_COOKIE_DOMAIN
+                  value: ".{{ joanie_host }}"
+                - name: DJANGO_SETTINGS_MODULE
+                  value: joanie.configs.settings
+                - name: JOANIE_BACKOFFICE_BASE_URL
+                  value: "https://{{ joanie_admin_host }}"
+                - name: DJANGO_CELERY_DEFAULT_QUEUE
+                  value: "default-queue-{{ deployment_stamp }}"
+              envFrom:
+                - secretRef:
+                    name: "{{ joanie_secret_name }}"
+                - configMapRef:
+                    name: "joanie-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ joanie_delete_stuck_orders_cronjob_resources }}
+              volumeMounts:
+                - name: joanie-configmap
+                  mountPath: /app/joanie/configs
+          restartPolicy: Never
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}
+          volumes:
+            - name: joanie-configmap
+              configMap:
+                defaultMode: 420
+                name: joanie-app-{{ deployment_stamp }}

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -85,6 +85,7 @@ joanie_celery_readynessprobe:
 # Joanie cronjobs
 joanie_process_payment_schedules_cronjob_schedule: "0 3 * * *"
 joanie_send_mail_upcoming_debit_cronjob_schedule: "0 3 * * *"
+joanie_delete_stuck_orders_cronjob_schedule: "0 * * * *"
 
 # -- resources
 {% set app_resources = {
@@ -98,6 +99,7 @@ joanie_app_resources: "{{ app_resources }}"
 joanie_app_job_db_migrate_resources: "{{ app_resources }}"
 joanie_process_payment_schedules_cronjob_resources: "{{ app_resources }}"
 joanie_send_mail_upcoming_debit_cronjob_resources: "{{ app_resources }}"
+joanie_delete_stuck_orders_cronjob_resources: "{{ app_resources }}"
 
 joanie_nginx_resources:
   requests:


### PR DESCRIPTION
## Purpose

We have to add a cronjob in the tray to manage the delete_stuck_orders management command.