### PR TITLE
🔖(chore) bump to 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.17.0] - 2025-03-05
+
 ### Added
 
 - Add `start` and `end` datetime fields on order group model
@@ -615,7 +617,8 @@ and this project adheres to
 - First working version serving sellable micro-credentials for multiple
   organizations synchronized to a remote catalog
 
-[unreleased]: https://github.com/openfun/joanie/compare/v2.16.0...main
+[unreleased]: https://github.com/openfun/joanie/compare/v2.17.0...main
+[2.17.0]: https://github.com/openfun/joanie/compare/v2.16.0...v2.17.0
 [2.16.0]: https://github.com/openfun/joanie/compare/v2.15.0...v2.16.0
 [2.15.0]: https://github.com/openfun/joanie/compare/v2.14.1...v2.15.0
 [2.14.1]: https://github.com/openfun/joanie/compare/v2.14.0...v2.14.1

--- a/arnold.yml
+++ b/arnold.yml
@@ -1,6 +1,6 @@
 # arnold.yml
 metadata:
   name: joanie
-  version: 2.16.0
+  version: 2.17.0
 source:
   path: src/tray

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "joanie"
-version = "2.16.0"
+version = "2.17.0"
 authors = [{ "name" = "Open FUN (France Université Numérique)", "email" = "fun.dev@fun-mooc.fr" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8072",

--- a/src/mail/package.json
+++ b/src/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mail_mjml",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "An util to generate html and text django's templates from mjml templates",
   "type": "module",
   "dependencies": {

--- a/src/openApiClientJs/package.json
+++ b/src/openApiClientJs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joanie-openapi-client-ts",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "private": true,
   "description": "Tool to generate Typescript api client for joanie",
   "scripts": {

--- a/src/tray/tray.yml
+++ b/src/tray/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: joanie
-  version: 2.16.0
+  version: 2.17.0

--- a/src/tray/vars/all/main.yml
+++ b/src/tray/vars/all/main.yml
@@ -21,7 +21,7 @@ joanie_nginx_static_cache_expires: "1M"
 
 # -- admin nginx
 joanie_admin_nginx_image_name: "fundocker/joanie-admin"
-joanie_admin_nginx_image_tag: "2.16.0"
+joanie_admin_nginx_image_tag: "2.17.0"
 joanie_admin_nginx_port: 8061
 joanie_admin_nginx_replicas: 1
 joanie_admin_nginx_healthcheck_port: 5000
@@ -41,7 +41,7 @@ joanie_database_secret_name: "joanie-postgresql-{{ joanie_vault_checksum | defau
 
 # -- joanie
 joanie_image_name: "fundocker/joanie"
-joanie_image_tag: "2.16.0"
+joanie_image_tag: "2.17.0"
 # The image pull secret name should match the name of your secret created to
 # login to your private docker registry
 joanie_image_pull_secret_name: ""


### PR DESCRIPTION
## Purpose

Bump joanie to 2.17.0

### Added
- Add `start` and `end` datetime fields on order group model
- Add Sarbacane newsletter client

### Changed
- Remove `generate_certificates` action in django admin views
- Remove `owner` and `is_main` in CreditCard model permanently
- Remove `is_active` on order group client serializer

### Fixed
- Internationalization of certificate verification view
- BO: generate certificates for orders with product of type certificate