### PR TITLE
:sparkles:(backend) admin api batch order actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 ### Added
 
+- Add admin API endpoints for batch orders to confirm quote, purchase order
+  and bank transfer
 - Add payment methods for batch orders
 - Add unique reference for a quote once generated
 

--- a/src/backend/joanie/core/api/admin/__init__.py
+++ b/src/backend/joanie/core/api/admin/__init__.py
@@ -948,6 +948,32 @@ class BatchOrderViewSet(
 
         return Response(status=HTTPStatus.OK)
 
+    @action(
+        detail=True,
+        methods=["POST"],
+        url_path="confirm-bank-transfer",
+    )
+    def confirm_bank_transfer(self, request, *args, **kwargs):
+        """
+        Confirm the bank transfer of a batch order, it will validate the payment
+        and generate the orders with their voucher codes.
+        """
+        batch_order = self.get_object()
+
+        if not (
+            batch_order.uses_bank_transfer
+            and batch_order.is_eligible_to_validate_payment
+        ):
+            return Response(
+                _("You are not allowed to validate the bank transfer."),
+                status=HTTPStatus.BAD_REQUEST,
+            )
+
+        validate_success_payment(batch_order)
+        batch_order.flow.update()
+
+        return Response(status=HTTPStatus.OK)
+
 
 class OrganizationAddressViewSet(
     mixins.CreateModelMixin,

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -2451,11 +2451,16 @@ class BatchOrder(BaseModel):
         """Return boolean value whether the batch order is related to a quote"""
         return hasattr(self, "quote")
 
+    @property
+    def is_canceled(self):
+        """Returns boolean value whether the batch order is canceled or not."""
+        return self.state == enums.BATCH_ORDER_STATE_CANCELED
+
     def cancel_orders(self):
         """
         Cancel all orders associated with this batch order and delete their linked vouchers.
         """
-        if self.state != enums.BATCH_ORDER_STATE_CANCELED:
+        if not self.is_canceled:
             message = "You must cancel the batch order before canceling the orders"
             logger.error(
                 message,

--- a/src/backend/joanie/tests/core/api/admin/batch_order/test_confirm_bank_transfer.py
+++ b/src/backend/joanie/tests/core/api/admin/batch_order/test_confirm_bank_transfer.py
@@ -1,0 +1,170 @@
+"""Test suite for the admin batch orders API confirm bank transfer order endpoint."""
+
+from http import HTTPStatus
+
+from django.test import TestCase
+
+from joanie.core import enums, factories
+from joanie.payment.models import Invoice, Transaction
+
+
+class BatchOrdersAdminConfirmBankTransferApiTestCase(TestCase):
+    """Test suite for the admin batch orders API confirm bank transfer order endpoint."""
+
+    def test_api_admin_batch_order_confirm_bank_transfer_anonymous(self):
+        """Anonymous user should not be able to confirm a bank transfer."""
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-bank-transfer/",
+            content_type="application/json",
+            data={},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED, response.json())
+
+    def test_api_admin_batch_order_confirm_bank_transfer_lambda_user(self):
+        """Lambda user should not be able to confirm a bank transfer."""
+        user = factories.UserFactory(is_staff=True, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-bank-transfer/",
+            content_type="application/json",
+            data={},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN, response.json())
+
+    def test_api_admin_batch_order_confirm_bank_transfer_get_method(self):
+        """
+        Authenticated admin user should not be able to confirm a bank transfer with get method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.get(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-bank-transfer/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_bank_transfer_update_method(self):
+        """
+        Authenticated admin user should not be able to confirm a bank transfer with update method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.put(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-bank-transfer/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_bank_transfer_post_method(self):
+        """
+        Authenticated admin user should not be able to confirm a bank transfer with PATCH method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-bank-transfer/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_bank_transfer_delete_method(self):
+        """
+        Authenticated admin user should not be able to confirm a bank transfer with delete method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-bank-transfer/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_bank_transfer_invalid_id(self):
+        """
+        Authenticated admin user should not be able to confirm a bank transfer with an invalid id.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self.client.post(
+            "/api/v1.0/admin/batch-orders/invalid_id/confirm-bank-transfer/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.json())
+
+    def test_api_admin_batch_order_confirm_bank_transfer_payment_methods(self):
+        """
+        Authenticated admin user should only be able to confirm a bank transfer when the
+        batch order's payment method is set with bank transfer. Else, it should return error.
+        When the payment method is bank transfer, once validated, it should generate the child
+        invoice, the transaction, generate the orders and the vouchers.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        for payment_method, _ in enums.BATCH_ORDER_PAYMENT_METHOD_CHOICES:
+            with self.subTest(payment_method=payment_method):
+                if payment_method == enums.BATCH_ORDER_WITH_PURCHASE_ORDER:
+                    state = enums.BATCH_ORDER_STATE_SIGNING
+                else:
+                    state = enums.BATCH_ORDER_STATE_PENDING
+
+                batch_order = factories.BatchOrderFactory(
+                    state=state,
+                    payment_method=payment_method,
+                    nb_seats=3,
+                )
+
+                response = self.client.post(
+                    f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-bank-transfer/",
+                    content_type="application/json",
+                )
+
+                if payment_method != enums.BATCH_ORDER_WITH_BANK_TRANSFER:
+                    self.assertContains(
+                        response,
+                        "You are not allowed to validate the bank transfer",
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                else:
+                    self.assertTrue(
+                        Invoice.objects.filter(parent=batch_order.main_invoice).exists()
+                    )
+                    self.assertTrue(
+                        Transaction.objects.get(reference=f"bo_{batch_order.id}")
+                    )
+
+                    batch_order.refresh_from_db()
+
+                    self.assertEqual(
+                        batch_order.state, enums.BATCH_ORDER_STATE_COMPLETED
+                    )
+                    self.assertTrue(batch_order.orders.exists())
+                    self.assertEqual(len(batch_order.vouchers), 3)

--- a/src/backend/joanie/tests/core/api/admin/batch_order/test_confirm_purchase_order.py
+++ b/src/backend/joanie/tests/core/api/admin/batch_order/test_confirm_purchase_order.py
@@ -1,0 +1,207 @@
+"""Test suite for the admin batch orders API confirm purchase order endpoint."""
+
+from http import HTTPStatus
+
+from django.test import TestCase
+
+from joanie.core import enums, factories
+
+
+class BatchOrdersAdminConfirmPurchaseOrderApiTestCase(TestCase):
+    """Test suite for the admin batch orders API confirm purchase order endpoint."""
+
+    def test_api_admin_batch_order_confirm_purchase_order_anonymous(self):
+        """Anonymous user should not be able to confirm a purchase order."""
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+            data={},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED, response.json())
+
+    def test_api_admin_batch_order_confirm_purchase_order_lambda_user(self):
+        """Lambda user should not be able to confirm a purchase order."""
+        user = factories.UserFactory(is_staff=True, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+            data={},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN, response.json())
+
+    def test_api_admin_batch_order_confirm_purchase_order_get_method(self):
+        """
+        Authenticated admin user should not be able to confirm purchase order with get method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.get(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_purchase_order_update_method(self):
+        """
+        Authenticated admin user should not be able to confirm purchase order with update method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.put(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_purchase_order_post_method(self):
+        """
+        Authenticated admin user should not be able to confirm purchase order with post method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.post(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_purchase_order_delete_method(self):
+        """
+        Authenticated admin user should not be able to confirm purchase order with delete method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_purchase_order_invalid_id(self):
+        """
+        Authenticated admin user should not be able to confirm purchase order with an invalid id.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self.client.patch(
+            "/api/v1.0/admin/batch-orders/invalid_id/confirm-purchase-order/",
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.json())
+
+    def test_api_admin_batch_order_confirm_purchase_order_quote_not_signed_nor_total(
+        self,
+    ):
+        """
+        Authenticated admin user should not be able to confirm a purchase when the quote has
+        not been signed and the batch order has no total set yet.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        batch_order = factories.BatchOrderFactory(
+            state=enums.BATCH_ORDER_STATE_QUOTED,
+            payment_method=enums.BATCH_ORDER_WITH_PURCHASE_ORDER,
+        )
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+        )
+
+        self.assertContains(
+            response,
+            "Batch order's quote is not signed, nor has a total.",
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    def test_api_admin_batch_order_confirm_purchase_order_when_already_confirmed(self):
+        """Authenticated admin user cannot confirm twice a purchase order of a batch order."""
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        batch_order = factories.BatchOrderFactory(
+            state=enums.BATCH_ORDER_STATE_QUOTED,
+            payment_method=enums.BATCH_ORDER_WITH_PURCHASE_ORDER,
+        )
+        batch_order.quote.context = "context"
+        batch_order.freeze_total("123.45")
+        batch_order.quote.tag_has_purchase_order()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+            content_type="application/json",
+        )
+
+        self.assertContains(
+            response,
+            "Batch order's quote purchase order already confirmed.",
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    def test_api_admin_batch_order_confirm_purchase_order_with_payment_methods(self):
+        """
+        Authenticated admin user should only be able to confirm a purchase order when the payment
+        method is with `purchase_order`, else the other payment methods (bank_transfer or card
+        payment) does not required to confirm a purchase order. When the purchase order is
+        confirmed, the batch order's state should transition to `to_sign`.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        for payment_method, _ in enums.BATCH_ORDER_PAYMENT_METHOD_CHOICES:
+            with self.subTest(payment_method=payment_method):
+                batch_order = factories.BatchOrderFactory(
+                    state=enums.BATCH_ORDER_STATE_QUOTED,
+                    payment_method=payment_method,
+                )
+                if payment_method == enums.BATCH_ORDER_WITH_PURCHASE_ORDER:
+                    batch_order.quote.context = "context"
+                    batch_order.freeze_total("123.45")
+
+                response = self.client.patch(
+                    f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-purchase-order/",
+                    content_type="application/json",
+                )
+
+                if payment_method != enums.BATCH_ORDER_WITH_PURCHASE_ORDER:
+                    self.assertContains(
+                        response,
+                        "Cannot confirm purchase order. Batch order payment"
+                        f" method is {payment_method}",
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                else:
+                    batch_order.refresh_from_db()
+                    self.assertEqual(response.status_code, HTTPStatus.OK)
+                    self.assertTrue(batch_order.quote.has_purchase_order)
+                    self.assertEqual(batch_order.state, enums.BATCH_ORDER_STATE_TO_SIGN)

--- a/src/backend/joanie/tests/core/api/admin/batch_order/test_confirm_quote.py
+++ b/src/backend/joanie/tests/core/api/admin/batch_order/test_confirm_quote.py
@@ -1,0 +1,217 @@
+"""Test suite for the admin batch orders API confirm quote endpoint."""
+
+from decimal import Decimal as D
+from http import HTTPStatus
+
+from django.test import TestCase
+
+from joanie.core import enums, factories, models
+
+
+class BatchOrdersAdminConfirmQuoteApiTestCase(TestCase):
+    """Test suite for the admin batch orders API confirm quote endpoint."""
+
+    def test_api_admin_batch_order_confirm_quote_anonymous(self):
+        """
+        Anonymous user should not be able to confirm a quote.
+        """
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED, response.json())
+
+    def test_api_admin_batch_order_confirm_quote_lambda_user(self):
+        """
+        Lambda user should not be able to confirm a quote.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=False)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN, response.json())
+
+    def test_api_admin_batch_order_confirm_quote_get_method(self):
+        """
+        Authenticated admin user should not be able to confirm a quote with the get method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.get(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={"total": "123.45"},
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_quote_update_method(self):
+        """
+        Authenticated admin user should not be able to confirm a quote with the update method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.put(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={"total": "123.45"},
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_quote_post_method(self):
+        """
+        Authenticated admin user should not be able to confirm a quote with the post method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.post(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={"total": "123.45"},
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_quote_delete_method(self):
+        """
+        Authenticated admin user should not be able to confirm a quote with the delete method.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory()
+
+        response = self.client.delete(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={"total": "123.45"},
+        )
+
+        self.assertEqual(
+            response.status_code, HTTPStatus.METHOD_NOT_ALLOWED, response.json()
+        )
+
+    def test_api_admin_batch_order_confirm_quote_invalid_id(self):
+        """
+        Authenticated admin user should not be able to confirm a quote with an invalid id.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        response = self.client.patch(
+            "/api/v1.0/admin/batch-orders/invalid_id/confirm-quote/",
+            content_type="application/json",
+            data={"total": "123.45"},
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND, response.json())
+
+    def test_api_admin_batch_order_confirm_quote_state_other_than_quoted(self):
+        """
+        Authenticated admin user should not be able to confirm a quote if the batch order's state
+        is other than `quoted`.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+
+        batch_order_states = [
+            state
+            for state, _ in enums.BATCH_ORDER_STATE_CHOICES
+            if state
+            not in [
+                # State assigned always transitions to quotes in init_flow() method
+                enums.BATCH_ORDER_STATE_ASSIGNED,
+                enums.BATCH_ORDER_STATE_QUOTED,
+            ]
+        ]
+        for state in batch_order_states:
+            with self.subTest(state=state):
+                batch_order = factories.BatchOrderFactory(state=state)
+                response = self.client.patch(
+                    f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+                    content_type="application/json",
+                    data={"total": "123.45"},
+                )
+
+                if state == enums.BATCH_ORDER_STATE_DRAFT:
+                    self.assertContains(
+                        response,
+                        "You must generate the quote first.",
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                elif state == enums.BATCH_ORDER_STATE_CANCELED:
+                    self.assertContains(
+                        response,
+                        "Batch order is canceled, cannot confirm quote signature.",
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+                else:
+                    self.assertContains(
+                        response,
+                        "Quote is already signed, and total is frozen.",
+                        status_code=HTTPStatus.BAD_REQUEST,
+                    )
+
+    def test_api_admin_batch_order_confirm_quote_missing_total(self):
+        """
+        Authenticated admin user should not be able to confirm a quote if its missing the total
+        in the payload.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory(state=enums.BATCH_ORDER_STATE_QUOTED)
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={},
+        )
+
+        self.assertContains(
+            response,
+            "Missing total value. It's required to confirm quote.",
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+
+    def test_api_admin_batch_order_confirm_quote_authenticated(self):
+        """
+        Authenticated admin user should be able to confirm a quote. Once they have confirmed the
+        quote, the organization signed on field should be set and the total of the batch order.
+        """
+        user = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=user.username, password="password")
+        batch_order = factories.BatchOrderFactory(state=enums.BATCH_ORDER_STATE_QUOTED)
+
+        response = self.client.patch(
+            f"/api/v1.0/admin/batch-orders/{batch_order.id}/confirm-quote/",
+            content_type="application/json",
+            data={"total": "123.45"},
+        )
+
+        batch_order = models.BatchOrder.objects.get()
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertIsNotNone(batch_order.quote.organization_signed_on)
+        self.assertEqual(batch_order.total, D("123.45"))

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -167,6 +167,58 @@
                 }
             }
         },
+        "/api/v1.0/admin/batch-orders/{id}/confirm-purchase-order/": {
+            "patch": {
+                "operationId": "batch_orders_confirm_purchase_order_partial_update",
+                "description": "Confirm the purchase order when the batch order payment method is `purchase_order`.\nOnce confirmed, the batch order's state transition to `to_sign`.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "batch-orders"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAdminBatchOrderRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAdminBatchOrderRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AdminBatchOrder"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/admin/batch-orders/{id}/confirm-quote/": {
             "patch": {
                 "operationId": "batch_orders_confirm_quote_partial_update",

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -167,6 +167,59 @@
                 }
             }
         },
+        "/api/v1.0/admin/batch-orders/{id}/confirm-bank-transfer/": {
+            "post": {
+                "operationId": "batch_orders_confirm_bank_transfer_create",
+                "description": "Confirm the bank transfer of a batch order, it will validate the payment\nand generate the orders with their voucher codes.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "batch-orders"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminBatchOrderRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AdminBatchOrderRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AdminBatchOrder"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/admin/batch-orders/{id}/confirm-purchase-order/": {
             "patch": {
                 "operationId": "batch_orders_confirm_purchase_order_partial_update",

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -167,6 +167,58 @@
                 }
             }
         },
+        "/api/v1.0/admin/batch-orders/{id}/confirm-quote/": {
+            "patch": {
+                "operationId": "batch_orders_confirm_quote_partial_update",
+                "description": "Confirm the organization has signed the quote and freeze total.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "primary key for the record as UUID"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "batch-orders"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAdminBatchOrderRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAdminBatchOrderRequest"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AdminBatchOrder"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1.0/admin/batch-orders/{id}/generate-orders/": {
             "post": {
                 "operationId": "batch_orders_generate_orders_create",
@@ -10005,6 +10057,98 @@
                         "items": {
                             "$ref": "#/components/schemas/AdminUser"
                         }
+                    }
+                }
+            },
+            "PatchedAdminBatchOrderRequest": {
+                "type": "object",
+                "description": "Admin Batch Order Serializer",
+                "properties": {
+                    "owner": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID"
+                    },
+                    "relation": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "primary key for the record as UUID"
+                    },
+                    "company_name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "company name",
+                        "maxLength": 255
+                    },
+                    "identification_number": {
+                        "type": "string",
+                        "minLength": 1,
+                        "title": "Company identification number",
+                        "description": "company identification number like SIRET in France",
+                        "maxLength": 255
+                    },
+                    "vat_registration": {
+                        "type": "string",
+                        "nullable": true,
+                        "title": "Tax registration number",
+                        "description": "company's vat identification number like Numero de TVA intracommunautaire in France",
+                        "maxLength": 255
+                    },
+                    "address": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "company address",
+                        "maxLength": 255
+                    },
+                    "postcode": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "company postcode",
+                        "maxLength": 50
+                    },
+                    "city": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "company city",
+                        "maxLength": 255
+                    },
+                    "country": {
+                        "$ref": "#/components/schemas/CountryEnum"
+                    },
+                    "nb_seats": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "The number of seats to reserve"
+                    },
+                    "payment_method": {
+                        "$ref": "#/components/schemas/PaymentMethodEnum"
+                    },
+                    "administrative_firstname": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "administrative_lastname": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "administrative_profession": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "administrative_email": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "administrative_telephone": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "billing_address": {
+                        "$ref": "#/components/schemas/AdminBatchOrderBillingAddressRequest"
+                    },
+                    "funding_entity": {
+                        "type": "string",
+                        "minLength": 1
                     }
                 }
             },


### PR DESCRIPTION
## Purpose

Our Admin API `BatchorderViewset` requires some actions that be triggered by an admin user. Confirming the quote, confirming the purchase order, and confirming the bank transfer are not yet implemented.

## Proposal

- [x] admin API confirm quote is signed by organization
- [x] admin API confirm purchase order is received 
- [x] admin API confirm bank transfer is done 
