### PR TITLE
:sparkles: (backend) add payment method and session code columns to admin csv order export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add payment method, session code and course code to order export csv
 - Update Volta configuration with yarn fixed version
 - Update certificate degree
 - Update micro credentials to handle two issuers

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -1554,6 +1554,7 @@ class AdminOrderExportSerializer(serializers.ModelSerializer):  # pylint: disabl
             ("voucher", _("Voucher")),
             ("batch_order", _("Batch order")),
             ("nature", _("Nature")),
+            ("payment_method", _("Payment method")),
             ("has_waived_withdrawal_right", _("Waived withdrawal right")),
             ("certificate", _("Certificate generated for this order")),
             ("contract", _("Contract")),
@@ -1611,7 +1612,7 @@ class AdminOrderExportSerializer(serializers.ModelSerializer):  # pylint: disabl
     has_waived_withdrawal_right = serializers.SerializerMethodField(read_only=True)
     certificate = serializers.SerializerMethodField(read_only=True)
     nature = serializers.SerializerMethodField(read_only=True)
-
+    payment_method = serializers.SerializerMethodField(read_only=True)
     contract = serializers.SlugRelatedField(
         read_only=True, slug_field="definition__title"
     )
@@ -1660,6 +1661,15 @@ class AdminOrderExportSerializer(serializers.ModelSerializer):  # pylint: disabl
     def get_nature(self, instance) -> str:
         """Return the translated nature label."""
         return instance.get_nature_display()
+
+    def get_payment_method(self, instance) -> str:
+        """Return the translated payment method label."""
+        if instance.batch_order:
+            return instance.batch_order.get_payment_method_display()
+        if instance.nature == enums.ORDER_NATURE_CPF:
+            return instance.get_nature_display()
+        # By default, standard orders are paid by card payment
+        return _("Card payment")
 
     def get_product_type(self, instance) -> str:
         """Return the translated product type label."""

--- a/src/backend/joanie/core/serializers/admin.py
+++ b/src/backend/joanie/core/serializers/admin.py
@@ -21,6 +21,7 @@ from joanie.core.serializers.fields import (
 )
 from joanie.core.utils import get_default_currency_symbol
 from joanie.core.utils.batch_order import get_active_offering_rule
+from joanie.core.utils.order import extract_session_code_as_string
 from joanie.core.utils.organization import get_least_active_organization
 from joanie.payment import models as payment_models
 
@@ -1538,6 +1539,8 @@ class AdminOrderExportSerializer(serializers.ModelSerializer):  # pylint: disabl
         fields_labels = [
             ("id", _("Order reference")),
             ("product", _("Product")),
+            ("course", _("Course code")),
+            ("session_code", _("Session code")),
             ("owner_name", _("Owner")),
             ("owner_email", _("Email")),
             ("organization", _("Organization")),
@@ -1591,6 +1594,8 @@ class AdminOrderExportSerializer(serializers.ModelSerializer):  # pylint: disabl
 
     state = serializers.SerializerMethodField(read_only=True)
     product = serializers.SlugRelatedField(read_only=True, slug_field="title")
+    course = serializers.SlugRelatedField(read_only=True, slug_field="code")
+    session_code = serializers.SerializerMethodField(read_only=True)
     owner_name = serializers.SerializerMethodField(read_only=True)
     owner_email = serializers.SlugRelatedField(
         read_only=True, slug_field="email", source="owner"
@@ -1670,6 +1675,12 @@ class AdminOrderExportSerializer(serializers.ModelSerializer):  # pylint: disabl
             return instance.get_nature_display()
         # By default, standard orders are paid by card payment
         return _("Card payment")
+
+    def get_session_code(self, instance) -> str:
+        """
+        Return the session code of the course run related to the course
+        """
+        return extract_session_code_as_string(instance)
 
     def get_product_type(self, instance) -> str:
         """Return the translated product type label."""

--- a/src/backend/joanie/core/utils/order.py
+++ b/src/backend/joanie/core/utils/order.py
@@ -89,3 +89,35 @@ def get_prepaid_order(
         )
     except models.Order.DoesNotExist:
         return None
+
+
+def extract_session_code_as_string(order: models.Order) -> str:
+    """
+    Extract the session code of the title for product type credentials
+    related to the order. When no session code is found in the title,
+    we just return the course code instead. Also, when the product is
+    type certificate, we only return the course code.
+    """
+    # Non-credential products
+    if order.product.type != enums.PRODUCT_TYPE_CREDENTIAL:
+        return (
+            order.course.code
+            if not order.enrollment
+            else order.enrollment.course_run.course.code
+        )
+    # Take the selected course run if present, if None were selected,
+    # than select the oldest course run available.
+    target_course_run = (
+        order.target_course_runs[0]
+        if order.target_course_runs.count() == 1
+        else order.target_course_runs.order_by("created_on").first()
+    )
+
+    if not target_course_run or not target_course_run.title:
+        return order.course.code
+
+    # Extract the session code from the title
+    parts = target_course_run.title.rsplit("-", 2)
+    if len(parts) == 3:  # noqa : PLR2004
+        return f"{parts[1].strip()}-{parts[2].strip()}"
+    return order.course.code

--- a/src/backend/joanie/tests/core/api/admin/orders/test_export.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_export.py
@@ -19,6 +19,16 @@ def yes_no(value):
     return str(_("Yes")) if value else str(_("No"))
 
 
+def get_payment_method(order):
+    """Returns the payment method of the order"""
+    if order.batch_order:
+        return order.batch_order.get_payment_method_display()
+    if order.nature == enums.ORDER_NATURE_CPF:
+        return enums.ORDER_NATURE_CPF
+    # By default, standard orders are paid by card payment
+    return _("Card payment")
+
+
 def expected_csv_content(order):
     """Return the expected CSV content for an order."""
     content = {
@@ -40,6 +50,7 @@ def expected_csv_content(order):
         "Voucher": order.voucher.code if order.batch_order else "",
         "Batch order": "",
         "Nature": order.get_nature_display(),
+        "Payment method": get_payment_method(order),
         "Waived withdrawal right": yes_no(order.has_waived_withdrawal_right),
         "Certificate generated for this order": yes_no(hasattr(order, "certificate")),
         "Contract": "",

--- a/src/backend/joanie/tests/core/api/admin/orders/test_export.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_export.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 
 from joanie.core import enums, factories
 from joanie.core.models import Course, Order
+from joanie.core.utils.order import extract_session_code_as_string
 from joanie.tests import format_date_export
 from joanie.tests.base import BaseAPITestCase
 from joanie.tests.testing_utils import Demo
@@ -34,6 +35,8 @@ def expected_csv_content(order):
     content = {
         "Order reference": str(order.id),
         "Product": order.product.title,
+        "Course code": order.course.code if order.course else "",
+        "Session code": extract_session_code_as_string(order),
         "Owner": order.owner.get_full_name(),
         "Email": order.owner.email,
         "Organization": order.organization.title,
@@ -81,6 +84,7 @@ def expected_csv_content(order):
         content["Enrollment session"] = order.enrollment.course_run.title
         content["Session status"] = str(order.enrollment.course_run.state)
         content["Enrolled on"] = format_date_export(order.enrollment.created_on)
+        content["Session code"] = order.enrollment.course_run.course.code
 
     if hasattr(order, "contract"):
         content["Contract"] = order.contract.definition.title

--- a/src/backend/joanie/tests/core/api/admin/products/test_target_courses.py
+++ b/src/backend/joanie/tests/core/api/admin/products/test_target_courses.py
@@ -4,7 +4,8 @@ Test suite for Product Admin API.
 
 from http import HTTPStatus
 
-from joanie.core import factories, models
+from joanie.core import enums, factories, models
+from joanie.core.models import CourseState
 from joanie.tests.base import BaseAPITestCase
 
 
@@ -217,3 +218,81 @@ class ProductAdminApiTargetCoursesTest(BaseAPITestCase):
         self.assertEqual(offerings.get(course=courses[0]).position, 2)
         self.assertEqual(offerings.get(course=courses[2]).position, 3)
         self.assertEqual(offerings.get(course=courses[4]).position, 4)
+
+    def test_admin_api_product_edit_target_courses_course_run_select_one(self):
+        """
+        An authenticated admin user should be able to update the course run
+        of the target courses of a product. When many course runs are available,
+        he should be able to select a specific course run to be active.
+        """
+        admin = factories.UserFactory(is_staff=True, is_superuser=True)
+        self.client.login(username=admin.username, password="password")
+
+        course = factories.CourseFactory(
+            code="00002",
+            title="Course for credential",
+        )
+        # Create a course run opened
+        factories.CourseRunFactory(
+            title="Course run credential - 00002",
+            course=course,
+            state=CourseState.ONGOING_OPEN,
+            is_listed=False,
+        )
+        # This course run should be the selected one for the order and in the target course
+        # of the product
+        course_run_credential_ongoing = factories.CourseRunFactory(
+            title="Course run credential - 00002-2",
+            course=course,
+            state=CourseState.ONGOING_OPEN,
+            is_listed=True,
+        )
+        # Create another course run opened
+        factories.CourseRunFactory(
+            title="Course run credential - 00002-3",
+            course=course,
+            state=CourseState.ONGOING_OPEN,
+            is_listed=False,
+        )
+        credential_product = factories.ProductFactory(
+            contract_definition_batch_order=factories.ContractDefinitionFactory(
+                name=enums.PROFESSIONAL_TRAINING_AGREEMENT_UNICAMP
+            ),
+            contract_definition_order=factories.ContractDefinitionFactory(
+                name=enums.CONTRACT_DEFINITION_UNICAMP
+            ),
+            quote_definition=factories.QuoteDefinitionFactory(),
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+            title="Credential Product",
+            courses=[course_run_credential_ongoing.course],
+            target_courses=[
+                course_run_credential_ongoing.course,
+            ],
+            price=100,
+        )
+        credential_offering = models.CourseProductRelation.objects.get(
+            course=credential_product.courses.first(),
+            product=credential_product,
+        )
+
+        # Update the active course run to the product target courses
+        self.client.patch(
+            f"/api/v1.0/admin/products/{credential_offering.product.id}"
+            f"/target-courses/{credential_offering.course.id}/",
+            data={
+                "course_runs": [
+                    f"{course_run_credential_ongoing.id}",
+                ]
+            },
+            content_type="application/json",
+        )
+        # Create an order that should target the selected course run of the target
+        # course of product
+        order = factories.OrderGeneratorFactory(
+            state=enums.ORDER_STATE_COMPLETED,
+            course=credential_offering.course,
+            product=credential_offering.product,
+        )
+
+        self.assertEqual(credential_product.target_course_runs.count(), 1)
+        self.assertEqual(order.target_course_runs.count(), 1)

--- a/src/backend/joanie/tests/testing_utils.py
+++ b/src/backend/joanie/tests/testing_utils.py
@@ -843,7 +843,7 @@ class Demo:
             self.log("")
 
             course_run_certificate = factories.CourseRunFactory(
-                title="Course run certificate",
+                title="Course run certificate - 00000",
                 resource_link=OPENEDX_COURSE_RUN_URI.format(
                     course="00000", course_run="CourseRunCertificate_run1"
                 ),
@@ -890,7 +890,7 @@ class Demo:
             self.log("")
 
             course_run_certificate_discount = factories.CourseRunFactory(
-                title="Course run certificate discount",
+                title="Course run certificate discount - 00001",
                 resource_link=OPENEDX_COURSE_RUN_URI.format(
                     course="00001", course_run="CourseRunCertificate_run1"
                 ),
@@ -951,8 +951,8 @@ class Demo:
             self.log(f'Successfully created "{course.title}" course')
             self.log("")
 
-            course_run_credential = factories.CourseRunFactory(
-                title="Course run credential",
+            course_run_first = factories.CourseRunFactory(
+                title="Course run credential - 00002",
                 resource_link=OPENEDX_COURSE_RUN_URI.format(
                     course="00002", course_run="CourseRunCredential_run1"
                 ),
@@ -961,7 +961,33 @@ class Demo:
                 state=CourseState.ONGOING_OPEN,
                 is_listed=False,
             )
-            self.log(f'Successfully created "{course_run_credential.title}" course run')
+            self.log(f'Successfully created "{course_run_first.title}" course run')
+            self.log("")
+
+            course_run_second = factories.CourseRunFactory(
+                title="Course run credential - 00002-2",
+                resource_link=OPENEDX_COURSE_RUN_URI.format(
+                    course="00002-2", course_run="CourseRunCredential_run1"
+                ),
+                course=course,
+                languages=self.get_random_languages(),
+                state=CourseState.ONGOING_OPEN,
+                is_listed=True,
+            )
+            self.log(f'Successfully created "{course_run_second.title}" course run')
+            self.log("")
+
+            course_run_selected = factories.CourseRunFactory(
+                title="Course run credential - 00002-3",
+                resource_link=OPENEDX_COURSE_RUN_URI.format(
+                    course="00002-3", course_run="CourseRunCredential_run1"
+                ),
+                course=course,
+                languages=self.get_random_languages(),
+                state=CourseState.ONGOING_OPEN,
+                is_listed=False,
+            )
+            self.log(f'Successfully created "{course_run_selected.title}" course run')
             self.log("")
 
             credential_product = factories.ProductFactory(
@@ -974,10 +1000,8 @@ class Demo:
                 quote_definition=factories.QuoteDefinitionFactory(),
                 type=enums.PRODUCT_TYPE_CREDENTIAL,
                 title="Credential Product",
-                courses=[course_run_credential.course],
-                target_courses=[
-                    course_run_credential.course,
-                ],
+                courses=[course],
+                target_courses=[course],
                 price=100,
             )
             self.log(f'Successfully created "{credential_product.title}" product')
@@ -987,7 +1011,80 @@ class Demo:
                 course=credential_product.courses.first(),
                 product=credential_product,
             )
+            # Explicitly link only the ongoing course run to the product relation
+            # This filters which course runs are available for this product
+            product_target_relation = credential_product.target_course_relations.get(
+                course=course
+            )
+
+            # Test for each session of course runs in product's target courses
+            for course_run in [
+                course_run_first,
+                course_run_second,
+            ]:
+                # For each order we create, aim to one specific course run
+                product_target_relation.course_runs.set([course_run])
+                order = factories.OrderGeneratorFactory(
+                    state=enums.ORDER_STATE_COMPLETED,
+                    course=credential_offering.course,
+                    product=credential_offering.product,
+                )
+                self.log(f"Successfully created completed order {order.id} ")
+                self.log("")
+
+            order = factories.OrderFactory(
+                state=enums.ORDER_STATE_COMPLETED,
+                course=credential_offering.course,
+                product=credential_offering.product,
+                nature=enums.ORDER_NATURE_CPF,
+                owner=factories.UserFactory(),
+            )
+            self.log(f"Successfully created CPF completed order {order.id} ")
+            self.log("")
+
+            # Apply the same for batch orders, each course run, one batch order
+            for course_run in [
+                course_run_first,
+                course_run_second,
+            ]:
+                for payment_method, _ in enums.BATCH_ORDER_PAYMENT_METHOD_CHOICES:
+                    product_target_relation.course_runs.set([course_run])
+                    batch_order = factories.BatchOrderFactory(
+                        organization=organization,
+                        state=enums.BATCH_ORDER_STATE_COMPLETED,
+                        offering=credential_offering,
+                        nb_seats=3,
+                        payment_method=payment_method,
+                    )
+                    self.log(f"Successfully created batch order {batch_order.id} ")
+                    self.log("")
+
             credential_offering.organizations.add(second_organization)
+            batch_order = factories.BatchOrderFactory(
+                organization=organization,
+                state=enums.BATCH_ORDER_STATE_COMPLETED,
+                offering=credential_offering,
+                nb_seats=5,
+            )
+            batch_order.generate_orders()
+            for order in batch_order.orders.all():
+                order.owner = factories.UserFactory()
+                order.save(update_fields=["owner"])
+                order.flow.update()
+            self.log(
+                f"Successfully created batch order {batch_order.id} "
+                f"(COMPLETED, {batch_order.nb_seats} seats, "
+                f"contract signed: {batch_order.contract.is_fully_signed})"
+            )
+            self.log("")
+
+            product_target_relation.course_runs.set([course_run_selected])
+            order = factories.OrderGeneratorFactory(
+                state=enums.ORDER_STATE_COMPLETED,
+                course=credential_offering.course,
+                product=credential_offering.product,
+            )
+
             batch_order_kwargs = {
                 "state": enums.BATCH_ORDER_STATE_COMPLETED,
                 "offering": credential_offering,
@@ -1025,7 +1122,7 @@ class Demo:
                             payment_method=payment_method[0],
                         )
 
-            course_run_credential.save()
+            course_run_selected.save()
 
         if create_credential_discount:
             course = factories.CourseFactory(
@@ -1038,7 +1135,7 @@ class Demo:
             self.log("")
 
             course_run_credential_discount = factories.CourseRunFactory(
-                title="Course run credential discount",
+                title="Course run credential discount - 00003",
                 resource_link=OPENEDX_COURSE_RUN_URI.format(
                     course="00003", course_run="CourseRunCredential_run1"
                 ),
@@ -1068,7 +1165,9 @@ class Demo:
                         organizations=[organization],
                         title="Target Course for credential product discount",
                         course_runs=factories.CourseRunFactory.create_batch(
-                            1, course__code="cred_disc"
+                            1,
+                            course__code="cred_disc",
+                            title="Target Course for credential product discount - 00003",
                         ),
                         code="00003",
                     )


### PR DESCRIPTION
## Purpose

Since we added batch orders and different natures of orders, we need to know the category of payment method used for an order. It can be `card_payment`,  `cpf`, `bank_transfer`, or finally `purchase_order`.
Also, we have added two extra columns that describes the course's code, and the session code. 
The session code is written inside the selected course run's title in the target course of a product.

## Proposal

- [x] add payment method column of orders
- [x] add training code and session code columns of orders
- [x] update `dev-data` command to replicate data in product concerning course run's selected session on a product target courses.
