### PR TITLE
🐛(backend) generate contract definition pdf aware of timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
 
 ### Fixed
 
+- Course `start` and `end` are timezone aware from configuration
+  TIME_ZONE when generating the PDF contract definition
 - Invalidate course product relation cache on order group update
 - Compute offer rule properties instead of returning the first one
 

--- a/src/backend/joanie/core/utils/contract_definition.py
+++ b/src/backend/joanie/core/utils/contract_definition.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 from datetime import date, timedelta
+from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -145,18 +146,21 @@ def prepare_course_context(language_code, order=None):
     }
 
     if order:
+        timezone = ZoneInfo(settings.TIME_ZONE)
+
         course_dates = order.get_equivalent_course_run_dates()
         course_start = course_dates["start"]
         course_end = course_dates["end"]
         course_effort = order.course.effort
+
         # Transform duration value to ISO 8601 format
         if isinstance(course_effort, timedelta):
             course_effort = duration_iso_string(course_effort)
         # Transform date value to ISO 8601 format
         if isinstance(course_start, date):
-            course_start = course_start.isoformat()
+            course_start = course_start.astimezone(timezone).isoformat()
         if isinstance(course_end, date):
-            course_end = course_end.isoformat()
+            course_end = course_end.astimezone(timezone).isoformat()
 
         course_context.update(
             {


### PR DESCRIPTION
## Purpose

We have discovered while generating the PDF on the server side, it would ignore the timezone of the user. This caused the course start and course end values to differ from those set via the client interface, which uses timezone awareness datetimes. We now have fixed this issue to not ignore the configured timezone while generating the PDF contract definition.

For example, on the client interface, the user would set the course_start the following way :
* start : 06/06/2025 00:00 AM : it would render as 05/05/2025 10:00 PM

The generation is done on the server side, so it would ignore the client interface timezone.

:construction: 
**Question : what have we set for Joanie's preprod or prod for the configuration variable TIME_ZONE ?** => We should not touch the settings "UTC" configured in settings. 


**Discussions** : we might just update the Backoffice of Joanie to only display UTC datetime while setting up the course run dates. Also, we might only keep the date and not the time (awaiting for legal team confirmation). Meanwhile, admin users of Joanie should all be aware that the datetimes set are in UTC and not in local time.

This work has become a draft.
:construction: 

## Proposal

- [x] Take in account the timezone configured in settings while generating the contract definition in PDF
