### PR TITLE
🔧(backend) Allow to configure JOANIE_LMS_BACKENDS through env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- JOANIE_LMS_BACKENDS is now configurable through env vars
+  as a JSON string array of LMS Backends
+
 ## [2.14.1] - 2025-02-03
 
 ### Fixed

--- a/docs/explanation/lms-connection.md
+++ b/docs/explanation/lms-connection.md
@@ -6,18 +6,19 @@ with your LMS.
 ## Settings
 
 You can link Joanie to several LMSs. You have to define your LMSs through the `JOANIE_LMS_BACKENDS`
-settings which is a list of LMS configuration.
+environment variable which is a JSON array string of LMS configuration.
 
 e.g: A basic configuration
 
-```python
-JOANIE_LMS_BACKENDS = [
+```shell
+JOANIE_LMS_BACKENDS = '[
         {
-            "BACKEND": values.Value(environ_name="MY_LMS_BACKEND", environ_prefix=None),
-            "BASE_URL": values.Value(environ_name="MY_LMS_BASE_URL", environ_prefix=None),
-            "SELECTOR_REGEX" : values.Value(environ_name="MY_LMS_SELECTOR_REGEX", environ_prefix=None)
+            "BACKEND": "MY_LMS_BACKEND",
+            "BASE_URL": "MY_LMS_BASE_URL",
+            "SELECTOR_REGEX" : "ˆMY_LMS_SELECTOR_REGEX$"
+            "COURSE_REGEX" : "ˆMY_LMS_COURSE_REGEX_REGEX$"
         }
-    ]
+    ]'
 ```
 
 `BACKEND`, `BASE_URL`, `SELECTOR_REGEX` are the three settings required by `LMSHandler`. In fact,

--- a/docs/moodle.md
+++ b/docs/moodle.md
@@ -93,7 +93,7 @@ we need to set up a Moodle webservice, and a Moodle webservice client.
 
 ## Setup Moodle settings in Joanie
 
-### Set Moodle backend environment variables
+### Declare a Moodle backend in JOANIE_LMS_BACKENDS environment variable
 
 - MOODLE_API_TOKEN: the token of the Joanie user in Moodle
 - MOODLE_BACKEND: use to override the Moodle backend module in Joanie
@@ -101,5 +101,15 @@ we need to set up a Moodle webservice, and a Moodle webservice client.
 - MOODLE_SELECTOR_REGEX: a regex to match the Moodle backend (e.g. `r"^.*/course/view.php\?id=.*$"`)
 - MOODLE_COURSE_REGEX: a regex to match the Moodle course id (e.g. `r"^.*/course/view.php\?id=(.*)$"`)
 
-
-
+```shell
+JOANIE_LMS_BACKENDS = '[
+    # ...
+    {
+       "API_TOKEN": "FakeApiKeyForExample",
+       "BACKEND": "joanie.lms_handler.backends.moodle.MoodleLMSBackend",
+       "BASE_URL": "http://moodle.test/webservice/rest/server.php",
+       "SELECTOR_REGEX": "^.*/course/view.php\\?id=.*$",
+       "COURSE_REGEX": "^.*/courses/(?P<course_id>.*)/course/?$"
+    }
+]'
+```

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -8,12 +8,14 @@ DJANGO_SUPERUSER_PASSWORD=admin
 PYTHONPATH=/app:/app/joanie
 
 # LMS BACKENDS
-# OpenEdX
-EDX_BASE_URL=http://edx:8073
-EDX_SELECTOR_REGEX='^.*/courses/(?P<course_id>.*)/course/?$'
-EDX_COURSE_REGEX='^.*/courses/(?P<course_id>.*)/course/?$'
-EDX_API_TOKEN=FakeEdXAPIKey
-EDX_BACKEND=joanie.lms_handler.backends.dummy.DummyLMSBackend
+JOANIE_LMS_BACKENDS = '[{
+    "API_TOKEN": "FakeEdXAPIKey",
+    "BACKEND": "joanie.lms_handler.backends.dummy.DummyLMSBackend",
+    "BASE_URL": "http://edx:8073",
+    "SELECTOR_REGEX": "^.*/courses/(?P<course_id>.*)/course/?$",
+    "COURSE_REGEX": "^.*/courses/(?P<course_id>.*)/course/?$",
+    "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages"]
+}]'
 
 #JWT
 DJANGO_JWT_PRIVATE_SIGNING_KEY=ThisIsAnExampleKeyForDevPurposeOnly

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -19,7 +19,7 @@ import sentry_sdk
 from configurations import Configuration, values
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from joanie.core.utils import JSONValue
+from joanie.core.utils import JSONValue, LMSBackendsValue
 from joanie.core.utils.sentry import before_send
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -230,38 +230,7 @@ class Base(Configuration):
     ]
 
     # Joanie
-    JOANIE_LMS_BACKENDS = [
-        {
-            "API_TOKEN": values.Value(
-                environ_name="EDX_API_TOKEN", environ_prefix=None
-            ),
-            "BACKEND": values.Value(environ_name="EDX_BACKEND", environ_prefix=None),
-            "BASE_URL": values.Value(environ_name="EDX_BASE_URL", environ_prefix=None),
-            "SELECTOR_REGEX": values.Value(
-                r".*", environ_name="EDX_SELECTOR_REGEX", environ_prefix=None
-            ),
-            "COURSE_REGEX": values.Value(
-                r".*", environ_name="EDX_COURSE_REGEX", environ_prefix=None
-            ),
-            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages"],
-        },
-        {
-            "API_TOKEN": values.Value(
-                environ_name="MOODLE_API_TOKEN", environ_prefix=None
-            ),
-            "BACKEND": values.Value(environ_name="MOODLE_BACKEND", environ_prefix=None),
-            "BASE_URL": values.Value(
-                environ_name="MOODLE_BASE_URL", environ_prefix=None
-            ),
-            "SELECTOR_REGEX": values.Value(
-                r"^disabled$", environ_name="MOODLE_SELECTOR_REGEX", environ_prefix=None
-            ),
-            "COURSE_REGEX": values.Value(
-                r"^disabled$", environ_name="MOODLE_COURSE_REGEX", environ_prefix=None
-            ),
-            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": [],
-        },
-    ]
+    JOANIE_LMS_BACKENDS = LMSBackendsValue([], environ_prefix=None)
     JOANIE_COURSE_RUN_SYNC_SECRETS = values.ListValue([], environ_prefix=None)
     MOODLE_AUTH_METHOD = values.Value(
         "oauth2", environ_name="MOODLE_AUTH_METHOD", environ_prefix=None

--- a/src/backend/joanie/tests/core/utils/configuration_fields/test_lms_backends_field.py
+++ b/src/backend/joanie/tests/core/utils/configuration_fields/test_lms_backends_field.py
@@ -1,0 +1,111 @@
+"""Test suite for the LMSBackendsValue custom field."""
+
+import json
+
+from django.test import TestCase
+
+from joanie.core.utils import LMSBackendsValue, LMSBackendValidator
+
+
+class TestCaseLMSBackendsValue(TestCase):
+    """Test suite for the LMSBackendsValue custom field."""
+
+    def setUp(self):
+        self.lms_configuration = {
+            "API_TOKEN": "FakeEdXAPIKey",
+            "BACKEND": "joanie.lms_handler.backends.dummy.DummyLMSBackend",
+            "BASE_URL": "http://edx:8073",
+            "SELECTOR_REGEX": "^.*/courses/(?P<course_id>.*)/course/?$",
+            "COURSE_REGEX": "^.*/courses/(?P<course_id>.*)/course/?$",
+            "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages"],
+        }
+
+    def test_lms_backends_value_return_list_of_configuration(self):
+        """If all validation pass, the return value should be a list of configuration."""
+
+        envvar = json.dumps([self.lms_configuration])
+        value = LMSBackendsValue().to_python(envvar)
+
+        self.assertIsInstance(value, list)
+        self.assertEqual(len(value), 1)
+        backend = value[0]
+        self.assertIsInstance(backend, dict)
+        self.assertEqual(backend["API_TOKEN"], "FakeEdXAPIKey")
+        self.assertEqual(
+            backend["BACKEND"], "joanie.lms_handler.backends.dummy.DummyLMSBackend"
+        )
+        self.assertEqual(backend["BASE_URL"], "http://edx:8073")
+        self.assertEqual(
+            backend["SELECTOR_REGEX"], "^.*/courses/(?P<course_id>.*)/course/?$"
+        )
+        self.assertEqual(
+            backend["COURSE_REGEX"], "^.*/courses/(?P<course_id>.*)/course/?$"
+        )
+        self.assertEqual(backend["COURSE_RUN_SYNC_NO_UPDATE_FIELDS"], ["languages"])
+
+    def test_lms_backends_value_validate_required_keys(self):
+        """It should ensure that all required keys are defined."""
+
+        for key in LMSBackendValidator.BACKEND_REQUIRED_KEYS:
+            with self.subTest("Missing key", key=key):
+                values = self.lms_configuration.copy()
+                values.pop(key)
+                envvar = json.dumps([values])
+
+                with self.assertRaises(ValueError):
+                    LMSBackendsValue().to_python(envvar)
+
+    def test_lms_backends_value_validate_regex_properties(self):
+        """It should ensure that the regex properties are valid."""
+
+        invalid_regex = r"ˆ][$"
+
+        # Both selector and course regex should be validated
+        for key in ["SELECTOR_REGEX", "COURSE_REGEX"]:
+            with self.subTest("Invalid regex", key=key):
+                values = self.lms_configuration.copy()
+                values[key] = invalid_regex
+                envvar = json.dumps([values])
+
+                with self.assertRaises(ValueError) as exception:
+                    LMSBackendsValue().to_python(envvar)
+
+                self.assertEqual(
+                    str(exception.exception), "Invalid regex ˆ][$ in LMS Backend."
+                )
+
+    def test_lms_backends_value_validate_backend_path(self):
+        """It should ensure that the backend path string is valid."""
+        values = self.lms_configuration.copy()
+        values["BACKEND"] = "invalid.path..to.backend"
+        envvar = json.dumps([values])
+
+        with self.assertRaises(ValueError) as exception:
+            LMSBackendsValue().to_python(envvar)
+
+        self.assertEqual(
+            str(exception.exception),
+            "invalid.path..to.backend must be a valid python module path string.",
+        )
+
+    def test_lms_backends_value_validate_no_update_fields_value(self):
+        """
+        It should ensure that the COURSE_RUN_SYNC_NO_UPDATE_FIELDS value is a list
+        if defined
+        """
+        values = self.lms_configuration.copy()
+        values.pop("COURSE_RUN_SYNC_NO_UPDATE_FIELDS")
+        envvar = json.dumps([values])
+
+        # No error should be raised if the value is not defined
+        LMSBackendsValue().to_python(envvar)
+
+        values.update({"COURSE_RUN_SYNC_NO_UPDATE_FIELDS": "invalid"})
+        envvar = json.dumps([values])
+
+        with self.assertRaises(ValueError) as exception:
+            LMSBackendsValue().to_python(envvar)
+
+        self.assertEqual(
+            str(exception.exception), "COURSE_RUN_SYNC_NO_UPDATE_FIELDS must be a list."
+        )


### PR DESCRIPTION
## Purpose

Currently, LMS Backends list is hardcoded in joanie settings. This is weird as if we want to setup new LMS that means we have to update those settings then make a release. Furthermore, it is also weird from an Open Source point of view as this settings is not overridable easily. So in order to fix that, we now allow to set all LMS backend configuration through a JSON array string environment variable.

**If you are a Joanie developer, you may have to update our `env.d/common` file to remove old LMS env vars and add the new `JOANIE_LMS_BACKENDS`. Take a look at `env.d/common.dist` as an example.**
