### PR TITLE
🐛(backend) set installment error in debit pending installment

### DIFF
--- a/src/backend/joanie/core/tasks/payment_schedule.py
+++ b/src/backend/joanie/core/tasks/payment_schedule.py
@@ -51,7 +51,7 @@ def debit_pending_installment(order_id):
                     installment["id"],
                     order.id,
                 )
-                order.set_installment_error(installment)
+                order.set_installment_error(installment["id"])
                 continue
 
 


### PR DESCRIPTION
## Purpose

When the payment provider has issues, we were supposed to pass the installment id to the the method `set_installment_error` instead of the installment object. This created issues in our sentry, and we couldn't follow the fact that payment provider raised an exception when calling `create_zero_click_payment`.

That behavior led us to believe that nothing happened, but in fact there was an issue with the payment provider while attempting to call the method to debit an installment.

## Proposal
- [x] fix `set_installment_error`

