### PR TITLE
✅(backend) fix flaky tests

### DIFF
--- a/src/backend/joanie/core/api/admin/__init__.py
+++ b/src/backend/joanie/core/api/admin/__init__.py
@@ -180,6 +180,7 @@ class UserViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     queryset = models.User.objects.all()
     filterset_class = filters.UserAdminFilterSet
     filter_backends = [DjangoFilterBackend, AliasOrderingFilter]
+    ordering = ["username"]
 
     def get_queryset(self):
         """

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -689,7 +689,7 @@ class OrderGroupFactory(DebugModelFactory, factory.django.DjangoModelFactory):
         model = models.OrderGroup
 
     course_product_relation = factory.SubFactory(CourseProductRelationFactory)
-    nb_seats = factory.fuzzy.FuzzyInteger(0, 100)
+    nb_seats = factory.fuzzy.FuzzyInteger(1, 100)
 
 
 class OrderFactory(DebugModelFactory, factory.django.DjangoModelFactory):


### PR DESCRIPTION
## Purpose

We have a flaky test (`test_admin_api_user_list_filter_by_id`) on the CI where the results are not sorted the expected way. To have more consistency overtime, we have decided to sort the result of the list endpoint by `username`.

We also have another flaky test (`test_api_admin_orders_course_retrieve`) that happens rarely, it's with the `OrderGroup` factory. If we don't set a number of seat,
it can choose a number between **0 to 100** for this value. The issue is that when it sets 0 for the number of seats and we try to create an order on that order group, it would block the creation. To avoid this behavior, we have decided that the factory can choose a value between **1 to 100** if no value is setted during creation.

## Proposal

- [x] Add ordering by `username` for admin api users viewset
- [x] Change the range of the random number of seats of the `OrderGroupFactory` when not setted in creation
