### PR TITLE
:sparkles: (backend) remove `is_active` in order group client serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Add `start` and `end` datetime fields on order group model
 
+### Changed
+
+- Remove `is_active` on order group client serializer
+
 ## [2.16.0] - 2025-02-13
 
 ### Added

--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -184,7 +184,12 @@ class CourseProductRelationViewSet(
         elif self.action == "list" or self.action == "retrieve" and not course_id:
             queryset = queryset.filter(course__accesses__user__username=self.username)
 
-        return queryset
+        return queryset.prefetch_related(
+            Prefetch(
+                "order_groups",
+                queryset=models.OrderGroup.objects.filter(is_active=True),
+            )
+        )
 
     def get_permissions(self):
         """Anonymous user should be able to retrieve a course product relation."""

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -765,7 +765,6 @@ class OrderGroupSerializer(serializers.ModelSerializer):
         model = models.OrderGroup
         fields = [
             "id",
-            "is_active",
             "nb_seats",
             "nb_available_seats",
             "is_enabled",

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_course_product_relations.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_course_product_relations.py
@@ -56,14 +56,14 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
                     course=course, product=product, organizations=[organizations[0]]
                 )
             )
-        with self.assertNumQueries(160):
+        with self.assertNumQueries(156):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
         # A second call to the url should benefit from caching on the product serializer
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             response = self.client.get(
                 f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
@@ -162,7 +162,7 @@ class OrganizationCourseProductRelationApiTest(BaseAPITestCase):
             )
 
         # A second call to the url should benefit from caching on the product serializer
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             response = self.client.get(
                 (
                     f"/api/v1.0/organizations/{organizations[0].id}/course-product-relations/"

--- a/src/backend/joanie/tests/core/test_api_course_product_relations.py
+++ b/src/backend/joanie/tests/core/test_api_course_product_relations.py
@@ -799,7 +799,6 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             [
                 {
                     "id": str(order_group1.id),
-                    "is_active": True,
                     "is_enabled": True,
                     "nb_available_seats": order_group1.nb_seats - 3,
                     "nb_seats": order_group1.nb_seats,
@@ -808,7 +807,6 @@ class CourseProductRelationApiTest(BaseAPITestCase):
                 },
                 {
                     "id": str(order_group2.id),
-                    "is_active": True,
                     "is_enabled": True,
                     "nb_available_seats": order_group2.nb_seats,
                     "nb_seats": order_group2.nb_seats,
@@ -844,7 +842,6 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             [
                 {
                     "id": str(order_group.id),
-                    "is_active": True,
                     "is_enabled": True,
                     "nb_available_seats": 10,
                     "nb_seats": 10,
@@ -870,7 +867,6 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             [
                 {
                     "id": str(order_group.id),
-                    "is_active": True,
                     "is_enabled": True,
                     "nb_available_seats": 9,
                     "nb_seats": 10,
@@ -895,7 +891,6 @@ class CourseProductRelationApiTest(BaseAPITestCase):
             [
                 {
                     "id": str(order_group.id),
-                    "is_active": True,
                     "is_enabled": True,
                     "nb_available_seats": 10,
                     "nb_seats": 10,

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -6226,10 +6226,6 @@
                         "readOnly": true,
                         "description": "primary key for the record as UUID"
                     },
-                    "is_active": {
-                        "type": "boolean",
-                        "readOnly": true
-                    },
                     "nb_seats": {
                         "type": "integer",
                         "readOnly": true,
@@ -6267,7 +6263,6 @@
                 "required": [
                     "end",
                     "id",
-                    "is_active",
                     "is_enabled",
                     "nb_available_seats",
                     "nb_seats",


### PR DESCRIPTION
## Purpose

Since is_active is now a property that is handle by admin users only, there is no need that the field and value is present 
into the client serializer of OrderGroup. What is more import for the client side, is the value `is_enabled` of an order group.

## Proposal

- [x] Remove is active in order group for client serializers
- [x] Exclude every order group that is not active into the `get_queryset` response of the `CourseProductRelation` Viewset.
 
