### PR TITLE
💄Fix style issues in default and unicamp micro credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Changed background color for micro-credential default template
 
+### Fixed
+
+- Style issues in micro-credentials templates
+
 ## [3.0.3] - 2025-09-04
 
 ### Changed

--- a/src/backend/joanie/core/templates/issuers/microcredential_degree_default.css
+++ b/src/backend/joanie/core/templates/issuers/microcredential_degree_default.css
@@ -203,10 +203,10 @@ a {
 
 .logo-organization {
   aspect-ratio: 1/1;
-  height: 22.3mm;
+  height: 31.8mm;
   object-fit: contain;
   object-position: center;
-  width: 45mm;
+  width: 77mm;
 }
 
 /* == Content */
@@ -252,6 +252,7 @@ a {
   display: flex;
   flex-direction: row;
   flex: 1;
+  height: 111.7mm;
   margin-top: 8.7mm;
 }
 
@@ -264,7 +265,6 @@ a {
 
 .course-details__teachers {
   flex: 1;
-  margin-top: 5mm;
 }
 
 .course-details__teachers .teacher:not(:last-child) {

--- a/src/backend/joanie/core/templates/issuers/microcredential_degree_unicamp.css
+++ b/src/backend/joanie/core/templates/issuers/microcredential_degree_unicamp.css
@@ -252,6 +252,7 @@ a {
   display: flex;
   flex-direction: row;
   flex: 1;
+  height: 111.7mm;
   margin-top: 8.7mm;
 }
 
@@ -264,7 +265,6 @@ a {
 
 .course-details__teachers {
   flex: 1;
-  margin-top: 5mm;
 }
 
 .course-details__teachers .teacher:not(:last-child) {


### PR DESCRIPTION
## Purpose

Fixes #1203 

The current micro-credential templates do not fully match the design provided by the COM Department.
Several alignment issues need to be corrected, visible in both the UniCamp and default templates.

## Proposal

In both templates:

- [x] Align the section “THIS TRAINING IS HOSTED...” to the bottom right
- [x] Place the certification level and the information line at the bottom left of the document
- [x] Align the instructor’s name with the label “issued by…”

In the default template:

- [x] Enlarge the producing institution’s logo (as it is the only logo on the document)

New designs below 

<img width="2702" height="1882" alt="image" src="https://github.com/user-attachments/assets/5a1fc803-fa60-4a19-abf7-a217abf7b94e" />

<img width="2737" height="1932" alt="image" src="https://github.com/user-attachments/assets/cebfdc54-3e0d-4884-b51b-a558a6609d31" />

[certificate_unicamp.pdf](https://github.com/user-attachments/files/22424428/certificate_unicamp.pdf)
[certificate_default.pdf](https://github.com/user-attachments/files/22424430/certificate_default.pdf)

