### PR TITLE
🥅(backend) catch payment provider api error on credit card deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Catch `PaymentProviderAPIException` on CreditCard `post_delete` signal
+
 ## [2.15.0] - 2025-02-05
 
 ### Changed


### PR DESCRIPTION
## Purpose

When a credit card is deleted, a post_delete signal is triggered to also remove the registered card from the payment provider. Currently, if this request fails,
 the credit card deletion transaction is rollback. In order to prevent that, we
 catch `PaymentProviderAPIException` and just log the error with useful
 information to remove credit card information later from the payment provider.