### PR TITLE
✨(backend) new structure for contract definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 
 ### Changed
 
+- Update contract definition template to move course section into
+  contract body before articles
 - Update limits for payment schedule for credential products and
   for certificate product should always be a one-off payment
 - Upgrade `djangorestframework` to 3.16.0

--- a/src/backend/joanie/core/templates/issuers/contract_definition_default.html
+++ b/src/backend/joanie/core/templates/issuers/contract_definition_default.html
@@ -67,58 +67,56 @@ this template as a base.
                           <li>{% translate "Telephone number: " %}{{ student.phone_number|default:"-" }}</li>
                       </ul>
                   </dd>
-                  <dt>{% translate 'Course (hereinafter "the Course"):' %}</dt>
-                  <dd>
-                      <ul>
-                          <li>{% translate "Course number: " %}{{ course.code }}</li>
-                          <li>{% translate "Name of the Course: " %}{{ course.name }}</li>
-                          <li>{% translate "Session start date: " %}
-                              {% with start=course.start|iso8601_to_date:"SHORT_DATETIME_FORMAT" %}
-                                {% if start %}
-                                {{ start }}
-                                {% else %}
-                                {{ course.start|default:"-" }}
-                                {% endif %}
-                              {% endwith %}
-                          </li>
-                          <li>{% translate "Session end date: " %}
-                              {% with end=course.end|iso8601_to_date:"SHORT_DATETIME_FORMAT" %}
-                                {% if end %}
-                                {{ end }}
-                                {% else %}
-                                {{ course.end|default:"-" }}
-                                {% endif %}
-                              {% endwith %}
-                          </li>
-                          {% if course.effort %}
-                            <li>{% translate "Total duration of the course: " %}
-                                {% with duration=course.effort|iso8601_to_duration:"hours" %}
-                                {% if duration %}
-                                {% blocktranslate with duration=duration count duration=duration trimmed%}
-                                {{ duration }} hour
-                                {% plural %}
-                                {{ duration }} hours
-                                {% endblocktranslate %}
-                                {% else %}
-                                {{ course.effort|default:"-" }}
-                                {% endif %}
-                                {% endwith %}
-                            </li>
-                          {% endif %}
-                          <li>{% translate "Price of the course: " %}
-                              {% with price=course.price|floatformat:2 currency=course.currency %}
-                                {% if price %}
-                                {{ price }} {{ currency }}
-                                {% else %}
-                                {{ course.price|default:"-" }}
-                                {% endif %}
-                              {% endwith %}
-                          </li>
-                      </ul>
-                  </dd>
               </dl>
           </section>
           <article class="content-articles">
+              <h3>{% translate "Article 1 : Training Description" %}</h3>
+              <ul>
+                <li>{% translate "Course number: " %}{{ course.code }}</li>
+                <li>{% translate "Name of the Course: " %}{{ course.name }}</li>
+                <li>{% translate "Session start date: " %}
+                    {% with start=course.start|iso8601_to_date:"SHORT_DATETIME_FORMAT" %}
+                    {% if start %}
+                    {{ start }}
+                    {% else %}
+                    {{ course.start|default:"-" }}
+                    {% endif %}
+                    {% endwith %}
+                </li>
+                <li>{% translate "Session end date: " %}
+                    {% with end=course.end|iso8601_to_date:"SHORT_DATETIME_FORMAT" %}
+                    {% if end %}
+                    {{ end }}
+                    {% else %}
+                    {{ course.end|default:"-" }}
+                    {% endif %}
+                    {% endwith %}
+                </li>
+                {% if course.effort %}
+                <li>{% translate "Total duration of the course: " %}
+                    {% with duration=course.effort|iso8601_to_duration:"hours" %}
+                    {% if duration %}
+                    {% blocktranslate with duration=duration count duration=duration trimmed%}
+                    {{ duration }} hour
+                    {% plural %}
+                    {{ duration }} hours
+                    {% endblocktranslate %}
+                    {% else %}
+                    {{ course.effort|default:"-" }}
+                    {% endif %}
+                    {% endwith %}
+                </li>
+                {% endif %}
+                <li>{% translate "Price of the course: " %}
+                    {% with price=course.price|floatformat:2 currency=course.currency %}
+                    {% if price %}
+                    {{ price }} {{ currency }}
+                    {% else %}
+                    {{ course.price|default:"-" }}
+                    {% endif %}
+                    {% endwith %}
+                </li>
+              </ul>
               {% if contract %}
                   {{ contract.body|safe }}
               {% endif %}

--- a/src/backend/joanie/tests/core/test_api_contract_definitions.py
+++ b/src/backend/joanie/tests/core/test_api_contract_definitions.py
@@ -164,6 +164,10 @@ class ContractDefinitionApiTest(BaseAPITestCase):
             "the University and the Learner, as identified below:",
             document_text,
         )
+        self.assertIn("Article 1 : Training Description", document_text)
+        self.assertIn("Session start date", document_text)
+        self.assertIn("Total duration of the course", document_text)
+        self.assertIn("Price of the course", document_text)
         self.assertIn("Terms and conditions", document_text)
         self.assertIn("Learner's signature", document_text)
         self.assertIn("[SignatureField#1]", document_text)


### PR DESCRIPTION
## Purpose

For legal purposes, we move the dynamic content of the course section from of the contract definition the contract's body.
Those informations have become the **Article 1** of that body of the contract.

Once this development is deployed into the next release, you should increment by +1 your list of articles that you have set in the contract definition body.

Preview of the new structure: [unicamp_new_contract_definition_structure.pdf](https://github.com/user-attachments/files/20838476/unicamp_new_contract_definition_structure.pdf)

## Proposal

- [x] update the contract definition template to move the course section into the article 1


