### PR TITLE
🚚(backend) rename payment schedule endpoint to payment plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to
 
 ### Changed
 
+- Rename `payment_schedule` endpoint to `payment_plan`
 - Update contract definition template to move course section into
   contract body before articles
 - Update limits for payment schedule for credential products and

--- a/src/backend/joanie/core/api/client/__init__.py
+++ b/src/backend/joanie/core/api/client/__init__.py
@@ -190,7 +190,7 @@ class OfferingViewSet(
         if (
             self.action == "retrieve"
             and self.kwargs.get("course_id")
-            or self.action == "payment_schedule"
+            or self.action == "payment_plan"
         ):
             permission_classes = [drf_permissions.AllowAny]
         else:
@@ -200,17 +200,17 @@ class OfferingViewSet(
 
     def get_serializer_class(self):
         """Return the serializer class to use."""
-        if self.action == "payment_schedule":
+        if self.action == "payment_plan":
             return serializers.OrderPaymentScheduleSerializer
         if self.action == "list":
             return serializers.OfferingLightSerializer
         return self.serializer_class
 
-    @action(detail=True, methods=["GET"], url_path="payment-schedule")
-    def payment_schedule(self, request, *args, **kwargs):
+    @action(detail=True, methods=["GET"], url_path="payment-plan")
+    def payment_plan(self, request, *args, **kwargs):
         """
-        Return the price and the payment schedule for an offering, whether there is a discount
-        or a voucher code that is passed.
+        Return information on the payment schedule, the price, the discount if any
+        (on the offering or through a voucher code), and the discounted price.
         """
         offering = self.get_object()
 

--- a/src/backend/joanie/tests/core/test_api_offerings.py
+++ b/src/backend/joanie/tests/core/test_api_offerings.py
@@ -1630,7 +1630,7 @@ class OfferingApiTest(BaseAPITestCase):
         },
         DEFAULT_CURRENCY="EUR",
     )
-    def test_api_offering_payment_schedule_with_product_id(
+    def test_api_offering_payment_plan_with_product_id(
         self,
     ):
         """
@@ -1670,10 +1670,10 @@ class OfferingApiTest(BaseAPITestCase):
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/"
+                f"products/{product.id}/payment-plan/"
             )
             response_relation_path = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/"
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/"
             )
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -1713,7 +1713,7 @@ class OfferingApiTest(BaseAPITestCase):
         },
         DEFAULT_CURRENCY="EUR",
     )
-    def test_api_offering_payment_schedule_with_product_id_discount(
+    def test_api_offering_payment_plan_with_product_id_discount(
         self,
     ):
         """
@@ -1758,10 +1758,10 @@ class OfferingApiTest(BaseAPITestCase):
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/"
+                f"products/{product.id}/payment-plan/"
             )
             response_relation_path = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/"
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/"
             )
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -1799,7 +1799,7 @@ class OfferingApiTest(BaseAPITestCase):
         },
         DEFAULT_CURRENCY="EUR",
     )
-    def test_api_offering_payment_schedule_with_certificate_product_id(
+    def test_api_offering_payment_plan_with_certificate_product_id(
         self,
     ):
         """
@@ -1831,10 +1831,10 @@ class OfferingApiTest(BaseAPITestCase):
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/"
+                f"products/{product.id}/payment-plan/"
             )
             response_relation_path = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/"
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/"
             )
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -1865,7 +1865,7 @@ class OfferingApiTest(BaseAPITestCase):
         },
         DEFAULT_CURRENCY="EUR",
     )
-    def test_api_offering_payment_schedule_with_certificate_product_id_discount(
+    def test_api_offering_payment_plan_with_certificate_product_id_discount(
         self,
     ):
         """
@@ -1901,10 +1901,10 @@ class OfferingApiTest(BaseAPITestCase):
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/"
+                f"products/{product.id}/payment-plan/"
             )
             response_relation_path = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/"
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/"
             )
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -1929,7 +1929,7 @@ class OfferingApiTest(BaseAPITestCase):
         self.assertEqual(response_relation_path.status_code, HTTPStatus.OK)
         self.assertEqual(response_relation_path.json(), response.json())
 
-    def test_api_offering_voucher_estimated_price_authenticated_invalid_voucher(
+    def test_api_offering_voucher_payment_plan_authenticated_invalid_voucher(
         self,
     ):
         """
@@ -1942,22 +1942,22 @@ class OfferingApiTest(BaseAPITestCase):
 
         response = self.client.get(
             f"/api/v1.0/courses/{offering.course.code}/"
-            f"products/{offering.product.id}/payment-schedule/",
+            f"products/{offering.product.id}/payment-plan/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={"voucher_code": "invalid_code"},
         )
         response_relation_path = self.client.get(
-            f"/api/v1.0/offerings/{offering.id}/payment-schedule/",
+            f"/api/v1.0/offerings/{offering.id}/payment-plan/",
             HTTP_AUTHORIZATION=f"Bearer {token}",
             data={"voucher_code": "invalid_code"},
         )
         response_with_query_params = self.client.get(
             f"/api/v1.0/courses/{offering.course.code}/"
-            f"products/{offering.product.id}/payment-schedule/?voucher_code=invalid_code",
+            f"products/{offering.product.id}/payment-plan/?voucher_code=invalid_code",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         response_relation_path_with_query_param = self.client.get(
-            f"/api/v1.0/offerings/{offering.id}/payment-schedule/?voucher_code=invalid_code",
+            f"/api/v1.0/offerings/{offering.id}/payment-plan/?voucher_code=invalid_code",
             HTTP_AUTHORIZATION=f"Bearer {token}",
         )
 
@@ -1982,7 +1982,7 @@ class OfferingApiTest(BaseAPITestCase):
         },
         DEFAULT_CURRENCY="EUR",
     )
-    def test_api_offering_voucher_estimated_price_anonymous(
+    def test_api_offering_voucher_payment_plan_anonymous(
         self,
     ):
         """
@@ -2023,19 +2023,19 @@ class OfferingApiTest(BaseAPITestCase):
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{offering.course.code}/"
-                f"products/{offering.product.id}/payment-schedule/",
+                f"products/{offering.product.id}/payment-plan/",
                 data={"voucher_code": voucher.code},
             )
             response_relation_path = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/",
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/",
                 data={"voucher_code": voucher.code},
             )
             response_with_query_params = self.client.get(
                 f"/api/v1.0/courses/{offering.course.code}/"
-                f"products/{offering.product.id}/payment-schedule/?voucher_code={voucher.code}",
+                f"products/{offering.product.id}/payment-plan/?voucher_code={voucher.code}",
             )
             response_relation_with_query_params = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/?voucher_code={voucher.code}",
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/?voucher_code={voucher.code}",
             )
 
         self.assertEqual(response.status_code, HTTPStatus.OK, response.json())
@@ -2084,7 +2084,7 @@ class OfferingApiTest(BaseAPITestCase):
         },
         DEFAULT_CURRENCY="EUR",
     )
-    def test_api_offering_voucher_estimated_price_with_credential_product_id_with_voucher_code(
+    def test_api_offering_voucher_payment_plan_with_credential_product_id_with_voucher_code(
         self,
     ):
         """
@@ -2131,22 +2131,22 @@ class OfferingApiTest(BaseAPITestCase):
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/",
+                f"products/{product.id}/payment-plan/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
                 data=payload,
             )
             response_relation_path = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/",
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
                 data=payload,
             )
             response_with_query_params = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/?voucher_code={voucher.code}",
+                f"products/{product.id}/payment-plan/?voucher_code={voucher.code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
             response_relation_path_with_query_param = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/"
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/"
                 f"?voucher_code={voucher.code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
@@ -2199,7 +2199,7 @@ class OfferingApiTest(BaseAPITestCase):
         },
         DEFAULT_CURRENCY="EUR",
     )
-    def test_api_offering_voucher_estimated_price_with_certificate_product_id_with_voucher_code(
+    def test_api_offering_voucher_payment_plan_with_certificate_product_id_with_voucher_code(
         self,
     ):
         """
@@ -2237,22 +2237,22 @@ class OfferingApiTest(BaseAPITestCase):
         ):
             response = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/",
+                f"products/{product.id}/payment-plan/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
                 data=payload,
             )
             response_relation_path = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/",
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
                 data=payload,
             )
             response_with_query_params = self.client.get(
                 f"/api/v1.0/courses/{course_run.course.code}/"
-                f"products/{product.id}/payment-schedule/?voucher_code={voucher.code}",
+                f"products/{product.id}/payment-plan/?voucher_code={voucher.code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )
             response_relation_path_with_query_param = self.client.get(
-                f"/api/v1.0/offerings/{offering.id}/payment-schedule/"
+                f"/api/v1.0/offerings/{offering.id}/payment-plan/"
                 f"?voucher_code={voucher.code}",
                 HTTP_AUTHORIZATION=f"Bearer {token}",
             )

--- a/src/backend/joanie/tests/swagger/swagger.json
+++ b/src/backend/joanie/tests/swagger/swagger.json
@@ -2022,10 +2022,10 @@
                 }
             }
         },
-        "/api/v1.0/courses/{course_id}/products/{pk_or_product_id}/payment-schedule/": {
+        "/api/v1.0/courses/{course_id}/products/{pk_or_product_id}/payment-plan/": {
             "get": {
-                "operationId": "courses_products_payment_schedule_retrieve",
-                "description": "Return the price and the payment schedule for an offering, whether there is a discount\nor a voucher code that is passed.",
+                "operationId": "courses_products_payment_plan_retrieve",
+                "description": "Return information on the payment schedule, the price, the discount if any\n(on the offering or through a voucher code), and the discounted price.",
                 "parameters": [
                     {
                         "in": "path",
@@ -2907,10 +2907,10 @@
                 }
             }
         },
-        "/api/v1.0/offerings/{pk_or_product_id}/payment-schedule/": {
+        "/api/v1.0/offerings/{pk_or_product_id}/payment-plan/": {
             "get": {
-                "operationId": "offerings_payment_schedule_retrieve",
-                "description": "Return the price and the payment schedule for an offering, whether there is a discount\nor a voucher code that is passed.",
+                "operationId": "offerings_payment_plan_retrieve",
+                "description": "Return information on the payment schedule, the price, the discount if any\n(on the offering or through a voucher code), and the discounted price.",
                 "parameters": [
                     {
                         "in": "path",
@@ -4435,10 +4435,10 @@
                 }
             }
         },
-        "/api/v1.0/organizations/{organization_id}/offerings/{pk_or_product_id}/payment-schedule/": {
+        "/api/v1.0/organizations/{organization_id}/offerings/{pk_or_product_id}/payment-plan/": {
             "get": {
-                "operationId": "organizations_offerings_payment_schedule_retrieve",
-                "description": "Return the price and the payment schedule for an offering, whether there is a discount\nor a voucher code that is passed.",
+                "operationId": "organizations_offerings_payment_plan_retrieve",
+                "description": "Return information on the payment schedule, the price, the discount if any\n(on the offering or through a voucher code), and the discounted price.",
                 "parameters": [
                     {
                         "in": "path",


### PR DESCRIPTION
## Purpose

For more clarity and since the endpoint payment schedule returns more informations about the payment plan of an offering, we have decided to change the name of this endpoint. It did not make anymore sense to keep it called that way, so now, it has been renamed to `payment-plan`.

## Proposal

- [x] Rename payment_schedule endpoint to payment_plan

