### PR TITLE
🐛(backend) fix lyra is_already_paid

### DIFF
--- a/src/backend/joanie/payment/backends/lyra/__init__.py
+++ b/src/backend/joanie/payment/backends/lyra/__init__.py
@@ -134,8 +134,8 @@ class LyraBackend(BasePaymentBackend):
                 e,
                 extra={"context": context},
             )
-            raise exceptions.PaymentProviderAPIException(
-                f"Error when calling Lyra API - {e.__class__.__name__} : {e}"
+            raise exceptions.PaymentProviderAPIServerException(
+                f"Error when calling Lyra API Server - {e.__class__.__name__} : {e}"
             ) from e
 
         response_json = response.json()
@@ -331,7 +331,10 @@ class LyraBackend(BasePaymentBackend):
         payload = {
             "orderId": str(order.id),
         }
-        response_json = self._call_api(url, payload)
+        try:
+            response_json = self._call_api(url, payload)
+        except exceptions.PaymentProviderAPIException:
+            return False
         answer = response_json.get("answer")
 
         if not answer:

--- a/src/backend/joanie/payment/exceptions.py
+++ b/src/backend/joanie/payment/exceptions.py
@@ -61,3 +61,11 @@ class PaymentProviderAPIException(APIException):
     status_code = HTTPStatus.BAD_REQUEST
     default_detail = _("Payment provider API error.")
     default_code = "payment_provider_api_error"
+
+
+class PaymentProviderAPIServerException(APIException):
+    """Exception triggered when the payment provider API server call failed"""
+
+    status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    default_detail = _("Payment provider API server error.")
+    default_code = "payment_provider_api_server_error"


### PR DESCRIPTION


## Purpose

When we check for installment payment to lyra server, if we get a PSP_010 error, we want to consider the payment as unpaid.

Fixes #1048
