### PR TITLE
♻️(backend) use property for offer rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to
 ### Fixed
 
 - Invalidate course product relation cache on order group update
+- Compute offer rule properties instead of returning the first one
 
 ## [2.18.1] - 2025-05-28
 

--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -221,7 +221,7 @@ class OfferViewSet(
         )
 
         payment_schedule = generate_payment_schedule(
-            offer.discounted_price or offer.product.price,
+            offer.rules.get("discounted_price") or offer.product.price,
             timezone.now(),
             course_run_dates["start"],
             course_run_dates["end"],

--- a/src/backend/joanie/core/factories.py
+++ b/src/backend/joanie/core/factories.py
@@ -691,7 +691,6 @@ class OfferRuleFactory(DebugModelFactory, factory.django.DjangoModelFactory):
         model = models.OfferRule
 
     course_product_relation = factory.SubFactory(OfferFactory)
-    nb_seats = factory.fuzzy.FuzzyInteger(1, 100)
 
 
 class OrderFactory(DebugModelFactory, factory.django.DjangoModelFactory):

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -868,6 +868,68 @@ class CourseSerializer(AbilitiesModelSerializer):
         read_only_fields = fields
 
 
+class OfferRulePropertySerializer(serializers.Serializer):
+    """
+    Serializer for the rules property of an offer.
+    """
+
+    discounted_price = serializers.DecimalField(
+        coerce_to_string=False,
+        decimal_places=2,
+        max_digits=9,
+        min_value=D(0.00),
+        read_only=True,
+        help_text=_("Discounted price of the offer."),
+    )
+    discount_rate = serializers.DecimalField(
+        coerce_to_string=False,
+        decimal_places=2,
+        max_digits=9,
+        min_value=D(0.00),
+        max_value=D(100.00),
+        read_only=True,
+        help_text=_("Discount rate of the offer."),
+    )
+    discount_amount = serializers.DecimalField(
+        coerce_to_string=False,
+        decimal_places=2,
+        max_digits=9,
+        min_value=D(0.00),
+        read_only=True,
+        help_text=_("Discount amount of the offer."),
+    )
+    discount_start = serializers.DateTimeField(
+        read_only=True,
+        help_text=_("Start date of the discount period for the offer."),
+    )
+    discount_end = serializers.DateTimeField(
+        read_only=True,
+        help_text=_("End date of the discount period for the offer."),
+    )
+    description = serializers.CharField(
+        read_only=True,
+        help_text=_("Description of the offer rule."),
+    )
+    nb_available_seats = serializers.IntegerField(
+        read_only=True,
+        help_text=_("Number of available seats for the offer."),
+    )
+    has_seat_limit = serializers.BooleanField(
+        read_only=True,
+        help_text=_("Indicates if the offer has a seat limit."),
+    )
+    has_seats_left = serializers.BooleanField(
+        read_only=True,
+        help_text=_("Indicates if there are seats left for the offer."),
+    )
+
+    def create(self, validated_data):
+        """Only there to avoid a NotImplementedError"""
+
+    def update(self, instance, validated_data):
+        """Only there to avoid a NotImplementedError"""
+
+
 class OfferLightSerializer(CachedModelSerializer):
     """
     Serialize an offer in its minimal format.
@@ -898,18 +960,15 @@ class OfferSerializer(OfferLightSerializer):
     """
 
     is_withdrawable = serializers.BooleanField(read_only=True)
+    rules = OfferRulePropertySerializer(
+        read_only=True,
+        help_text=_("Offer rules applied to this offer."),
+    )
 
     class Meta(OfferLightSerializer.Meta):
         fields = OfferLightSerializer.Meta.fields + [
             "is_withdrawable",
-            "discounted_price",
-            "discount_rate",
-            "discount_amount",
-            "discount_start",
-            "discount_end",
-            "description",
-            "nb_available_seats",
-            "nb_seats",
+            "rules",
         ]
         read_only_fields = fields
 

--- a/src/backend/joanie/tests/core/api/admin/orders/test_retrieve.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_retrieve.py
@@ -36,7 +36,10 @@ class OrdersAdminApiRetrieveTestCase(TestCase):
             product__contract_definition=factories.ContractDefinitionFactory(),
             product__certificate_definition=factories.CertificateDefinitionFactory(),
         )
-        offer_rule = factories.OfferRuleFactory(course_product_relation=offer)
+        offer_rule = factories.OfferRuleFactory(
+            course_product_relation=offer,
+            nb_seats=10,
+        )
         order = factories.OrderGeneratorFactory(
             course=offer.course,
             product=offer.product,

--- a/src/backend/joanie/tests/core/test_api_admin_offer_rule.py
+++ b/src/backend/joanie/tests/core/test_api_admin_offer_rule.py
@@ -44,7 +44,10 @@ class OfferRuleAdminApiTest(TestCase):
         discount = factories.DiscountFactory(rate=0.3)
         offer_rules = [
             factories.OfferRuleFactory(
-                position=i, course_product_relation=offer, discount=discount
+                position=i,
+                course_product_relation=offer,
+                discount=discount,
+                nb_seats=10,
             )
             for i in range(3)
         ]
@@ -126,6 +129,7 @@ class OfferRuleAdminApiTest(TestCase):
         offer_rule = factories.OfferRuleFactory(
             course_product_relation=offer,
             discount=factories.DiscountFactory(amount=30),
+            nb_seats=10,
         )
 
         with self.assertNumQueries(8):
@@ -302,7 +306,7 @@ class OfferRuleAdminApiTest(TestCase):
         data = {
             "is_active": True,
         }
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(5):
             response = self.client.patch(
                 f"{self.base_url}/{offer.id}/offer-rules/{str(offer_rule.id)}/",
                 content_type="application/json",

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -6391,75 +6391,24 @@
                         "type": "boolean",
                         "readOnly": true
                     },
-                    "discounted_price": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true,
-                        "description": "Return the discounted price of the product, if any.",
-                        "readOnly": true
-                    },
-                    "discount_rate": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true,
-                        "description": "Return the discount rate of the first enabled offer rule, if any.",
-                        "readOnly": true
-                    },
-                    "discount_amount": {
-                        "type": "number",
-                        "format": "double",
-                        "nullable": true,
-                        "description": "Return the discount amount of the first enabled offer rule, if any.",
-                        "readOnly": true
-                    },
-                    "discount_start": {
-                        "type": "string",
-                        "format": "date-time",
-                        "nullable": true,
-                        "description": "Return the discount start date of the first enabled offer rule, if any.",
-                        "readOnly": true
-                    },
-                    "discount_end": {
-                        "type": "string",
-                        "format": "date-time",
-                        "nullable": true,
-                        "description": "Return the discount end date of the first enabled offer rule, if any.",
-                        "readOnly": true
-                    },
-                    "description": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Return the description of the first enabled offer rule, if any.",
-                        "readOnly": true
-                    },
-                    "nb_available_seats": {
-                        "type": "integer",
-                        "nullable": true,
-                        "description": "Return the number of seats available for the first enabled offer rule, if any.",
-                        "readOnly": true
-                    },
-                    "nb_seats": {
-                        "type": "integer",
-                        "nullable": true,
-                        "description": "Return the total number of seats for the first enabled offer rule, if any.",
-                        "readOnly": true
+                    "rules": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OfferRuleProperty"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "Offer rules applied to this offer."
                     }
                 },
                 "required": [
                     "course",
                     "created_on",
-                    "description",
-                    "discount_amount",
-                    "discount_end",
-                    "discount_rate",
-                    "discount_start",
-                    "discounted_price",
                     "id",
                     "is_withdrawable",
-                    "nb_available_seats",
-                    "nb_seats",
                     "organizations",
-                    "product"
+                    "product",
+                    "rules"
                 ]
             },
             "OfferLight": {
@@ -6513,6 +6462,81 @@
                     "is_withdrawable",
                     "organizations",
                     "product"
+                ]
+            },
+            "OfferRuleProperty": {
+                "type": "object",
+                "description": "Serializer for the rules property of an offer.",
+                "properties": {
+                    "discounted_price": {
+                        "type": "number",
+                        "format": "double",
+                        "maximum": 10000000,
+                        "minimum": 0.0,
+                        "exclusiveMaximum": true,
+                        "readOnly": true,
+                        "description": "Discounted price of the offer."
+                    },
+                    "discount_rate": {
+                        "type": "number",
+                        "format": "double",
+                        "maximum": 100.0,
+                        "minimum": 0.0,
+                        "readOnly": true,
+                        "description": "Discount rate of the offer."
+                    },
+                    "discount_amount": {
+                        "type": "number",
+                        "format": "double",
+                        "maximum": 10000000,
+                        "minimum": 0.0,
+                        "exclusiveMaximum": true,
+                        "readOnly": true,
+                        "description": "Discount amount of the offer."
+                    },
+                    "discount_start": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "Start date of the discount period for the offer."
+                    },
+                    "discount_end": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "End date of the discount period for the offer."
+                    },
+                    "description": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Description of the offer rule."
+                    },
+                    "nb_available_seats": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "Number of available seats for the offer."
+                    },
+                    "has_seat_limit": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "Indicates if the offer has a seat limit."
+                    },
+                    "has_seats_left": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "Indicates if there are seats left for the offer."
+                    }
+                },
+                "required": [
+                    "description",
+                    "discount_amount",
+                    "discount_end",
+                    "discount_rate",
+                    "discount_start",
+                    "discounted_price",
+                    "has_seat_limit",
+                    "has_seats_left",
+                    "nb_available_seats"
                 ]
             },
             "Order": {


### PR DESCRIPTION

## Purpose

In he CourseProductRelation (Offer) model, previous implementation was wrong as only
the first offer rule were returned.
Now several use cases are fixed, including:
When an order_group with a discount has no seat left, CourseProductRelation should not display a discount.

Fixes #1121
