### PR TITLE
✨(frontend) add order state to_own to OrderStatesEnum

### DIFF
--- a/src/frontend/admin/src/components/templates/orders/view/translations.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/translations.tsx
@@ -268,6 +268,11 @@ export const orderStatesMessages = defineMessages<OrderStatesEnum>({
     defaultMessage: "Pending payment",
     description: "Text for pending payment order state",
   },
+  to_own: {
+    id: "components.templates.orders.view.orderStatesMessages.to_own",
+    defaultMessage: "To own",
+    description: "Text for to own order state",
+  },
   failed_payment: {
     id: "components.templates.orders.view.orderStatesMessages.failed_payment",
     defaultMessage: "Failed payment",

--- a/src/frontend/admin/src/services/api/models/Order.ts
+++ b/src/frontend/admin/src/services/api/models/Order.ts
@@ -121,6 +121,7 @@ export enum OrderStatesEnum {
   ORDER_STATE_PENDING = "pending", // payment has failed but can be retried
   ORDER_STATE_CANCELED = "canceled", // has been canceled
   ORDER_STATE_PENDING_PAYMENT = "pending_payment", // payment is pending
+  ORDER_STATE_TO_OWN = "to_own", // order is paid but is awaiting owner to claim it
   ORDER_STATE_FAILED_PAYMENT = "failed_payment", // last payment has failed
   ORDER_STATE_NO_PAYMENT = "no_payment", // no payment has been made
   ORDER_STATE_COMPLETED = "completed", // is completed


### PR DESCRIPTION
## Purpose

The development of batch order has introduced a new order state that is `to_own`. We needed to add this new state to the `OrderStatesEnum`

## Proposal

- [x] add missing order state `to_own`
