### PR TITLE
✅(backend) add COURSE_WEB_HOOKS configuration to test cases

### DIFF
--- a/src/backend/joanie/tests/core/test_api_enrollment.py
+++ b/src/backend/joanie/tests/core/test_api_enrollment.py
@@ -31,7 +31,8 @@ from joanie.tests.base import BaseAPITestCase
             "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
             "SELECTOR_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
         }
-    ]
+    ],
+    COURSE_WEB_HOOKS=[],
 )
 class EnrollmentApiTest(BaseAPITestCase):
     """Test the API of the Enrollment object."""

--- a/src/backend/joanie/tests/core/test_flows_order.py
+++ b/src/backend/joanie/tests/core/test_flows_order.py
@@ -282,7 +282,8 @@ class OrderFlowsTestCase(LoggingTestCase):
                 "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
                 "SELECTOR_REGEX": r".*",
             }
-        ]
+        ],
+        COURSE_WEB_HOOKS=[],
     )
     def test_flows_order_validate_auto_enroll(self):
         """
@@ -393,7 +394,8 @@ class OrderFlowsTestCase(LoggingTestCase):
                 "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
                 "SELECTOR_REGEX": r".*",
             }
-        ]
+        ],
+        COURSE_WEB_HOOKS=[],
     )
     def test_flows_order_validate_auto_enroll_edx_failure(self):
         """
@@ -539,7 +541,8 @@ class OrderFlowsTestCase(LoggingTestCase):
                 "COURSE_REGEX": r"^.*/course/view.php\?id=.*$",
                 "SELECTOR_REGEX": r"^.*/course/view.php\?id=.*$",
             }
-        ]
+        ],
+        COURSE_WEB_HOOKS=[],
     )
     def test_flows_order_complete_preexisting_enrollments_targeted_moodle(self):
         """
@@ -659,7 +662,8 @@ class OrderFlowsTestCase(LoggingTestCase):
                 "COURSE_REGEX": r"^.*/course/view.php\?id=.*$",
                 "SELECTOR_REGEX": r"^.*/course/view.php\?id=.*$",
             }
-        ]
+        ],
+        COURSE_WEB_HOOKS=[],
     )
     def test_flows_order_validate_auto_enroll_moodle_failure(self):
         """
@@ -751,6 +755,7 @@ class OrderFlowsTestCase(LoggingTestCase):
                 self.assertIsNone(order.credit_card)
 
     @responses.activate
+    @override_settings(COURSE_WEB_HOOKS=[])
     def test_flows_order_cancel_certificate_product_openedx_enrollment_mode(self):
         """
         Test that the source enrollment is set back to "honor" in the LMS when a related order
@@ -834,7 +839,8 @@ class OrderFlowsTestCase(LoggingTestCase):
                 "COURSE_REGEX": r"^.*/course/view.php\?id=.*$",
                 "SELECTOR_REGEX": r"^.*/course/view.php\?id=.*$",
             }
-        ]
+        ],
+        COURSE_WEB_HOOKS=[],
     )
     def test_flows_order_cancel_certificate_product_moodle(self):
         """

--- a/src/backend/joanie/tests/lms_handler/test_backend_openedx.py
+++ b/src/backend/joanie/tests/lms_handler/test_backend_openedx.py
@@ -31,7 +31,8 @@ from joanie.lms_handler.backends.openedx import (
             "COURSE_REGEX": r"^.*/courses/(?P<course_id>.*)/course/?$",
             "SELECTOR_REGEX": r".*",
         }
-    ]
+    ],
+    COURSE_WEB_HOOKS=[],
 )
 class OpenEdXLMSBackendTestCase(TestCase):
     """Test suite for the OpenEdX LMS Backend."""


### PR DESCRIPTION


## Purpose

If COURSE_WEB_HOOKS is defined locally in env.d/development/common, tests will fail.
Overriding prevents this.
