### PR TITLE
♻️(backend) deeplink max length to 400 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to
 
 ### Changed
 
+- Allow deeplink max length to 400 characters
 - Gate admin order custom discount behind the `admin_order_custom_discount`
   waffle switch (off by default)
 - Restrict admin order creation offering search to those with a deep link

--- a/src/backend/joanie/core/models/courses.py
+++ b/src/backend/joanie/core/models/courses.py
@@ -952,6 +952,7 @@ class OfferingDeepLink(BaseModel):
 
     deep_link = models.URLField(
         _("deep_link"),
+        max_length=400,
         help_text=_(
             "Deep link of an offering where a learner can subscribe with an external link."
         ),

--- a/src/backend/joanie/tests/core/models/test_offering_deep_link.py
+++ b/src/backend/joanie/tests/core/models/test_offering_deep_link.py
@@ -119,3 +119,26 @@ class OfferingDeepLinkModelTestCase(TestCase):
 
         self.assertTrue(models.OfferingDeepLink.objects.count())
         self.assertFalse(deep_link.is_active)
+
+    def test_models_offering_deeplink_create_exceed_max_length(self):
+        """
+        An offering deeplink should not exceed more than 400 characters.
+        """
+        organization = factories.OrganizationFactory()
+        offering = factories.OfferingFactory(organizations=[organization])
+
+        base_deeplink = "https://test-deeplink.com/"
+        extended_deeplink = (401 - len(base_deeplink)) * "a"
+        deeplink = f"{base_deeplink}{extended_deeplink}"
+
+        with self.assertRaises(ValidationError) as context:
+            models.OfferingDeepLink.objects.create(
+                organization=organization,
+                offering=offering,
+                deep_link=deeplink,
+            )
+
+        self.assertTrue(
+            str(context.exception),
+            "Ensure this value has at most 400 characters (it has 401).'",
+        )

--- a/src/backend/joanie/tests/swagger/admin-swagger.json
+++ b/src/backend/joanie/tests/swagger/admin-swagger.json
@@ -8776,7 +8776,7 @@
                         "type": "string",
                         "format": "uri",
                         "description": "Deep link of an offering where a learner can subscribe with an external link.",
-                        "maxLength": 200
+                        "maxLength": 400
                     },
                     "is_active": {
                         "type": "boolean",
@@ -8797,7 +8797,7 @@
                         "format": "uri",
                         "minLength": 1,
                         "description": "Deep link of an offering where a learner can subscribe with an external link.",
-                        "maxLength": 200
+                        "maxLength": 400
                     },
                     "is_active": {
                         "type": "boolean",
@@ -12011,7 +12011,7 @@
                         "format": "uri",
                         "minLength": 1,
                         "description": "Deep link of an offering where a learner can subscribe with an external link.",
-                        "maxLength": 200
+                        "maxLength": 400
                     },
                     "is_active": {
                         "type": "boolean",

--- a/src/frontend/admin/src/components/templates/courses/form/sections/offering/OfferingDeepLinkForm.tsx
+++ b/src/frontend/admin/src/components/templates/courses/form/sections/offering/OfferingDeepLinkForm.tsx
@@ -53,7 +53,7 @@ export function OfferingDeepLinkForm({
 
   const Schema = Yup.object().shape({
     organization_id: Yup.string().required(),
-    deep_link: Yup.string().url().max(200).required(),
+    deep_link: Yup.string().url().max(400).required(),
     is_active: Yup.boolean().required(),
   });
 


### PR DESCRIPTION

## Purpose

In production our deeplinks most of time exceeded 200 characters. 
For safety, we have decided to double the initial length to 400 characters.

## Proposal

- [x] Double the length of the URLField of deeplink in `OfferingDeepLink` model
