### PR TITLE
📌(backend) pin boto3 to version less than 1.36

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,8 @@
       "matchPackageNames": [
         "hashids",
         "PyMongo",
-        "django-storages"
+        "django-storages",
+        "boto3"
       ]
     },
     {

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -26,7 +26,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "arrow==1.3.0",
-    "boto3==1.36.6",
+    "boto3<1.36",
     "Brotli==1.1.0",
     "celery[redis]==5.4.0",
     "cryptography==44.0.0",


### PR DESCRIPTION
## Purpose

Since the version 1.36, boto3 storage is no more compatible with our third party
 storage S3 like... Currently the only way to fix that is to rollback to the
 version 1.35.x

 https://github.com/boto/boto3/issues/4409
