### PR TITLE
✨(backend) change to activate payment schedule depending product type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
 
 ### Changed
 
+- Update limits for payment schedule for credential products and
+  for certificate product should always be a one-off payment
 - Upgrade `djangorestframework` to 3.16.0
 - Use discounted_price in payment_schedule
 - Replace order groups from the client API with course product relations

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -394,7 +394,7 @@ class Base(Configuration):
         ),
     }
     JOANIE_PAYMENT_SCHEDULE_LIMITS = values.DictValue(
-        {150: (100,), 200: (30, 70), 500: (30, 35, 35), 1000: (30, 25, 25, 20)},
+        {200: (30, 70), 500: (30, 35, 35), 1000: (30, 25, 25, 20)},
         environ_name="JOANIE_PAYMENT_SCHEDULE_LIMITS",
         environ_prefix=None,
     )


### PR DESCRIPTION
## Purpose

When the product is type certificate, it should remain a one-off payment no matter the price. Previously, our payment schedule configurations would create more than 1 installment if the certificate's price was strictly over 150 euros.

When the product is type credential, if the product's price is less or equal than 150 euros, we should always have 2 installments at minimum. The first installment should always be 30% of the total price, no matter the amount set on the product.

## Proposal

- [x] change the configuration of `JOANIE_PAYMENT_SCHEDULE_LIMITS` to affect orders with credential product payment schedule to have 2 installments at minimum
- [x] change for certificate product type to always have 1 installment in the payment schedule only
