### PR TITLE
🔧(frontend) add yarn fixed version to volta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Update Volta configuration with yarn fixed version
+
 ## [3.3.0] - 2026-04-09
 
 ### Added

--- a/src/frontend/admin/package.json
+++ b/src/frontend/admin/package.json
@@ -113,6 +113,7 @@
     "workerDirectory": "public"
   },
   "volta": {
-    "node": "20.18.2"
+    "node": "20.18.2",
+    "yarn": "1.22.22"
   }
 }


### PR DESCRIPTION
## Purpose

Yarn version is now fixed to `1.22.22` in frontend admin `package.json`.

