### PR TITLE
🔧(backend) adjust Sarbacane retry backoff factor

### DIFF
--- a/src/backend/joanie/core/utils/newsletter/sarbacane.py
+++ b/src/backend/joanie/core/utils/newsletter/sarbacane.py
@@ -27,8 +27,8 @@ RETRY_STATUSES = [
 
 adapter = requests.adapters.HTTPAdapter(
     max_retries=Retry(
-        total=3,
-        backoff_factor=0.1,
+        total=settings.SARBACANE_API_RETRY_TOTAL,
+        backoff_factor=settings.SARBACANE_API_RETRY_BACKOFF_FACTOR,
         status_forcelist=RETRY_STATUSES,
         allowed_methods=["GET"],
         raise_on_status=False,

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -553,6 +553,14 @@ class Base(Configuration):
     SARBACANE_API_KEY = values.Value(
         None, environ_name="SARBACANE_API_KEY", environ_prefix=None
     )
+    # https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html?highlight=backoff_factor
+    # Use 0.25 factor as default [0s, 0.5s, 1s]
+    SARBACANE_API_RETRY_BACKOFF_FACTOR = values.Value(
+        0.25, environ_name="SARBACANE_API_RETRY_BACKOFF_FACTOR", environ_prefix=None
+    )
+    SARBACANE_API_RETRY_TOTAL = values.Value(
+        3, environ_name="SARBACANE_API_RETRY_TOTAL", environ_prefix=None
+    )
     SARBACANE_ACCOUNT_ID = values.Value(
         None, environ_name="SARBACANE_ACCOUNT_ID", environ_prefix=None
     )


### PR DESCRIPTION
## Purpose

Increase the backoff factor for Sarbacane GET requests from 0.1 to 0.25 to expand delay between retry.

https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html?highlight=backoff_factor
