### PR TITLE
🐛(backend) certificate verification view internationalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to
 - Remove `owner` and `is_main` in CreditCard model permanently
 - Remove `is_active` on order group client serializer
 
-## Fixed
+### Fixed
 
+- Internationalization of certificate verification view
 - BO: generate certificates for orders with product of type certificate
 
 ## [2.16.0] - 2025-02-13

--- a/src/backend/joanie/core/models/certifications.py
+++ b/src/backend/joanie/core/models/certifications.py
@@ -241,7 +241,7 @@ class Certificate(BaseModel):
         # - Retrieve the current language code or a fallback if the language is not available
         current_language_code = get_language_settings(get_language()).get("code")
         site = Site.objects.get_current()
-        with override(current_language_code, True):
+        with override(current_language_code):
             path = reverse(
                 "certificate-verification", kwargs={"certificate_id": self.pk}
             )

--- a/src/backend/joanie/tests/core/utils/test_issuers_certificate_document.py
+++ b/src/backend/joanie/tests/core/utils/test_issuers_certificate_document.py
@@ -63,6 +63,7 @@ class UtilsIssuersCertificateGenerateDocumentTestCase(TestCase):
         self.assertRegex(
             document_text, rf"https://example.com/en-us/certificates/{certificate.id}"
         )
+        self.assertRegex(document_text, r"en-us")
 
         with switch_language(product, "fr-fr"):
             document = issuers.generate_document(
@@ -79,6 +80,8 @@ class UtilsIssuersCertificateGenerateDocumentTestCase(TestCase):
                 rf"https://example.com/fr-fr/certificates/{certificate.id}",
             )
 
+            self.assertRegex(document_text, r"fr-fr")
+
         with switch_language(product, "de-de"):
             # - Finally, unknown language should use the default language as fallback
             document = issuers.generate_document(
@@ -94,6 +97,7 @@ class UtilsIssuersCertificateGenerateDocumentTestCase(TestCase):
                 document_text,
                 rf"https://example.com/en-us/certificates/{certificate.id}",
             )
+            self.assertRegex(document_text, r"en-us")
 
     def test_utils_issuers_generate_document_certificate_document(self):
         """
@@ -248,6 +252,7 @@ class UtilsIssuersCertificateGenerateDocumentTestCase(TestCase):
             document_text, rf"https://example.com/en-us/certificates/{certificate.id}"
         )
         self.assertRegex(document_text, r"https://example.com/terms")
+        self.assertRegex(document_text, r"en-us")
 
         with switch_language(product, "fr-fr"):
             document = issuers.generate_document(
@@ -271,6 +276,7 @@ class UtilsIssuersCertificateGenerateDocumentTestCase(TestCase):
                 document_text,
                 r"Compétence 1.*Compétence 2",
             )
+            self.assertRegex(document_text, r"fr-fr")
 
         with switch_language(product, "de-de"):
             # - Finally, unknown language should use the default language as fallback
@@ -287,6 +293,7 @@ class UtilsIssuersCertificateGenerateDocumentTestCase(TestCase):
                 document_text,
                 rf"https://example.com/en-us/certificates/{certificate.id}",
             )
+            self.assertRegex(document_text, r"en-us")
 
     def test_utils_issuers_generate_document_certificate_unicamp_degree_document_without_certification_level(  # pylint: disable=line-too-long
         self,
@@ -334,3 +341,21 @@ class UtilsIssuersCertificateGenerateDocumentTestCase(TestCase):
             document_text,
             r"Certification.*level",
         )
+        self.assertRegex(document_text, r"en-us")
+
+        with switch_language(product, "fr-fr"):
+            document = issuers.generate_document(
+                name=certificate.certificate_definition.template,
+                context=certificate.get_document_context(),
+            )
+            document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+            self.assertRegex(document_text, r"fr-fr")
+
+        with switch_language(product, "de-de"):
+            # - Finally, unknown language should use the default language as fallback
+            document = issuers.generate_document(
+                name=certificate.certificate_definition.template,
+                context=certificate.get_document_context(),
+            )
+            document_text = pdf_extract_text(BytesIO(document)).replace("\n", "")
+            self.assertRegex(document_text, r"en-us")


### PR DESCRIPTION
## Purpose

We had an issue with the internationalization of the verification view of certificates. Some part of the iframe were not translated into the current language and was using django's defaut language code instead.

Now, by wrapping the generation of the context of a certificate with the requested language, the templates are translated as expected and not using the default language in django settings when the translation exists.

## Proposal

- [x] Fix internationalization of the verification certificate view
