### PR TITLE
Add archived state checks and refactor tests for clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Exclude archived course runs from synchronization
+
 ## [3.0.2] - 2025-09-01
 
 ### Fixed

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -160,6 +160,14 @@ class CourseState(Mapping):
         """Make it easy to compare two course states."""
         return self._d["priority"] < other["priority"]
 
+    @property
+    def is_archived(self):
+        """Return True if the course state is archived."""
+        return self._d["priority"] in [
+            CourseState.ARCHIVED_OPEN,
+            CourseState.ARCHIVED_CLOSED,
+        ]
+
 
 class Organization(parler_models.TranslatableModel, BaseModel):
     """
@@ -1146,6 +1154,11 @@ class CourseRun(parler_models.TranslatableModel, BaseModel):
         return self.compute_state(
             self.start, self.end, self.enrollment_start, self.enrollment_end
         )
+
+    @property
+    def is_archived(self):
+        """Return True if the course run is archived."""
+        return self.state.is_archived
 
     def clean(self):
         """

--- a/src/backend/joanie/core/utils/offering.py
+++ b/src/backend/joanie/core/utils/offering.py
@@ -61,6 +61,8 @@ def get_serialized_course_runs(offering, visibility=None):
     course_runs = course.course_runs.all()
     serialized_course_runs = []
     for course_run in course_runs:
+        if course_run.is_archived:
+            continue
         if serialized_runs := course_run.get_serialized(
             visibility=visibility,
             certifying=certifying,

--- a/src/backend/joanie/tests/core/test_signals.py
+++ b/src/backend/joanie/tests/core/test_signals.py
@@ -926,7 +926,9 @@ class SignalsTestCase(TestCase):
         """
         Product synchronization should be triggered when an offering rule is created.
         """
-        course_run = factories.CourseRunFactory()
+        course_run = factories.CourseRunFactory(
+            state=CourseState.ONGOING_OPEN,
+        )
         product = factories.ProductFactory(
             courses=[course_run.course],
             price="100.00",
@@ -959,7 +961,9 @@ class SignalsTestCase(TestCase):
         Product synchronization should be triggered when an offering rule is created
         for a credential product with is_graded set to True.
         """
-        course_run = factories.CourseRunFactory()
+        course_run = factories.CourseRunFactory(
+            state=CourseState.ONGOING_OPEN,
+        )
         product = factories.ProductFactory(
             courses=[course_run.course],
             price="100.00",
@@ -1023,7 +1027,10 @@ class SignalsTestCase(TestCase):
         """
         Product synchronization should be triggered when an offering rule is created.
         """
-        course_run = factories.CourseRunFactory(is_listed=True)
+        course_run = factories.CourseRunFactory(
+            state=CourseState.ONGOING_OPEN,
+            is_listed=True,
+        )
         product = factories.ProductFactory(
             courses=[course_run.course],
             price="100.00",
@@ -1078,7 +1085,10 @@ class SignalsTestCase(TestCase):
         """
         Product synchronization should be triggered when an offering rule is deleted.
         """
-        course_run = factories.CourseRunFactory(is_listed=False)
+        course_run = factories.CourseRunFactory(
+            state=CourseState.ONGOING_OPEN,
+            is_listed=True,
+        )
         product = factories.ProductFactory(
             courses=[course_run.course],
             target_courses=[course_run.course],
@@ -1132,7 +1142,10 @@ class SignalsTestCase(TestCase):
         Product synchronization should be triggered when an offering rule is deleted
         for a credential product with is_graded set to True.
         """
-        course_run = factories.CourseRunFactory(is_listed=False)
+        course_run = factories.CourseRunFactory(
+            state=CourseState.ONGOING_OPEN,
+            is_listed=True,
+        )
         product = factories.ProductFactory(
             courses=[course_run.course],
             target_courses=[course_run.course],
@@ -1193,7 +1206,10 @@ class SignalsTestCase(TestCase):
         """
         Product synchronization should be triggered when an offering rule is deleted.
         """
-        course_run = factories.CourseRunFactory(is_listed=True)
+        course_run = factories.CourseRunFactory(
+            state=CourseState.ONGOING_OPEN,
+            is_listed=True,
+        )
         product = factories.ProductFactory(
             courses=[course_run.course],
             target_courses=[],


### PR DESCRIPTION
## Purpose

This pull request improves the handling of archived states for courses and course runs, ensuring outdated runs are excluded from serialization. It also simplifies and enhances test cases for better readability and maintainability.

## Proposal

- Introduce the `is_archived` property to `Course` and `CourseRun` models to filter archived states.
- Update offering serialization to skip archived course runs.
- Add test coverage for archived state verification.
- Refactor date formatting in test cases using a shared `format_date` helper function.
- Update test assertions to validate data structure as lists for synchronization.
- Rename variables and clarify test signals for product synchronization.