### PR TITLE
✨ allow custom voucher discount on admin order creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to
 - Introduce django-waffle and expose its status through `waffle_status`
 - Add `useWaffle` hook to read feature flags in the admin frontend
 
+### Changed
+
+- Gate admin order custom discount behind the `admin_order_custom_discount`
+  waffle switch (off by default)
+
 ## [3.3.0] - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - Update Volta configuration with yarn fixed version
 - Allow custom discount (percentage or fixed amount) when creating admin orders
+- Introduce django-waffle and expose its status through `waffle_status`
 
 ## [3.3.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - Allow custom discount (percentage or fixed amount) when creating admin orders
 - Introduce django-waffle and expose its status through `waffle_status`
 - Add `useWaffle` hook to read feature flags in the admin frontend
+- Add `has_deep_links` filter on admin offering API
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - Update Volta configuration with yarn fixed version
 - Allow custom discount (percentage or fixed amount) when creating admin orders
 - Introduce django-waffle and expose its status through `waffle_status`
+- Add `useWaffle` hook to read feature flags in the admin frontend
 
 ## [3.3.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
 
 - Gate admin order custom discount behind the `admin_order_custom_discount`
   waffle switch (off by default)
+- Restrict admin order creation offering search to those with a deep link
+  when custom discount is off
 
 ## [3.3.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Added
 
 - Update Volta configuration with yarn fixed version
+- Allow custom discount (percentage or fixed amount) when creating admin orders
 
 ## [3.3.0] - 2026-04-09
 

--- a/src/backend/joanie/admin_urls.py
+++ b/src/backend/joanie/admin_urls.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.urls import include, path
 
 from rest_framework.routers import DefaultRouter
+from waffle.views import waffle_json
 
 from joanie.core.api import admin as api_admin
 
@@ -111,6 +112,11 @@ admin_offering_related_router.register(
 )
 
 urlpatterns = [
+    path(
+        f"api/{API_VERSION}/admin/waffle_status/",
+        waffle_json,
+        name="admin_waffle_status",
+    ),
     path(
         f"api/{API_VERSION}/admin/",
         include([*admin_router.urls]),

--- a/src/backend/joanie/core/api/admin/__init__.py
+++ b/src/backend/joanie/core/api/admin/__init__.py
@@ -780,9 +780,24 @@ class OrderViewSet(
     filter_backends = [DjangoFilterBackend, AliasOrderingFilter]
 
     def perform_create(self, serializer):
-        """Create a standalone to_own order with a 100% voucher."""
-        order = serializer.save(owner=None, nature=enums.ORDER_NATURE_CPF)
-        discount, _ = models.Discount.objects.get_or_create(rate=1)
+        """Create a standalone to_own order with a voucher."""
+        discount_type = serializer.validated_data.pop("discount_type", None)
+        discount_value = serializer.validated_data.pop("discount_value", None)
+
+        nature = enums.ORDER_NATURE_B2C if discount_type else enums.ORDER_NATURE_CPF
+        order = serializer.save(owner=None, nature=nature)
+
+        if discount_type == "rate":
+            discount, _ = models.Discount.objects.get_or_create(
+                rate=float(discount_value / 100)
+            )
+        elif discount_type == "amount":
+            discount, _ = models.Discount.objects.get_or_create(
+                amount=int(discount_value)
+            )
+        else:
+            discount, _ = models.Discount.objects.get_or_create(rate=1)
+
         order.voucher = models.Voucher.objects.create(
             discount=discount,
             multiple_use=False,

--- a/src/backend/joanie/core/filters/admin/__init__.py
+++ b/src/backend/joanie/core/filters/admin/__init__.py
@@ -478,6 +478,7 @@ class OfferingAdminFilterSet(filters.FilterSet):
 
     query = filters.CharFilter(method="filter_by_query")
     ids = MultipleValueFilter(field_class=fields.UUIDField, field_name="id")
+    has_deep_links = filters.BooleanFilter(method="filter_by_has_deep_links")
 
     def filter_by_query(self, queryset, _name, value):
         """
@@ -489,6 +490,15 @@ class OfferingAdminFilterSet(filters.FilterSet):
             | Q(course__translations__title__icontains=value)
             | Q(course__code__icontains=value)
         ).distinct()
+
+    def filter_by_has_deep_links(self, queryset, _name, value):
+        """
+        Filter offerings depending on whether they have at least one
+        OfferingDeepLink attached.
+        """
+        if value:
+            return queryset.filter(organization_links__isnull=False).distinct()
+        return queryset.filter(organization_links__isnull=True)
 
 
 class VoucherAdminFilterSet(DiscountAdminFilterSet):

--- a/src/backend/joanie/core/migrations/0095_create_admin_order_custom_discount_switch.py
+++ b/src/backend/joanie/core/migrations/0095_create_admin_order_custom_discount_switch.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+SWITCH_NAME = "admin_order_custom_discount"
+SWITCH_NOTE = (
+    "Toggle the custom discount option on the admin order creation form."
+)
+
+
+def create_switch(apps, schema_editor):
+    Switch = apps.get_model("waffle", "Switch")
+    Switch.objects.update_or_create(
+        name=SWITCH_NAME,
+        defaults={"active": False, "note": SWITCH_NOTE},
+    )
+
+
+def delete_switch(apps, schema_editor):
+    Switch = apps.get_model("waffle", "Switch")
+    Switch.objects.filter(name=SWITCH_NAME).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0094_order_nature"),
+        ("waffle", "0004_update_everyone_nullbooleanfield"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_switch, delete_switch),
+    ]

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -7,6 +7,7 @@ from decimal import Decimal as D
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
+import waffle
 from django_countries.serializer_fields import CountryField
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
@@ -24,6 +25,8 @@ from joanie.core.utils.organization import get_least_active_organization
 from joanie.payment import models as payment_models
 
 PAYMENT_STATE_LABELS = dict(enums.PAYMENT_STATE_CHOICES)
+
+ADMIN_ORDER_CUSTOM_DISCOUNT_SWITCH = "admin_order_custom_discount"
 
 
 class AdminContractDefinitionSerializer(serializers.ModelSerializer):
@@ -1504,6 +1507,10 @@ class AdminOrderCreateSerializer(serializers.ModelSerializer):
         """
         discount_type = attrs.get("discount_type")
         discount_value = attrs.get("discount_value")
+        if (
+            discount_type is not None or discount_value is not None
+        ) and not waffle.switch_is_active(ADMIN_ORDER_CUSTOM_DISCOUNT_SWITCH):
+            raise serializers.ValidationError(_("Custom discount is not enabled."))
         if bool(discount_type) != bool(discount_value is not None):
             raise serializers.ValidationError(
                 _("discount_type and discount_value must be provided together.")

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -1457,6 +1457,8 @@ class AdminOrderLightSerializer(serializers.ModelSerializer):
 class AdminOrderCreateSerializer(serializers.ModelSerializer):
     """Write serializer for creating an Order in to_own state."""
 
+    DISCOUNT_TYPE_CHOICES = [("rate", "rate"), ("amount", "amount")]
+
     product_id = serializers.PrimaryKeyRelatedField(
         source="product",
         queryset=models.Product.objects.all(),
@@ -1474,10 +1476,49 @@ class AdminOrderCreateSerializer(serializers.ModelSerializer):
         required=False,
         allow_null=True,
     )
+    discount_type = serializers.ChoiceField(
+        choices=DISCOUNT_TYPE_CHOICES,
+        required=False,
+    )
+    discount_value = serializers.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        required=False,
+    )
 
     class Meta:
         model = models.Order
-        fields = ("product_id", "course_code", "organization_id")
+        fields = (
+            "product_id",
+            "course_code",
+            "organization_id",
+            "discount_type",
+            "discount_value",
+        )
+
+    def validate(self, attrs):
+        """
+        Enforce the custom discount waffle switch and check that, when
+        provided, ``discount_type`` and ``discount_value`` are consistent
+        and within the allowed bounds.
+        """
+        discount_type = attrs.get("discount_type")
+        discount_value = attrs.get("discount_value")
+        if bool(discount_type) != bool(discount_value is not None):
+            raise serializers.ValidationError(
+                _("discount_type and discount_value must be provided together.")
+            )
+        if discount_type == "rate" and discount_value is not None:
+            if discount_value <= 0 or discount_value > 100:  # noqa: PLR2004
+                raise serializers.ValidationError(
+                    {"discount_value": _("Rate must be between 1 and 100.")}
+                )
+        if discount_type == "amount" and discount_value is not None:
+            if discount_value <= 0 or discount_value != int(discount_value):
+                raise serializers.ValidationError(
+                    {"discount_value": _("Amount must be a positive whole number.")}
+                )
+        return attrs
 
 
 class AdminOrderExportSerializer(serializers.ModelSerializer):  # pylint: disable=too-many-public-methods

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -193,6 +193,7 @@ class Base(Configuration):
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "joanie.core.middleware.JoanieDockerflowMiddleware",
+        "waffle.middleware.WaffleMiddleware",
     ]
 
     AUTHENTICATION_BACKENDS = [
@@ -218,6 +219,7 @@ class Base(Configuration):
         "rest_framework",
         "parler",
         "easy_thumbnails",
+        "waffle",
         # Joanie
         "joanie.core",
         # contrib admin needs to be after joanie.core to override templates

--- a/src/backend/joanie/tests/core/api/admin/offerings/test_list.py
+++ b/src/backend/joanie/tests/core/api/admin/offerings/test_list.py
@@ -131,3 +131,45 @@ class CourseProductRelationListAdminApiTestCase(BaseAPITestCase):
             },
             response.json(),
         )
+
+    def test_admin_api_offering_list_filter_has_deep_links_true(self):
+        """
+        Filtering offerings with `?has_deep_links=true` should return only
+        offerings that have at least one OfferingDeepLink attached.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering_with = factories.OfferingFactory(product__courses=[])
+        factories.OfferingDeepLinkFactory(offering=offering_with)
+        factories.OfferingFactory(product__courses=[])
+
+        response = self.client.get(
+            "/api/v1.0/admin/offerings/?has_deep_links=true",
+        )
+
+        self.assertStatusCodeEqual(response, HTTPStatus.OK)
+        data = response.json()
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["results"][0]["id"], str(offering_with.id))
+
+    def test_admin_api_offering_list_filter_has_deep_links_false(self):
+        """
+        Filtering offerings with `?has_deep_links=false` should return only
+        offerings that do not have any OfferingDeepLink attached.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering_with = factories.OfferingFactory(product__courses=[])
+        factories.OfferingDeepLinkFactory(offering=offering_with)
+        offering_without = factories.OfferingFactory(product__courses=[])
+
+        response = self.client.get(
+            "/api/v1.0/admin/offerings/?has_deep_links=false",
+        )
+
+        self.assertStatusCodeEqual(response, HTTPStatus.OK)
+        data = response.json()
+        self.assertEqual(data["count"], 1)
+        self.assertEqual(data["results"][0]["id"], str(offering_without.id))

--- a/src/backend/joanie/tests/core/api/admin/orders/test_create.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_create.py
@@ -110,3 +110,152 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertEqual(order.voucher.discount.rate, 1)
         self.assertFalse(order.voucher.multiple_use)
         self.assertFalse(order.voucher.multiple_users)
+
+    def test_api_admin_orders_create_with_discount_rate(self):
+        """An admin should be able to create an order with a custom rate discount."""
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        organization = offering.organizations.first()
+
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "organization_id": str(organization.id),
+                "discount_type": "rate",
+                "discount_value": 50,
+            },
+            content_type="application/json",
+        )
+
+        self.assertStatusCodeEqual(response, HTTPStatus.CREATED)
+        order = models.Order.objects.get(id=response.json()["id"])
+        self.assertEqual(order.state, enums.ORDER_STATE_TO_OWN)
+        self.assertEqual(order.nature, enums.ORDER_NATURE_B2C)
+        self.assertIsNotNone(order.voucher)
+        self.assertEqual(order.voucher.discount.rate, 0.5)
+        self.assertIsNone(order.voucher.discount.amount)
+
+    def test_api_admin_orders_create_with_discount_amount(self):
+        """An admin should be able to create an order with a fixed amount discount."""
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        organization = offering.organizations.first()
+
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "organization_id": str(organization.id),
+                "discount_type": "amount",
+                "discount_value": 150,
+            },
+            content_type="application/json",
+        )
+
+        self.assertStatusCodeEqual(response, HTTPStatus.CREATED)
+        order = models.Order.objects.get(id=response.json()["id"])
+        self.assertEqual(order.state, enums.ORDER_STATE_TO_OWN)
+        self.assertEqual(order.nature, enums.ORDER_NATURE_B2C)
+        self.assertIsNotNone(order.voucher)
+        self.assertIsNone(order.voucher.discount.rate)
+        self.assertEqual(order.voucher.discount.amount, 150)
+
+    def test_api_admin_orders_create_with_discount_rate_over_100(self):
+        """A rate discount value above 100 should be rejected."""
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "discount_type": "rate",
+                "discount_value": 150,
+            },
+            content_type="application/json",
+        )
+        self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
+        self.assertIn("discount_value", response.json())
+
+    def test_api_admin_orders_create_with_discount_rate_zero(self):
+        """A rate discount value of 0 should be rejected."""
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "discount_type": "rate",
+                "discount_value": 0,
+            },
+            content_type="application/json",
+        )
+        self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
+        self.assertIn("discount_value", response.json())
+
+    def test_api_admin_orders_create_with_discount_amount_decimal(self):
+        """A non-integer amount discount should be rejected."""
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "discount_type": "amount",
+                "discount_value": 10.5,
+            },
+            content_type="application/json",
+        )
+        self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
+        self.assertIn("discount_value", response.json())
+
+    def test_api_admin_orders_create_with_discount_amount_negative(self):
+        """A negative amount discount should be rejected."""
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "discount_type": "amount",
+                "discount_value": -10,
+            },
+            content_type="application/json",
+        )
+        self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
+        self.assertIn("discount_value", response.json())
+
+    def test_api_admin_orders_create_with_discount_type_without_value(self):
+        """Providing discount_type without discount_value should be rejected."""
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "discount_type": "rate",
+            },
+            content_type="application/json",
+        )
+        self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)

--- a/src/backend/joanie/tests/core/api/admin/orders/test_create.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_create.py
@@ -2,6 +2,8 @@
 
 from http import HTTPStatus
 
+from waffle.testutils import override_switch
+
 from joanie.core import enums, factories, models
 from joanie.tests.base import BaseAPITestCase
 
@@ -111,6 +113,7 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertFalse(order.voucher.multiple_use)
         self.assertFalse(order.voucher.multiple_users)
 
+    @override_switch("admin_order_custom_discount", active=True)
     def test_api_admin_orders_create_with_discount_rate(self):
         """An admin should be able to create an order with a custom rate discount."""
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
@@ -139,6 +142,7 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertEqual(order.voucher.discount.rate, 0.5)
         self.assertIsNone(order.voucher.discount.amount)
 
+    @override_switch("admin_order_custom_discount", active=True)
     def test_api_admin_orders_create_with_discount_amount(self):
         """An admin should be able to create an order with a fixed amount discount."""
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
@@ -167,6 +171,7 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertIsNone(order.voucher.discount.rate)
         self.assertEqual(order.voucher.discount.amount, 150)
 
+    @override_switch("admin_order_custom_discount", active=True)
     def test_api_admin_orders_create_with_discount_rate_over_100(self):
         """A rate discount value above 100 should be rejected."""
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
@@ -186,6 +191,7 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
         self.assertIn("discount_value", response.json())
 
+    @override_switch("admin_order_custom_discount", active=True)
     def test_api_admin_orders_create_with_discount_rate_zero(self):
         """A rate discount value of 0 should be rejected."""
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
@@ -205,6 +211,7 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
         self.assertIn("discount_value", response.json())
 
+    @override_switch("admin_order_custom_discount", active=True)
     def test_api_admin_orders_create_with_discount_amount_decimal(self):
         """A non-integer amount discount should be rejected."""
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
@@ -224,6 +231,7 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
         self.assertIn("discount_value", response.json())
 
+    @override_switch("admin_order_custom_discount", active=True)
     def test_api_admin_orders_create_with_discount_amount_negative(self):
         """A negative amount discount should be rejected."""
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
@@ -243,6 +251,7 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
         self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
         self.assertIn("discount_value", response.json())
 
+    @override_switch("admin_order_custom_discount", active=True)
     def test_api_admin_orders_create_with_discount_type_without_value(self):
         """Providing discount_type without discount_value should be rejected."""
         admin = factories.UserFactory(is_staff=True, is_superuser=True)
@@ -259,3 +268,26 @@ class OrdersAdminApiCreateTestCase(BaseAPITestCase):
             content_type="application/json",
         )
         self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
+
+    def test_api_admin_orders_create_with_discount_rejected_when_switch_off(self):
+        """
+        Submitting custom discount fields while the
+        admin_order_custom_discount switch is off should be rejected.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        offering = factories.OfferingFactory()
+        response = self.client.post(
+            "/api/v1.0/admin/orders/",
+            data={
+                "product_id": str(offering.product.id),
+                "course_code": offering.course.code,
+                "organization_id": str(offering.organizations.first().id),
+                "discount_type": "rate",
+                "discount_value": 50,
+            },
+            content_type="application/json",
+        )
+        self.assertStatusCodeEqual(response, HTTPStatus.BAD_REQUEST)
+        self.assertIn("Custom discount is not enabled.", str(response.json()))

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -9285,6 +9285,14 @@
                         "format": "uuid",
                         "description": "primary key for the record as UUID",
                         "nullable": true
+                    },
+                    "discount_type": {
+                        "$ref": "#/components/schemas/DiscountTypeEnum"
+                    },
+                    "discount_value": {
+                        "type": "string",
+                        "format": "decimal",
+                        "pattern": "^-?\\d{0,8}(?:\\.\\d{0,2})?$"
                     }
                 },
                 "required": [
@@ -10934,6 +10942,14 @@
                 ],
                 "type": "string",
                 "description": "* `owner` - owner\n* `administrator` - administrator\n* `instructor` - instructor\n* `manager` - manager"
+            },
+            "DiscountTypeEnum": {
+                "enum": [
+                    "rate",
+                    "amount"
+                ],
+                "type": "string",
+                "description": "* `rate` - rate\n* `amount` - amount"
             },
             "EnrollmentStateEnum": {
                 "enum": [

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -3036,6 +3036,13 @@
                 "parameters": [
                     {
                         "in": "query",
+                        "name": "has_deep_links",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
                         "name": "ids",
                         "schema": {
                             "type": "string",

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "django-redis==6.0.0",
     "django-storages==1.14.3",
     "django-viewflow==2.2.15",
+    "django-waffle==5.0.0",
     "Django<5",
     "djangorestframework-simplejwt==5.5.1",
     "djangorestframework==3.16.1",

--- a/src/frontend/admin/src/components/templates/offerings/inputs/search/OfferingSearch.tsx
+++ b/src/frontend/admin/src/components/templates/offerings/inputs/search/OfferingSearch.tsx
@@ -23,10 +23,14 @@ const getOfferingLabel = (offering: Maybe<Offering>): string => {
   return `${offering.product.title} — ${offering.course.title}`;
 };
 
-export function OfferingSearch(props: RHFAutocompleteSearchProps<Offering>) {
+type Props = RHFAutocompleteSearchProps<Offering> & {
+  filters?: Record<string, unknown>;
+};
+
+export function OfferingSearch({ filters, ...props }: Props) {
   const intl = useIntl();
   const [query, setQuery] = useState("");
-  const offerings = useOfferings({ query });
+  const offerings = useOfferings({ query, ...filters });
 
   return (
     <RHFSearch

--- a/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.spec.tsx
+++ b/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.spec.tsx
@@ -9,6 +9,7 @@ import { OrderFactory } from "@/services/factories/orders";
 import { buildApiUrl } from "@/services/http/HttpService";
 import { offeringsRoutes } from "@/services/repositories/offering/OfferingRepository";
 import { orderRoutes } from "@/services/repositories/orders/OrderRepository";
+import { waffleRoutes } from "@/services/repositories/waffle/WaffleRepository";
 import { OrderCreateForm } from "@/components/templates/orders/form/OrderCreateForm";
 import { TestingWrapper } from "@/components/testing/TestingWrapper";
 
@@ -30,6 +31,18 @@ describe("<OrderCreateForm />", () => {
 
   beforeEach(() => {
     server.use(
+      http.get(buildApiUrl(waffleRoutes.getStatus), () => {
+        return HttpResponse.json({
+          flags: {},
+          switches: {
+            admin_order_custom_discount: {
+              is_active: true,
+              last_modified: "2026-04-27T12:00:00Z",
+            },
+          },
+          samples: {},
+        });
+      }),
       http.get(buildApiUrl(offeringsRoutes.getAll()), () => {
         return HttpResponse.json({
           count: 2,

--- a/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.spec.tsx
+++ b/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.spec.tsx
@@ -117,4 +117,103 @@ describe("<OrderCreateForm />", () => {
     await screen.findByRole("button", { name: "Submit" });
     expect(afterSubmit).toHaveBeenCalledWith(createdOrder);
   });
+
+  it("shows the full discount checkbox checked by default and hides discount fields", async () => {
+    render(<OrderCreateForm />, { wrapper: TestingWrapper });
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Full discount (100%)",
+    });
+    expect(checkbox).toBeChecked();
+    expect(screen.queryByLabelText("Value")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Type")).not.toBeInTheDocument();
+  });
+
+  it("shows discount fields when full discount checkbox is unchecked", async () => {
+    render(<OrderCreateForm />, { wrapper: TestingWrapper });
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Full discount (100%)",
+    });
+    await userEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    await screen.findByLabelText("Value");
+    await screen.findByLabelText("Type");
+  });
+
+  it("hides discount fields when full discount checkbox is re-checked", async () => {
+    render(<OrderCreateForm />, { wrapper: TestingWrapper });
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Full discount (100%)",
+    });
+    await userEvent.click(checkbox);
+    await screen.findByLabelText("Value");
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+    expect(screen.queryByLabelText("Value")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Type")).not.toBeInTheDocument();
+  });
+
+  it("sends discount_type and discount_value when full discount is unchecked", async () => {
+    const createdOrder = OrderFactory();
+    let capturedBody: any;
+    server.use(
+      http.post(buildApiUrl(orderRoutes.create()), async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(createdOrder, { status: 201 });
+      }),
+    );
+
+    const afterSubmit = jest.fn();
+    render(<OrderCreateForm afterSubmit={afterSubmit} />, {
+      wrapper: TestingWrapper,
+    });
+
+    const combobox = await screen.findByRole("combobox", { name: "Offering" });
+    await userEvent.click(combobox);
+    await userEvent.click(
+      await screen.findByText("Single Org Product — Single Org Course"),
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Full discount (100%)",
+    });
+    await userEvent.click(checkbox);
+
+    const valueInput = await screen.findByLabelText("Value");
+    await userEvent.type(valueInput, "50");
+
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    await screen.findByRole("button", { name: "Submit" });
+
+    expect(afterSubmit).toHaveBeenCalled();
+    expect(capturedBody.discount_type).toBe("amount");
+    expect(capturedBody.discount_value).toBe(50);
+  });
+
+  it("does not send discount fields when full discount is checked", async () => {
+    const createdOrder = OrderFactory();
+    let capturedBody: any;
+    server.use(
+      http.post(buildApiUrl(orderRoutes.create()), async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(createdOrder, { status: 201 });
+      }),
+    );
+
+    const afterSubmit = jest.fn();
+    render(<OrderCreateForm afterSubmit={afterSubmit} />, {
+      wrapper: TestingWrapper,
+    });
+
+    const combobox = await screen.findByRole("combobox", { name: "Offering" });
+    await userEvent.click(combobox);
+    await userEvent.click(
+      await screen.findByText("Single Org Product — Single Org Course"),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    await screen.findByRole("button", { name: "Submit" });
+
+    expect(afterSubmit).toHaveBeenCalled();
+    expect(capturedBody.discount_type).toBeUndefined();
+    expect(capturedBody.discount_value).toBeUndefined();
+  });
 });

--- a/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.tsx
+++ b/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.tsx
@@ -9,10 +9,12 @@ import Typography from "@mui/material/Typography";
 import { defineMessages, useIntl } from "react-intl";
 import { RHFProvider } from "@/components/presentational/hook-form/RHFProvider";
 import { RHFSelect } from "@/components/presentational/hook-form/RHFSelect";
+import { RHFCheckbox } from "@/components/presentational/hook-form/RHFCheckbox";
+import { RHFTextField } from "@/components/presentational/hook-form/RHFTextField";
 import { OfferingSearch } from "@/components/templates/offerings/inputs/search/OfferingSearch";
 import { Offering } from "@/services/api/models/Offerings";
 import { Organization } from "@/services/api/models/Organization";
-import { OrderListItem } from "@/services/api/models/Order";
+import { DTOOrderCreate, OrderListItem } from "@/services/api/models/Order";
 import { useOrders } from "@/hooks/useOrders/useOrders";
 
 const messages = defineMessages({
@@ -31,31 +33,115 @@ const messages = defineMessages({
     defaultMessage: "Organization",
     description: "Label for the organization field in the order create form",
   },
+  fullDiscountLabel: {
+    id: "components.templates.orders.form.fullDiscountLabel",
+    defaultMessage: "Full discount (100%)",
+    description:
+      "Label for the full discount checkbox in the order create form",
+  },
+  discountSubtitle: {
+    id: "components.templates.orders.form.discountSubtitle",
+    defaultMessage: "Discount",
+    description: "Subtitle of the discount section of the order create form",
+  },
+  discountValueLabel: {
+    id: "components.templates.orders.form.discountValueLabel",
+    defaultMessage: "Value",
+    description: "Label for the discount value field in the order create form",
+  },
+  discountTypeLabel: {
+    id: "components.templates.orders.form.discountTypeLabel",
+    defaultMessage: "Type",
+    description: "Label for the discount type field in the order create form",
+  },
+  discountTypeRate: {
+    id: "components.templates.orders.form.discountTypeRate",
+    defaultMessage: "Percentage",
+    description: "Option label for percentage discount type",
+  },
+  discountTypeAmount: {
+    id: "components.templates.orders.form.discountTypeAmount",
+    defaultMessage: "Fixed amount",
+    description: "Option label for fixed amount discount type",
+  },
+  discountValuePositiveError: {
+    id: "components.templates.orders.form.discountValuePositiveError",
+    defaultMessage: "Value must be greater than 0",
+    description: "Error message when discount value is not a positive number",
+  },
+  discountRateMaxError: {
+    id: "components.templates.orders.form.discountRateMaxError",
+    defaultMessage: "Percentage must be between 1 and 100",
+    description: "Error message when percentage discount is out of range",
+  },
+  discountAmountIntegerError: {
+    id: "components.templates.orders.form.discountAmountIntegerError",
+    defaultMessage: "Amount must be a positive whole number",
+    description: "Error message when fixed amount discount is not an integer",
+  },
 });
 
 type FormValues = {
   offering: Offering | null;
   organization: Organization | null;
+  fullDiscount: boolean;
+  discountType: "rate" | "amount";
+  discountValue: number | "";
 };
 
 type Props = {
   afterSubmit?: (order: OrderListItem) => void;
 };
 
-const RegisterSchema = Yup.object().shape({
-  offering: Yup.mixed<Offering>().required(),
-  organization: Yup.mixed<Organization>()
-    .nullable()
-    .when("offering", {
-      is: (offering: Offering | null) =>
-        !!offering && offering.organizations.length > 1,
-      then: (schema) => schema.required(),
-      otherwise: (schema) => schema.notRequired(),
-    }),
-});
-
 export function OrderCreateForm({ afterSubmit }: Props) {
   const intl = useIntl();
+
+  const RegisterSchema = Yup.object().shape({
+    offering: Yup.mixed<Offering>().required(),
+    organization: Yup.mixed<Organization>()
+      .nullable()
+      .when("offering", {
+        is: (offering: Offering | null) =>
+          !!offering && offering.organizations.length > 1,
+        then: (schema) => schema.required(),
+        otherwise: (schema) => schema.notRequired(),
+      }),
+    fullDiscount: Yup.boolean().required(),
+    discountType: Yup.string().oneOf(["rate", "amount"]).required(),
+    discountValue: Yup.mixed()
+      .when("fullDiscount", {
+        is: false,
+        then: (schema) =>
+          schema
+            .required()
+            .test(
+              "is-positive",
+              intl.formatMessage(messages.discountValuePositiveError),
+              (value) => Number(value) > 0,
+            ),
+        otherwise: (schema) => schema.nullable(),
+      })
+      .when(["fullDiscount", "discountType"], {
+        is: (fullDiscount: boolean, discountType: string) =>
+          !fullDiscount && discountType === "rate",
+        then: (schema) =>
+          schema.test(
+            "rate-max",
+            intl.formatMessage(messages.discountRateMaxError),
+            (value) => Number(value) <= 100,
+          ),
+      })
+      .when(["fullDiscount", "discountType"], {
+        is: (fullDiscount: boolean, discountType: string) =>
+          !fullDiscount && discountType === "amount",
+        then: (schema) =>
+          schema.test(
+            "amount-integer",
+            intl.formatMessage(messages.discountAmountIntegerError),
+            (value) => Number.isInteger(Number(value)),
+          ),
+      }),
+  });
   const ordersQuery = useOrders({}, { enabled: false });
 
   const methods = useForm<FormValues>({
@@ -63,10 +149,17 @@ export function OrderCreateForm({ afterSubmit }: Props) {
     defaultValues: {
       offering: null,
       organization: null,
+      fullDiscount: true,
+      discountType: "amount",
+      discountValue: "",
     },
   });
 
   const offering = useWatch({ control: methods.control, name: "offering" });
+  const fullDiscount = useWatch({
+    control: methods.control,
+    name: "fullDiscount",
+  });
   const multipleOrgs = offering !== null && offering.organizations.length > 1;
 
   useEffect(() => {
@@ -78,16 +171,20 @@ export function OrderCreateForm({ afterSubmit }: Props) {
   }, [offering]);
 
   const onSubmit = (values: FormValues) => {
-    ordersQuery.methods.create(
-      {
-        product_id: values.offering!.product.id,
-        course_code: values.offering!.course.code,
-        organization_id: values.organization?.id ?? null,
-      },
-      {
-        onSuccess: (data) => afterSubmit?.(data),
-      },
-    );
+    const payload: DTOOrderCreate = {
+      product_id: values.offering!.product.id,
+      course_code: values.offering!.course.code,
+      organization_id: values.organization?.id ?? null,
+    };
+
+    if (!values.fullDiscount && values.discountValue !== "") {
+      payload.discount_type = values.discountType;
+      payload.discount_value = Number(values.discountValue);
+    }
+
+    ordersQuery.methods.create(payload, {
+      onSuccess: (data) => afterSubmit?.(data),
+    });
   };
 
   return (
@@ -127,6 +224,47 @@ export function OrderCreateForm({ afterSubmit }: Props) {
                 }}
               />
             </Grid>
+          )}
+
+          <Grid size={12}>
+            <Typography variant="subtitle2">
+              {intl.formatMessage(messages.discountSubtitle)}
+            </Typography>
+          </Grid>
+
+          <Grid size={12}>
+            <RHFCheckbox
+              name="fullDiscount"
+              label={intl.formatMessage(messages.fullDiscountLabel)}
+            />
+          </Grid>
+
+          {!fullDiscount && (
+            <>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <RHFTextField
+                  name="discountValue"
+                  type="number"
+                  label={intl.formatMessage(messages.discountValueLabel)}
+                />
+              </Grid>
+              <Grid size={{ xs: 12, md: 6 }}>
+                <RHFSelect
+                  name="discountType"
+                  label={intl.formatMessage(messages.discountTypeLabel)}
+                  options={[
+                    {
+                      label: intl.formatMessage(messages.discountTypeRate),
+                      value: "rate",
+                    },
+                    {
+                      label: intl.formatMessage(messages.discountTypeAmount),
+                      value: "amount",
+                    },
+                  ]}
+                />
+              </Grid>
+            </>
           )}
         </Grid>
       </RHFProvider>

--- a/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.tsx
+++ b/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.tsx
@@ -209,6 +209,9 @@ export function OrderCreateForm({ afterSubmit }: Props) {
             <OfferingSearch
               name="offering"
               label={intl.formatMessage(messages.offeringLabel)}
+              filters={
+                customDiscountEnabled ? undefined : { has_deep_links: true }
+              }
             />
           </Grid>
 

--- a/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.tsx
+++ b/src/frontend/admin/src/components/templates/orders/form/OrderCreateForm.tsx
@@ -16,6 +16,7 @@ import { Offering } from "@/services/api/models/Offerings";
 import { Organization } from "@/services/api/models/Organization";
 import { DTOOrderCreate, OrderListItem } from "@/services/api/models/Order";
 import { useOrders } from "@/hooks/useOrders/useOrders";
+import { useWaffleSwitch } from "@/hooks/useWaffle/useWaffle";
 
 const messages = defineMessages({
   generalSubtitle: {
@@ -95,6 +96,7 @@ type Props = {
 
 export function OrderCreateForm({ afterSubmit }: Props) {
   const intl = useIntl();
+  const customDiscountEnabled = useWaffleSwitch("admin_order_custom_discount");
 
   const RegisterSchema = Yup.object().shape({
     offering: Yup.mixed<Offering>().required(),
@@ -226,44 +228,50 @@ export function OrderCreateForm({ afterSubmit }: Props) {
             </Grid>
           )}
 
-          <Grid size={12}>
-            <Typography variant="subtitle2">
-              {intl.formatMessage(messages.discountSubtitle)}
-            </Typography>
-          </Grid>
-
-          <Grid size={12}>
-            <RHFCheckbox
-              name="fullDiscount"
-              label={intl.formatMessage(messages.fullDiscountLabel)}
-            />
-          </Grid>
-
-          {!fullDiscount && (
+          {customDiscountEnabled && (
             <>
-              <Grid size={{ xs: 12, md: 6 }}>
-                <RHFTextField
-                  name="discountValue"
-                  type="number"
-                  label={intl.formatMessage(messages.discountValueLabel)}
+              <Grid size={12}>
+                <Typography variant="subtitle2">
+                  {intl.formatMessage(messages.discountSubtitle)}
+                </Typography>
+              </Grid>
+
+              <Grid size={12}>
+                <RHFCheckbox
+                  name="fullDiscount"
+                  label={intl.formatMessage(messages.fullDiscountLabel)}
                 />
               </Grid>
-              <Grid size={{ xs: 12, md: 6 }}>
-                <RHFSelect
-                  name="discountType"
-                  label={intl.formatMessage(messages.discountTypeLabel)}
-                  options={[
-                    {
-                      label: intl.formatMessage(messages.discountTypeRate),
-                      value: "rate",
-                    },
-                    {
-                      label: intl.formatMessage(messages.discountTypeAmount),
-                      value: "amount",
-                    },
-                  ]}
-                />
-              </Grid>
+
+              {!fullDiscount && (
+                <>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <RHFTextField
+                      name="discountValue"
+                      type="number"
+                      label={intl.formatMessage(messages.discountValueLabel)}
+                    />
+                  </Grid>
+                  <Grid size={{ xs: 12, md: 6 }}>
+                    <RHFSelect
+                      name="discountType"
+                      label={intl.formatMessage(messages.discountTypeLabel)}
+                      options={[
+                        {
+                          label: intl.formatMessage(messages.discountTypeRate),
+                          value: "rate",
+                        },
+                        {
+                          label: intl.formatMessage(
+                            messages.discountTypeAmount,
+                          ),
+                          value: "amount",
+                        },
+                      ]}
+                    />
+                  </Grid>
+                </>
+              )}
             </>
           )}
         </Grid>

--- a/src/frontend/admin/src/hooks/useWaffle/useWaffle.tsx
+++ b/src/frontend/admin/src/hooks/useWaffle/useWaffle.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { WaffleRepository } from "@/services/repositories/waffle/WaffleRepository";
+
+export const useWaffle = () => {
+  return useQuery({
+    queryKey: ["waffle"],
+    staleTime: Infinity,
+    gcTime: Infinity,
+    queryFn: async () => WaffleRepository.getStatus(),
+  });
+};
+
+export const useWaffleSwitch = (name: string): boolean => {
+  const { data } = useWaffle();
+  return data?.switches?.[name]?.is_active ?? false;
+};

--- a/src/frontend/admin/src/services/api/models/Order.ts
+++ b/src/frontend/admin/src/services/api/models/Order.ts
@@ -119,6 +119,8 @@ export type DTOOrderCreate = {
   product_id: string;
   course_code?: string | null;
   organization_id?: string | null;
+  discount_type?: "rate" | "amount";
+  discount_value?: number;
 };
 
 export enum OrderInvoiceTypesEnum {

--- a/src/frontend/admin/src/services/api/models/Waffle.ts
+++ b/src/frontend/admin/src/services/api/models/Waffle.ts
@@ -1,0 +1,10 @@
+export type WaffleEntry = {
+  is_active: boolean;
+  last_modified: string;
+};
+
+export type WaffleStatus = {
+  flags: Record<string, WaffleEntry>;
+  switches: Record<string, WaffleEntry>;
+  samples: Record<string, WaffleEntry>;
+};

--- a/src/frontend/admin/src/services/repositories/waffle/WaffleRepository.ts
+++ b/src/frontend/admin/src/services/repositories/waffle/WaffleRepository.ts
@@ -1,0 +1,14 @@
+import { checkStatus, fetchApi } from "@/services/http/HttpService";
+import { WaffleStatus } from "@/services/api/models/Waffle";
+
+export const waffleRoutes = {
+  getStatus: "/waffle_status/",
+};
+
+export const WaffleRepository = class WaffleRepository {
+  static getStatus(): Promise<WaffleStatus> {
+    return fetchApi(waffleRoutes.getStatus, { method: "GET" }).then(
+      checkStatus,
+    );
+  }
+};

--- a/src/frontend/admin/src/tests/orders/orders.test.e2e.ts
+++ b/src/frontend/admin/src/tests/orders/orders.test.e2e.ts
@@ -677,6 +677,24 @@ test.describe("Order create", () => {
   let offerings: Offering[];
 
   test.beforeEach(async ({ page }) => {
+    await page.route(
+      "http://localhost:8071/api/v1.0/admin/waffle_status/",
+      async (route) => {
+        await route.fulfill({
+          json: {
+            flags: {},
+            switches: {
+              admin_order_custom_discount: {
+                is_active: true,
+                last_modified: "2026-04-27T12:00:00Z",
+              },
+            },
+            samples: {},
+          },
+        });
+      },
+    );
+
     offerings = [OfferingFactory()];
     offerings[0].product.title = "Test Product";
     offerings[0].course.title = "Test Course";

--- a/src/frontend/admin/src/tests/orders/orders.test.e2e.ts
+++ b/src/frontend/admin/src/tests/orders/orders.test.e2e.ts
@@ -6,6 +6,7 @@ import {
   mockPlaywrightCrud,
 } from "@/tests/useResourceHandler";
 import {
+  DTOOrderCreate,
   OrderInvoiceTypesEnum,
   OrderListItem,
   OrderStatesEnum,
@@ -24,6 +25,12 @@ import {
   orderNatureMessages,
   orderStatesMessages,
 } from "@/components/templates/orders/view/translations";
+import {
+  OfferingFactory,
+  Offering,
+  DTOOffering,
+} from "@/services/api/models/Offerings";
+import { OrderFactory } from "@/services/factories/orders";
 
 const url = "http://localhost:8071/api/v1.0/admin/orders/";
 const catchIdRegex = getUrlCatchIdRegex(url);
@@ -663,5 +670,181 @@ test.describe("Order list", () => {
       .allInnerTexts();
     expect(titles).not.toHaveLength(0);
     expect(titles).toEqual(titles.toSorted().reverse());
+  });
+});
+
+test.describe("Order create", () => {
+  let offerings: Offering[];
+
+  test.beforeEach(async ({ page }) => {
+    offerings = [OfferingFactory()];
+    offerings[0].product.title = "Test Product";
+    offerings[0].course.title = "Test Course";
+    offerings[0].organizations = [offerings[0].organizations[0]];
+
+    await mockPlaywrightCrud<Offering, DTOOffering>({
+      data: offerings,
+      routeUrl: "http://localhost:8071/api/v1.0/admin/offerings/",
+      page,
+    });
+  });
+
+  test("Full discount checkbox is checked by default and hides discount fields", async ({
+    page,
+  }) => {
+    await page.goto(PATH_ADMIN.orders.create);
+    const checkbox = page.getByRole("checkbox", {
+      name: "Full discount (100%)",
+    });
+    await expect(checkbox).toBeChecked();
+    await expect(page.getByLabel("Value")).not.toBeVisible();
+    await expect(page.getByLabel("Type", { exact: true })).not.toBeVisible();
+  });
+
+  test("Unchecking full discount shows value and type fields", async ({
+    page,
+  }) => {
+    await page.goto(PATH_ADMIN.orders.create);
+    const checkbox = page.getByRole("checkbox", {
+      name: "Full discount (100%)",
+    });
+    await checkbox.click();
+    await expect(checkbox).not.toBeChecked();
+    await expect(page.getByLabel("Value")).toBeVisible();
+    await expect(page.getByLabel("Type", { exact: true })).toBeVisible();
+  });
+
+  test("Re-checking full discount hides discount fields", async ({ page }) => {
+    await page.goto(PATH_ADMIN.orders.create);
+    const checkbox = page.getByRole("checkbox", {
+      name: "Full discount (100%)",
+    });
+    await checkbox.click();
+    await expect(page.getByLabel("Value")).toBeVisible();
+    await checkbox.click();
+    await expect(checkbox).toBeChecked();
+    await expect(page.getByLabel("Value")).not.toBeVisible();
+  });
+
+  test("Submit with full discount does not send discount fields", async ({
+    page,
+  }) => {
+    const createdOrder = OrderFactory();
+    let capturedBody: DTOOrderCreate | undefined;
+
+    await page.route(
+      "http://localhost:8071/api/v1.0/admin/orders/",
+      async (route, request) => {
+        if (request.method() === "POST") {
+          capturedBody = request.postDataJSON();
+          await route.fulfill({ json: createdOrder, status: 201 });
+        } else {
+          await route.fallback();
+        }
+      },
+    );
+
+    await page.goto(PATH_ADMIN.orders.create);
+
+    const combobox = page.getByRole("combobox", { name: "Offering" });
+    await combobox.click();
+    await page.getByText("Test Product — Test Course").click();
+    await Promise.all([
+      page.waitForResponse(
+        (res) =>
+          res.url().includes("/api/v1.0/admin/orders/") &&
+          res.request().method() === "POST",
+      ),
+      page.getByRole("button", { name: "Submit" }).click(),
+    ]);
+
+    expect(capturedBody).toBeDefined();
+    expect(capturedBody!.discount_type).toBeUndefined();
+    expect(capturedBody!.discount_value).toBeUndefined();
+  });
+
+  test("Submit with fixed amount discount sends discount fields", async ({
+    page,
+  }) => {
+    const createdOrder = OrderFactory();
+    let capturedBody: DTOOrderCreate | undefined;
+
+    await page.route(
+      "http://localhost:8071/api/v1.0/admin/orders/",
+      async (route, request) => {
+        if (request.method() === "POST") {
+          capturedBody = request.postDataJSON();
+          await route.fulfill({ json: createdOrder, status: 201 });
+        } else {
+          await route.fallback();
+        }
+      },
+    );
+
+    await page.goto(PATH_ADMIN.orders.create);
+
+    const combobox = page.getByRole("combobox", { name: "Offering" });
+    await combobox.click();
+    await page.getByText("Test Product — Test Course").click();
+
+    await page.getByRole("checkbox", { name: "Full discount (100%)" }).click();
+    await page.getByLabel("Value").fill("150");
+    await Promise.all([
+      page.waitForResponse(
+        (res) =>
+          res.url().includes("/api/v1.0/admin/orders/") &&
+          res.request().method() === "POST",
+      ),
+      page.getByRole("button", { name: "Submit" }).click(),
+    ]);
+
+    expect(capturedBody).toBeDefined();
+    expect(capturedBody!.discount_type).toBe("amount");
+    expect(capturedBody!.discount_value).toBe(150);
+  });
+
+  test("Submit with percentage discount sends correct discount type", async ({
+    page,
+  }) => {
+    const createdOrder = OrderFactory();
+    let capturedBody: DTOOrderCreate | undefined;
+
+    await page.route(
+      "http://localhost:8071/api/v1.0/admin/orders/",
+      async (route, request) => {
+        if (request.method() === "POST") {
+          capturedBody = request.postDataJSON();
+          await route.fulfill({ json: createdOrder, status: 201 });
+        } else {
+          await route.fallback();
+        }
+      },
+    );
+
+    await page.goto(PATH_ADMIN.orders.create);
+
+    const combobox = page.getByRole("combobox", { name: "Offering" });
+    await combobox.click();
+    await page.getByText("Test Product — Test Course").click();
+
+    await page.getByRole("checkbox", { name: "Full discount (100%)" }).click();
+
+    // Change type to percentage
+    await page.getByLabel("Type", { exact: true }).click();
+    await page.getByRole("option", { name: "Percentage" }).click();
+
+    await page.getByLabel("Value").fill("50");
+    await Promise.all([
+      page.waitForResponse(
+        (res) =>
+          res.url().includes("/api/v1.0/admin/orders/") &&
+          res.request().method() === "POST",
+      ),
+      page.getByRole("button", { name: "Submit" }).click(),
+    ]);
+
+    expect(capturedBody).toBeDefined();
+    expect(capturedBody!.discount_type).toBe("rate");
+    expect(capturedBody!.discount_value).toBe(50);
   });
 });


### PR DESCRIPTION
## Purpose

Let admins create standalone orders with a custom discount
(percentage or fixed amount), gated behind a feature flag so it
can be toggled per environment without redeploying. When off,
the form falls back to the existing 100%-voucher flow restricted
to CPF-eligible offerings.

## Proposal

- [x] Custom discount on `AdminOrderCreateSerializer` and on the
  order creation form (optional `discount_type` / `discount_value`).
- [x] Introduce `django-waffle` and expose its status under
  `/api/v1.0/admin/waffle_status/`; consume it on the admin with
  `useWaffleSwitch`.
- [x] Gate the custom discount behind the
  `admin_order_custom_discount` switch (off by default, created
  via data migration). Backend rejects the fields when off; frontend
  hides the discount section.
- [x] Add a `has_deep_links` filter on the admin offering API and
  apply it from the order creation form when the switch is off, so
  only CPF-eligible offerings show up.