### PR TITLE
👔(backend) update organization assignation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 ### Changed
 
 - Add course offer information into course webhook synchronization payload
+- Update organization assignation logic to ignore order with pending signature
+  or without payment method defined.
 
 ## [2.17.1] - 2025-03-06
 

--- a/src/backend/joanie/core/utils/organization.py
+++ b/src/backend/joanie/core/utils/organization.py
@@ -1,0 +1,41 @@
+"""Util to get the organization with the least binding orders count"""
+
+from django.db.models import Count, Exists, OuterRef, Q
+
+from joanie.core import enums, models
+
+
+def get_least_active_organization(product, course, enrollment=None):
+    """
+    Return the organization with the least binding orders count
+    for a given product and course.
+    """
+    course_id = course.id if course else enrollment.course_run.course_id
+
+    try:
+        course_relation = product.course_relations.get(course_id=course_id)
+    except models.CourseProductRelation.DoesNotExist:
+        return None
+
+    order_count_filter = Q(order__product=product) & Q(
+        order__state__in=enums.ORDER_STATES_BINDING
+    )
+
+    if enrollment:
+        order_count_filter &= Q(order__enrollment=enrollment)
+    else:
+        order_count_filter &= Q(order__course=course)
+
+    try:
+        organizations = course_relation.organizations.annotate(
+            order_count=Count("order", filter=order_count_filter, distinct=True),
+            is_author=Exists(
+                models.Organization.objects.filter(
+                    pk=OuterRef("pk"), courses__id=course_id
+                )
+            ),
+        )
+
+        return organizations.order_by("order_count", "-is_author", "?").first()
+    except models.Organization.DoesNotExist:
+        return None

--- a/src/backend/joanie/tests/core/utils/test_utils_organization.py
+++ b/src/backend/joanie/tests/core/utils/test_utils_organization.py
@@ -1,0 +1,91 @@
+"""Test suite for utils organization methods"""
+
+from django.test import TestCase
+
+from joanie.core import enums, factories
+from joanie.core.utils.organization import get_least_active_organization
+
+
+class UtilsOrganizationTestCase(TestCase):
+    """Test suite for utils organization methods"""
+
+    def setUp(self):
+        """Set up the test case"""
+        super().setUp()
+        self.organization_1, self.organization_2 = (
+            factories.OrganizationFactory.create_batch(2)
+        )
+        self.relation = factories.CourseProductRelationFactory(
+            organizations=[self.organization_1, self.organization_2]
+        )
+        self.course = self.relation.course
+        self.product = self.relation.product
+
+    def test_utils_organization_get_least_active_organization_no_orders(self):
+        """
+        With no orders, a random organization is returned.
+        """
+        selected_organization = get_least_active_organization(self.product, self.course)
+
+        # the first selected organization is random
+        self.assertIn(selected_organization, [self.organization_1, self.organization_2])
+
+        # Add a completed order to the selected organization
+        factories.OrderFactory(
+            product=self.product,
+            course=self.course,
+            organization=selected_organization,
+            state=enums.ORDER_STATE_COMPLETED,
+        )
+
+        # The next selected organization should be the other one
+        next_selected_organization = get_least_active_organization(
+            self.product, self.course
+        )
+        self.assertEqual(type(next_selected_organization), type(selected_organization))
+        self.assertNotEqual(next_selected_organization, selected_organization)
+
+    def test_utils_organization_get_least_active_organization_is_author(self):
+        """
+        With no order, and the first organization is the author, it is returned.
+        """
+        self.organization_1.courses.add(self.course)
+
+        selected_organization = get_least_active_organization(self.product, self.course)
+
+        self.assertEqual(selected_organization, self.organization_1)
+
+    def test_utils_organization_get_least_active_organization_all_states(self):
+        """
+        With one order to the first organization, the second organization is returned.
+        """
+        for state, _ in enums.ORDER_STATE_CHOICES:
+            with self.subTest(f"{state} order to the first organization", state=state):
+                self.setUp()
+                factories.OrderFactory(
+                    product=self.product,
+                    course=self.course,
+                    organization=self.organization_1,
+                    state=state,
+                )
+                # Add the course to the first organization to avoid randomness
+                self.organization_1.courses.add(self.course)
+                self.assertEqual(self.organization_1.courses.count(), 1)
+
+                selected_organization = get_least_active_organization(
+                    self.product, self.course
+                )
+
+                if state in [
+                    enums.ORDER_STATE_DRAFT,
+                    enums.ORDER_STATE_ASSIGNED,
+                    enums.ORDER_STATE_TO_SAVE_PAYMENT_METHOD,
+                    enums.ORDER_STATE_TO_SIGN,
+                    enums.ORDER_STATE_SIGNING,
+                    enums.ORDER_STATE_CANCELED,
+                    enums.ORDER_STATE_REFUNDING,
+                    enums.ORDER_STATE_REFUNDED,
+                ]:
+                    self.assertEqual(selected_organization, self.organization_1)
+                else:
+                    self.assertEqual(selected_organization, self.organization_2)


### PR DESCRIPTION
## Purpose

Currently only orders with inactive states (canceled, draft, assigned) were ignored in the organization assignation logic. But orders pending for signature or without payment method  are take in account but most of time this kind of orders are abandoned. So it has been ask to ignore this kind of order during assignation. Furthermore, we did not ignore refunded and refunding orders.

Resolve #1081