### PR TITLE
🐛(backend) add missing `updated_on` field to AdminOrderLightSerializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing field `updated_on` to `AdminOrderLightSerializer`
+
 ## [2.14.0] - 2025-01-29
 
 ### Added

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -1249,6 +1249,7 @@ class AdminOrderLightSerializer(serializers.ModelSerializer):
         fields = (
             "course_code",
             "created_on",
+            "updated_on",
             "enrollment_id",
             "id",
             "organization_title",

--- a/src/backend/joanie/tests/core/api/admin/orders/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_list.py
@@ -96,6 +96,7 @@ class OrdersAdminApiListTestCase(TestCase):
                 {
                     "course_code": order.course.code if order.course else None,
                     "created_on": format_date(order.created_on),
+                    "updated_on": format_date(order.updated_on),
                     "enrollment_id": str(order.enrollment.id)
                     if order.enrollment
                     else None,

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -6519,6 +6519,12 @@
                         "readOnly": true,
                         "description": "date and time at which a record was created"
                     },
+                    "updated_on": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "date and time at which a record was last updated"
+                    },
                     "enrollment_id": {
                         "type": "string",
                         "format": "uuid",
@@ -6575,7 +6581,8 @@
                     "product_title",
                     "state",
                     "total",
-                    "total_currency"
+                    "total_currency",
+                    "updated_on"
                 ]
             },
             "AdminOrderPayment": {


### PR DESCRIPTION
## Purpose

On the backoffice, we recently add a new column to display `updated_on` of an order. But currently, the api endpoint does not return this field so the view were broken.
