### PR TITLE
✨(backend) handle notification dummy payment backend batch order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Added `handle_notification` for batch order in dummy payment backend
 - Added discount column to csv order export
 - Added actions in admin api endpoints `BatchOrder` to validate payment,
   generate orders and send voucher codes, and send invitation signature link


### PR DESCRIPTION

## Purpose

We can now use the dummy payment backend to simulate payment (succeed of failed) for a batch order.
It was missing.

## Proposal

- [x] Handle the notification from the payment of batch order with the dummy payment backend
