### PR TITLE
✨(backend) improve payment schedule endpoint

### DIFF
--- a/src/backend/joanie/core/serializers/client.py
+++ b/src/backend/joanie/core/serializers/client.py
@@ -1240,6 +1240,20 @@ class OrderPaymentScheduleSerializer(serializers.Serializer):
         min_value=D(0.00),
         required=False,
     )
+    discount = serializers.CharField(
+        allow_null=True,
+        required=False,
+        help_text=_("String representation of the discount"),
+    )
+    discounted_price = serializers.DecimalField(
+        allow_null=True,
+        coerce_to_string=False,
+        decimal_places=2,
+        max_digits=9,
+        min_value=D(0.00),
+        required=False,
+        help_text=_("Discounted price of the offer."),
+    )
 
     def create(self, validated_data):
         """Only there to avoid a NotImplementedError"""

--- a/src/backend/joanie/tests/core/test_api_offerings.py
+++ b/src/backend/joanie/tests/core/test_api_offerings.py
@@ -13,6 +13,7 @@ from django.test import override_settings
 
 from joanie.core import enums, factories, models
 from joanie.core.serializers import fields
+from joanie.core.utils import get_default_currency_symbol
 from joanie.tests.base import BaseAPITestCase
 
 
@@ -1680,6 +1681,8 @@ class OfferingApiTest(BaseAPITestCase):
             response.json(),
             {
                 "price": 3.00,
+                "discount": None,
+                "discounted_price": None,
                 "payment_schedule": [
                     {
                         "id": "00000000-0000-0000-0000-000000000001",
@@ -1765,7 +1768,9 @@ class OfferingApiTest(BaseAPITestCase):
         self.assertEqual(
             response.json(),
             {
-                "price": 1.50,
+                "price": 3.00,
+                "discount": "-50%",
+                "discounted_price": 1.50,
                 "payment_schedule": [
                     {
                         "id": "00000000-0000-0000-0000-000000000001",
@@ -1837,6 +1842,8 @@ class OfferingApiTest(BaseAPITestCase):
             response.json(),
             {
                 "price": 3.00,
+                "discount": None,
+                "discounted_price": None,
                 "payment_schedule": [
                     {
                         "id": "00000000-0000-0000-0000-000000000001",
@@ -1904,7 +1911,9 @@ class OfferingApiTest(BaseAPITestCase):
         self.assertEqual(
             response.json(),
             {
-                "price": 1.50,
+                "price": 3.00,
+                "discount": "-50%",
+                "discounted_price": 1.50,
                 "payment_schedule": [
                     {
                         "id": "00000000-0000-0000-0000-000000000001",
@@ -2033,7 +2042,9 @@ class OfferingApiTest(BaseAPITestCase):
         self.assertEqual(
             response.json(),
             {
-                "price": 9.00,
+                "price": 10.00,
+                "discount": "-10%",
+                "discounted_price": 9.00,
                 "payment_schedule": [
                     {
                         "id": "00000000-0000-0000-0000-000000000001",
@@ -2110,7 +2121,7 @@ class OfferingApiTest(BaseAPITestCase):
         voucher = factories.VoucherFactory(
             multiple_use=True,
             multiple_users=True,
-            discount=factories.DiscountFactory(rate=0.1),
+            discount=factories.DiscountFactory(amount=1),
         )
         payload = {"voucher_code": voucher.code}
 
@@ -2144,7 +2155,9 @@ class OfferingApiTest(BaseAPITestCase):
         self.assertEqual(
             response.json(),
             {
-                "price": 9.00,
+                "price": 10.00,
+                "discount": f"-1 {get_default_currency_symbol()}",
+                "discounted_price": 9.00,
                 "payment_schedule": [
                     {
                         "id": "00000000-0000-0000-0000-000000000001",
@@ -2248,7 +2261,9 @@ class OfferingApiTest(BaseAPITestCase):
         self.assertEqual(
             response.json(),
             {
-                "price": 90.00,
+                "price": 100.00,
+                "discount": "-10%",
+                "discounted_price": 90.00,
                 "payment_schedule": [
                     {
                         "id": "00000000-0000-0000-0000-000000000001",

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -7109,6 +7109,20 @@
                         "maximum": 10000000,
                         "minimum": 0.0,
                         "exclusiveMaximum": true
+                    },
+                    "discount": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "String representation of the discount"
+                    },
+                    "discounted_price": {
+                        "type": "number",
+                        "format": "double",
+                        "maximum": 10000000,
+                        "minimum": 0.0,
+                        "exclusiveMaximum": true,
+                        "nullable": true,
+                        "description": "Discounted price of the offer."
                     }
                 },
                 "required": [


### PR DESCRIPTION

## Purpose

We need to return into the response of this endpoint the difference made with the voucher code or
the discounted price on the offering from its initial price. Now, this endpoint returns respectively, the initial price, the discount applied if one is set and finally the discounted price. If no discount, nor voucher code is set, it return a value for the initial price and sets None for the other two keys (`discount` and `discounted_amount`).

## Proposal

- [x] add the keys `discount` and `discounted_price`  to the response of `payment_schedule` endpoint