### PR TITLE
⬇️(backend) downgrade DRF to v3.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Downgrade `djangorestframework` to 3.15.2 to fix payzen notifications
+
 ## [2.18.0] - 2025-05-23
 
 ### Changed

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -6209,8 +6209,7 @@
                                 "$ref": "#/components/schemas/OrderStateEnum"
                             }
                         ],
-                        "readOnly": true,
-                        "default": "draft"
+                        "readOnly": true
                     },
                     "owner": {
                         "allOf": [

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "django-viewflow==2.2.10",
     "Django<5",
     "djangorestframework-simplejwt==5.5.0",
-    "djangorestframework==3.16.0",
+    "djangorestframework==3.15.2",
     "drf_spectacular==0.28.0",
     "dockerflow==2024.4.2",
     "easy_thumbnails==2.10",


### PR DESCRIPTION


## Purpose

DRF v3.16.0 added a verification around request data that prevents silent errors. In our case, the raised exception breaks payzen notifications. We downgrade DRF, and will properly fix our code once the problem is repdoduced in tests.

