### PR TITLE
✨(backend) add --owned-batch-orders option to create_dev_data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,12 +148,17 @@ demo-dev: ## flush db then create a dataset for dev purpose
 	@$(MANAGE) generate_jwt_tokens
 .PHONY: demo-dev
 
+ifeq (dev-data,$(firstword $(MAKECMDGOALS)))
+  DEV_DATA_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(DEV_DATA_ARGS):;@:)
+endif
+
 dev-data: ## flush db then create a simpler dataset for dev purpose
 	@echo "$(BOLD)Flush database$(RESET)"
 	@$(MANAGE) flush --no-input
 	@${MAKE} superuser
 	@$(MANAGE) set_default_site --domain=$(LOCALTUNNEL_DOMAIN) --name=$(LOCALTUNNEL_DOMAIN)
-	@$(MANAGE) create_dev_data ${ARGS}
+	@$(MANAGE) create_dev_data $(DEV_DATA_ARGS)
 	@$(MANAGE) generate_jwt_tokens
 .PHONY: dev-data
 

--- a/src/backend/joanie/demo/management/commands/create_dev_data.py
+++ b/src/backend/joanie/demo/management/commands/create_dev_data.py
@@ -41,6 +41,12 @@ class Command(BaseCommand):
             default=False,
             help="Create a bunch of batch orders.",
         )
+        parser.add_argument(
+            "--owned-batch-orders",
+            action="store_true",
+            default=False,
+            help="Assign batch orders to the connected user (user10).",
+        )
 
     def handle(self, *args, **options):
         def log(message):
@@ -53,4 +59,5 @@ class Command(BaseCommand):
             create_credential=options.get("credential"),
             create_credential_discount=options.get("credential_discount"),
             create_bunch_of_batch_orders=options.get("create_bunch_of_batch_orders"),
+            owned_batch_orders=options.get("owned_batch_orders"),
         )

--- a/src/backend/joanie/tests/testing_utils.py
+++ b/src/backend/joanie/tests/testing_utils.py
@@ -727,6 +727,7 @@ class Demo:
         create_credential=False,
         create_credential_discount=False,
         create_bunch_of_batch_orders=False,
+        owned_batch_orders=False,
     ):
         """Generate simple fake data."""
         translation.activate("en-us")
@@ -778,19 +779,6 @@ class Demo:
         payment_factories.CreditCardFactory(owners=[second_student_user])
         factories.UserAddressFactory(owner=second_student_user)
 
-        # user10 is the default user used to connect on Richie
-        batch_order_owner = factories.UserFactory(
-            username="user10",
-            email="benjamin59@example.org",
-            first_name="Ronald",
-            last_name="Johnson",
-        )
-        models.OrganizationAccess.objects.create(
-            user=batch_order_owner,
-            organization=organization,
-            role=enums.OWNER,
-        )
-
         discount = factories.DiscountFactory(
             amount=10,
             rate=None,
@@ -802,12 +790,15 @@ class Demo:
             multiple_users=True,
         )
 
-        if (
-            not create_credential
-            and not create_certificate
-            and not create_certificate_discount
-            and not create_credential_discount
-            and not create_bunch_of_batch_orders
+        if not any(
+            [
+                create_credential,
+                create_certificate,
+                create_certificate_discount,
+                create_credential_discount,
+                create_bunch_of_batch_orders,
+                owned_batch_orders,
+            ]
         ):
             item_options = [
                 "Certificate product",
@@ -815,6 +806,7 @@ class Demo:
                 "Credential product",
                 "Credential product with discount",
                 "Bunch of batch orders",
+                "Owned batch orders",
             ]
             items = select_multiple(item_options)
             create_certificate = "Certificate product" in items
@@ -822,6 +814,23 @@ class Demo:
             create_credential = "Credential product" in items
             create_credential_discount = "Credential product with discount" in items
             create_bunch_of_batch_orders = "Bunch of batch orders" in items
+            owned_batch_orders = "Owned batch orders" in items
+
+        batch_order_owner = None
+        if owned_batch_orders:
+            create_credential = True
+            # user10 is the default user used to connect on Richie
+            batch_order_owner = factories.UserFactory(
+                username="user10",
+                email="benjamin59@example.org",
+                first_name="Ronald",
+                last_name="Johnson",
+            )
+            models.OrganizationAccess.objects.create(
+                user=batch_order_owner,
+                organization=organization,
+                role=enums.OWNER,
+            )
 
         if create_certificate:
             course = factories.CourseFactory(
@@ -979,24 +988,27 @@ class Demo:
                 product=credential_product,
             )
             credential_offering.organizations.add(second_organization)
-            batch_order = factories.BatchOrderFactory(
-                owner=batch_order_owner,
-                organization=organization,
-                state=enums.BATCH_ORDER_STATE_COMPLETED,
-                offering=credential_offering,
-                nb_seats=5,
-            )
+            batch_order_kwargs = {
+                "state": enums.BATCH_ORDER_STATE_COMPLETED,
+                "offering": credential_offering,
+                "nb_seats": 5,
+            }
+            if owned_batch_orders:
+                batch_order_kwargs["owner"] = batch_order_owner
+                batch_order_kwargs["organization"] = organization
+            batch_order = factories.BatchOrderFactory(**batch_order_kwargs)
             batch_order.generate_orders()
-            for order in batch_order.orders.all():
-                order.owner = factories.UserFactory()
-                order.save(update_fields=["owner"])
-                order.flow.update()
-            self.log(
-                f"Successfully created batch order {batch_order.id} "
-                f"(COMPLETED, {batch_order.nb_seats} seats, "
-                f"contract signed: {batch_order.contract.is_fully_signed})"
-            )
-            self.log("")
+            if owned_batch_orders:
+                for order in batch_order.orders.all():
+                    order.owner = factories.UserFactory()
+                    order.save(update_fields=["owner"])
+                    order.flow.update()
+                self.log(
+                    f"Successfully created batch order {batch_order.id} "
+                    f"(COMPLETED, {batch_order.nb_seats} seats, "
+                    f"contract signed: {batch_order.contract.is_fully_signed})"
+                )
+                self.log("")
 
             if create_bunch_of_batch_orders:
                 for state in enums.BATCH_ORDER_STATE_CHOICES:
@@ -1084,24 +1096,27 @@ class Demo:
                 discount=discount,
             )
 
-            batch_order = factories.BatchOrderFactory(
-                owner=batch_order_owner,
-                organization=organization,
-                state=enums.BATCH_ORDER_STATE_COMPLETED,
-                offering=credential_discount_offering,
-                nb_seats=5,
-            )
+            batch_order_kwargs = {
+                "state": enums.BATCH_ORDER_STATE_COMPLETED,
+                "offering": credential_discount_offering,
+                "nb_seats": 5,
+            }
+            if owned_batch_orders:
+                batch_order_kwargs["owner"] = batch_order_owner
+                batch_order_kwargs["organization"] = organization
+            batch_order = factories.BatchOrderFactory(**batch_order_kwargs)
             batch_order.generate_orders()
-            for order in batch_order.orders.all():
-                order.owner = factories.UserFactory()
-                order.save(update_fields=["owner"])
-                order.flow.update()
-            self.log(
-                f"Successfully created batch order {batch_order.id} "
-                f"(COMPLETED, {batch_order.nb_seats} seats, "
-                f"contract signed: {batch_order.contract.is_fully_signed})"
-            )
-            self.log("")
+            if owned_batch_orders:
+                for order in batch_order.orders.all():
+                    order.owner = factories.UserFactory()
+                    order.save(update_fields=["owner"])
+                    order.flow.update()
+                self.log(
+                    f"Successfully created batch order {batch_order.id} "
+                    f"(COMPLETED, {batch_order.nb_seats} seats, "
+                    f"contract signed: {batch_order.contract.is_fully_signed})"
+                )
+                self.log("")
 
             if create_bunch_of_batch_orders:
                 for state in enums.BATCH_ORDER_STATE_CHOICES:

--- a/src/backend/joanie/tests/testing_utils.py
+++ b/src/backend/joanie/tests/testing_utils.py
@@ -779,6 +779,7 @@ class Demo:
         payment_factories.CreditCardFactory(owners=[second_student_user])
         factories.UserAddressFactory(owner=second_student_user)
 
+        batch_order_owner = None
         if owned_batch_orders:
             # user10 is the default user used to connect on Richie
             batch_order_owner = factories.UserFactory(

--- a/src/backend/joanie/tests/testing_utils.py
+++ b/src/backend/joanie/tests/testing_utils.py
@@ -727,6 +727,7 @@ class Demo:
         create_credential=False,
         create_credential_discount=False,
         create_bunch_of_batch_orders=False,
+        owned_batch_orders=False,
     ):
         """Generate simple fake data."""
         translation.activate("en-us")
@@ -778,18 +779,19 @@ class Demo:
         payment_factories.CreditCardFactory(owners=[second_student_user])
         factories.UserAddressFactory(owner=second_student_user)
 
-        # user10 is the default user used to connect on Richie
-        batch_order_owner = factories.UserFactory(
-            username="user10",
-            email="benjamin59@example.org",
-            first_name="Ronald",
-            last_name="Johnson",
-        )
-        models.OrganizationAccess.objects.create(
-            user=batch_order_owner,
-            organization=organization,
-            role=enums.OWNER,
-        )
+        if owned_batch_orders:
+            # user10 is the default user used to connect on Richie
+            batch_order_owner = factories.UserFactory(
+                username="user10",
+                email="benjamin59@example.org",
+                first_name="Ronald",
+                last_name="Johnson",
+            )
+            models.OrganizationAccess.objects.create(
+                user=batch_order_owner,
+                organization=organization,
+                role=enums.OWNER,
+            )
 
         discount = factories.DiscountFactory(
             amount=10,
@@ -808,6 +810,7 @@ class Demo:
             and not create_certificate_discount
             and not create_credential_discount
             and not create_bunch_of_batch_orders
+            and not owned_batch_orders
         ):
             item_options = [
                 "Certificate product",
@@ -815,6 +818,7 @@ class Demo:
                 "Credential product",
                 "Credential product with discount",
                 "Bunch of batch orders",
+                "Owned batch orders",
             ]
             items = select_multiple(item_options)
             create_certificate = "Certificate product" in items
@@ -822,6 +826,10 @@ class Demo:
             create_credential = "Credential product" in items
             create_credential_discount = "Credential product with discount" in items
             create_bunch_of_batch_orders = "Bunch of batch orders" in items
+            owned_batch_orders = "Owned batch orders" in items
+
+        if owned_batch_orders:
+            create_credential = True
 
         if create_certificate:
             course = factories.CourseFactory(
@@ -979,24 +987,27 @@ class Demo:
                 product=credential_product,
             )
             credential_offering.organizations.add(second_organization)
-            batch_order = factories.BatchOrderFactory(
-                owner=batch_order_owner,
-                organization=organization,
-                state=enums.BATCH_ORDER_STATE_COMPLETED,
-                offering=credential_offering,
-                nb_seats=5,
-            )
+            batch_order_kwargs = {
+                "state": enums.BATCH_ORDER_STATE_COMPLETED,
+                "offering": credential_offering,
+                "nb_seats": 5,
+            }
+            if owned_batch_orders:
+                batch_order_kwargs["owner"] = batch_order_owner
+                batch_order_kwargs["organization"] = organization
+            batch_order = factories.BatchOrderFactory(**batch_order_kwargs)
             batch_order.generate_orders()
-            for order in batch_order.orders.all():
-                order.owner = factories.UserFactory()
-                order.save(update_fields=["owner"])
-                order.flow.update()
-            self.log(
-                f"Successfully created batch order {batch_order.id} "
-                f"(COMPLETED, {batch_order.nb_seats} seats, "
-                f"contract signed: {batch_order.contract.is_fully_signed})"
-            )
-            self.log("")
+            if owned_batch_orders:
+                for order in batch_order.orders.all():
+                    order.owner = factories.UserFactory()
+                    order.save(update_fields=["owner"])
+                    order.flow.update()
+                self.log(
+                    f"Successfully created batch order {batch_order.id} "
+                    f"(COMPLETED, {batch_order.nb_seats} seats, "
+                    f"contract signed: {batch_order.contract.is_fully_signed})"
+                )
+                self.log("")
 
             if create_bunch_of_batch_orders:
                 for state in enums.BATCH_ORDER_STATE_CHOICES:
@@ -1084,24 +1095,27 @@ class Demo:
                 discount=discount,
             )
 
-            batch_order = factories.BatchOrderFactory(
-                owner=batch_order_owner,
-                organization=organization,
-                state=enums.BATCH_ORDER_STATE_COMPLETED,
-                offering=credential_discount_offering,
-                nb_seats=5,
-            )
+            batch_order_kwargs = {
+                "state": enums.BATCH_ORDER_STATE_COMPLETED,
+                "offering": credential_discount_offering,
+                "nb_seats": 5,
+            }
+            if owned_batch_orders:
+                batch_order_kwargs["owner"] = batch_order_owner
+                batch_order_kwargs["organization"] = organization
+            batch_order = factories.BatchOrderFactory(**batch_order_kwargs)
             batch_order.generate_orders()
-            for order in batch_order.orders.all():
-                order.owner = factories.UserFactory()
-                order.save(update_fields=["owner"])
-                order.flow.update()
-            self.log(
-                f"Successfully created batch order {batch_order.id} "
-                f"(COMPLETED, {batch_order.nb_seats} seats, "
-                f"contract signed: {batch_order.contract.is_fully_signed})"
-            )
-            self.log("")
+            if owned_batch_orders:
+                for order in batch_order.orders.all():
+                    order.owner = factories.UserFactory()
+                    order.save(update_fields=["owner"])
+                    order.flow.update()
+                self.log(
+                    f"Successfully created batch order {batch_order.id} "
+                    f"(COMPLETED, {batch_order.nb_seats} seats, "
+                    f"contract signed: {batch_order.contract.is_fully_signed})"
+                )
+                self.log("")
 
             if create_bunch_of_batch_orders:
                 for state in enums.BATCH_ORDER_STATE_CHOICES:


### PR DESCRIPTION
## Purpose

When running `make dev-data`, batch orders are created without an explicit
owner, which makes it impossible to exercise the "owned batch orders" flow
as the user connected on Richie (user10). The code to wire user10 onto
batch orders existed but was commented out, so there was no way to opt in.

On top of that, `make dev-data` required the awkward
`ARGS="--credential"` form to forward flags to `create_dev_data`, which
hurt discoverability when stacking multiple flags.

## Proposal

- [x] Uncomment the `user10` batch-order owner fixture in `generate_simple`
      and gate it behind a new `owned_batch_orders` flag (disabled by
      default). The flag also surfaces in the interactive `select_multiple`
      menu as "Owned batch orders".
- [x] Expose the flag as `--owned-batch-orders` on the
      `create_dev_data` management command.
- [x] Rework the `dev-data` Makefile target so flags after `--` are
      forwarded to `create_dev_data`, enabling:
      `make dev-data -- --owned-batch-orders --credential`