### PR TITLE
✨(backend) add offering rules on `ProductRelationSerializer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Add offering rules properties into the ProductRelationSerializer
+  to render discounted price for the purchase of a certificate product
 - Added discount column to csv order export
 - Added actions in admin api endpoints `BatchOrder` to validate payment,
   generate orders and send voucher codes, and send invitation signature link

--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -979,6 +979,9 @@ class ProductRelationSerializer(CachedModelSerializer):
     """
 
     product = ProductSerializer(read_only=True)
+    rules = OfferingRulePropertySerializer(
+        read_only=True, help_text=_("Offer rules applied to this offer.")
+    )
 
     class Meta:
         model = models.CourseProductRelation
@@ -986,6 +989,7 @@ class ProductRelationSerializer(CachedModelSerializer):
             "id",
             "product",
             "is_withdrawable",
+            "rules",
         ]
         read_only_fields = fields
 


### PR DESCRIPTION
## Purpose

Our API client would not inform to our consumers that there is a discounted price for the purchase of a certificate when they open the sales tunnel for informations.

Actually, even if an offer rule was activated for the product certificate, it always mention the initial product's price and not the discounted price. 

To fix this, the `ProductRelationSerializer` that is used for by our API consumers, they now see the discounted price when there is one into the rules properties of the `OfferingRules` related to the `Offering`. Else, they can rely on the product's initial price.

:construction: 
This work will is a draft now.

Since some new developments are carried on to bring the discounted prices if present from joanie to richie, we should not merge this

:construction: 

## Proposal

- [x] Add `discounted_price` property on ProductRelationSerializer

