### PR TITLE
✨(backend) bind course offer into course webhook payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Add course offer information into course webhook synchronization payload
+
 ## [2.17.1] - 2025-03-06
 
 ### Fixed

--- a/src/backend/joanie/core/apps.py
+++ b/src/backend/joanie/core/apps.py
@@ -26,6 +26,11 @@ class CoreConfig(AppConfig):
             sender=models.ProductTargetCourseRelation,
             dispatch_uid="save_product_target_course_relation",
         )
+        post_save.connect(
+            signals.on_save_product,
+            sender=models.Product,
+            dispatch_uid="save_product",
+        )
         m2m_changed.connect(
             signals.on_change_course_product_relation,
             sender=models.Course.products.through,

--- a/src/backend/joanie/core/enums.py
+++ b/src/backend/joanie/core/enums.py
@@ -230,3 +230,7 @@ PAYMENT_STATE_CHOICES = (
     (PAYMENT_STATE_CANCELED, _("Canceled")),
     (PAYMENT_STATE_ERROR, _("Error")),
 )
+
+# Course offers
+COURSE_OFFER_PAID = "paid"
+COURSE_OFFER_FREE = "free"


### PR DESCRIPTION
## Purpose

From Richie we recently add new fields to CourseRun models to set offer available on the CourseRun. As in Joanie we are able to set the course run offer according to product linked to the related course, we update the course synchronization to add this information.