### PR TITLE
✅(backend) fix failing test on auto assignation of organization

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
     "ipdb==0.13.13",
     "ipython==8.31.0",
     "lxml==5.3.0",
-    "pdbpp==0.10.3",
+    "pdbpp==0.11.5",
     "pdfminer.six==20240706",
     "pyfakefs==5.7.4",
     "pylint-django==2.6.1",


### PR DESCRIPTION
## Purpose

A new release of the package `fancycompleter` that we use for tab completion during breakpoints in tests was causing our circleCi [task](https://app.circleci.com/pipelines/github/openfun/joanie/9796/workflows/9c2d28df-e513-4d24-8b1d-33eb76f259bd/jobs/128219) to run tests to never execute. The [latest](https://pypi.org/project/fancycompleter/) release was done on the 13th of April 2025.

Fixed a flaky test due to latest change on assignation logic of organization on a new order.

## Proposal

Fix a failing flaky unit test that used the random module when it prepared the testing data. It was important to fix it because it is revealing how the auto assignation of an organization is on an order when the product has no fee. Also, we have changed the logic behind the assignation method, we needed to reflect that change into this test.

- [x] update version of `pdbpp`.
- [x] rewrite failing test for organization assignation on free product orders. 