### PR TITLE
🐛(backend) prevent duplicate order generation for batch orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Orders with a voucher discount of 100% should always
   create a main invoice
+- Prevent duplicate order generation for batch orders
 
 ### Added
 

--- a/src/backend/joanie/core/helpers.py
+++ b/src/backend/joanie/core/helpers.py
@@ -75,6 +75,19 @@ def generate_orders(batch_order_id: str):
     Voucher = apps.get_model("core", "Voucher")
 
     batch_order = BatchOrder.objects.get(pk=batch_order_id)
+    if batch_order.has_orders_generated:
+        message = "The batch order has already generated orders."
+        logger.error(
+            message,
+            extra={
+                "context": {
+                    "batch_order": batch_order.to_dict(),
+                    "relation": batch_order.relation.to_dict(),
+                }
+            },
+        )
+        raise ValidationError(message)
+
     if not batch_order.is_paid:
         message = "The batch order is not yet paid."
         logger.error(

--- a/src/backend/joanie/tests/core/models/test_batch_order.py
+++ b/src/backend/joanie/tests/core/models/test_batch_order.py
@@ -405,6 +405,23 @@ class BatchOrderModelsTestCase(LoggingTestCase):
             self.assertEqual(order.state, enums.ORDER_STATE_TO_OWN)
             self.assertEqual(order.voucher.discount.rate, 1)
 
+    def test_models_batch_order_generate_orders_with_orders_already_generated(self):
+        """
+        If we try to generate orders for a batch order that has already generated them,
+        it should raise a validation error.
+        """
+        batch_order = factories.BatchOrderFactory(
+            state=enums.BATCH_ORDER_STATE_COMPLETED,
+            payment_method=enums.BATCH_ORDER_WITH_BANK_TRANSFER,
+        )
+
+        with self.assertRaises(ValidationError) as context:
+            batch_order.generate_orders()
+
+        self.assertTrue(
+            "The batch order has already generated orders." in str(context.exception)
+        )
+
     def test_models_batch_order_create_billing_address(self):
         """
         When we call the method to create a billing address, it should take


### PR DESCRIPTION

## Purpose

Raise a validation error if a batch order attempts to generate orders when it has already done so. This guards against unintended duplicate order creation and ensures system consistency.

