### PR TITLE
🐛(backend) fix installment email total when discounted price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to
 
 ### Fixed
 
+- Render discounted price in installment emails when one is present
 - Invalidate course product relation cache on order group update
 - Compute offer rule properties instead of returning the first one
 - Offering rule form date time picker and discount

--- a/src/backend/joanie/core/utils/emails.py
+++ b/src/backend/joanie/core/utils/emails.py
@@ -34,7 +34,7 @@ def prepare_context_data(
         "email": order.owner.email,
         "product_title": product_title,
         "installment_amount": Money(installment_amount),
-        "product_price": Money(order.product.price),
+        "product_price": Money(order.total),
         "credit_card_last_numbers": credit_card_last_numbers,
         "order_payment_schedule": order.payment_schedule,
         "dashboard_order_link": (


### PR DESCRIPTION
## Purpose

Since we have introduced discounts on orders, the email that summarizes the installments paid or refused would still show the total representing the product's price instead of the order's total when a discount was applied. Now, the behavior as changed, we will always show the order's total instead.

Fix #1179

## Proposal

- [x] update in emails utils the method that prepares the context 

