### PR TITLE
✨(backend) add download quote action client api batch order

### DIFF
--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -2848,6 +2848,7 @@ class BatchOrder(BaseModel):
         """Return the available client actions for the batch order"""
         actions = {
             "confirm_quote": self.can_confirm_quote(),
+            "download_quote": self.can_download_quote(),
             "confirm_purchase_order": self.can_confirm_purchase_order(),
             "confirm_bank_transfer": self.can_confirm_bank_transfer(),
             "submit_for_signature": self.can_submit_for_signature(),
@@ -2855,7 +2856,7 @@ class BatchOrder(BaseModel):
         }
 
         for key, value in actions.items():
-            if value and key not in ("next_action",):
+            if value and key not in ("next_action", "download_quote"):
                 actions["next_action"] = key
                 break
 

--- a/src/backend/joanie/tests/core/api/batch_order/test_list.py
+++ b/src/backend/joanie/tests/core/api/batch_order/test_list.py
@@ -130,6 +130,7 @@ class BatchOrderReadListAPITest(BaseAPITestCase):
                         "funding_amount": float(bo.funding_amount),
                         "available_actions": {
                             "confirm_quote": True,
+                            "download_quote": False,
                             "confirm_purchase_order": False,
                             "confirm_bank_transfer": False,
                             "submit_for_signature": False,

--- a/src/backend/joanie/tests/core/api/batch_order/test_retrieve.py
+++ b/src/backend/joanie/tests/core/api/batch_order/test_retrieve.py
@@ -145,6 +145,7 @@ class BatchOrderReadDetailAPITest(BaseAPITestCase):
                 "funding_amount": float(batch_order.funding_amount),
                 "available_actions": {
                     "confirm_quote": True,
+                    "download_quote": False,
                     "confirm_purchase_order": False,
                     "confirm_bank_transfer": False,
                     "submit_for_signature": False,

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_agreements.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_agreements.py
@@ -249,6 +249,7 @@ class OrganizationAgreementApiTest(BaseAPITestCase):
                             },
                             "available_actions": {
                                 "confirm_quote": True,
+                                "download_quote": False,
                                 "confirm_purchase_order": False,
                                 "confirm_bank_transfer": False,
                                 "submit_for_signature": False,
@@ -540,6 +541,7 @@ class OrganizationAgreementApiTest(BaseAPITestCase):
                             },
                             "available_actions": {
                                 "confirm_quote": False,
+                                "download_quote": True,
                                 "confirm_purchase_order": False,
                                 "confirm_bank_transfer": False,
                                 "submit_for_signature": False,

--- a/src/backend/joanie/tests/core/api/organizations/test_api_organizations_quotes.py
+++ b/src/backend/joanie/tests/core/api/organizations/test_api_organizations_quotes.py
@@ -130,6 +130,7 @@ class OrganizationQuoteApiTest(BaseAPITestCase):
                             "total_currency": settings.DEFAULT_CURRENCY,
                             "available_actions": {
                                 "confirm_quote": True,
+                                "download_quote": False,
                                 "confirm_purchase_order": False,
                                 "confirm_bank_transfer": False,
                                 "submit_for_signature": False,
@@ -330,6 +331,7 @@ class OrganizationQuoteApiTest(BaseAPITestCase):
                     "total_currency": settings.DEFAULT_CURRENCY,
                     "available_actions": {
                         "confirm_quote": False,
+                        "download_quote": True,
                         "confirm_purchase_order": False,
                         "confirm_bank_transfer": False,
                         "submit_for_signature": False,

--- a/src/backend/joanie/tests/core/api/quotes/test_api_quotes.py
+++ b/src/backend/joanie/tests/core/api/quotes/test_api_quotes.py
@@ -104,6 +104,7 @@ class QuoteApiTest(BaseAPITestCase):
                             "total_currency": settings.DEFAULT_CURRENCY,
                             "available_actions": {
                                 "confirm_quote": True,
+                                "download_quote": False,
                                 "confirm_purchase_order": False,
                                 "confirm_bank_transfer": False,
                                 "submit_for_signature": False,
@@ -214,6 +215,7 @@ class QuoteApiTest(BaseAPITestCase):
                     "total_currency": settings.DEFAULT_CURRENCY,
                     "available_actions": {
                         "confirm_quote": False,
+                        "download_quote": True,
                         "confirm_purchase_order": False,
                         "confirm_bank_transfer": False,
                         "submit_for_signature": False,

--- a/src/backend/joanie/tests/core/models/test_batch_order.py
+++ b/src/backend/joanie/tests/core/models/test_batch_order.py
@@ -1269,6 +1269,7 @@ class BatchOrderModelsTestCase(LoggingTestCase):
         self.assertEqual(
             [
                 "confirm_quote",
+                "download_quote",
                 "confirm_purchase_order",
                 "confirm_bank_transfer",
                 "submit_for_signature",


### PR DESCRIPTION
## Purpose

We want our API client consumer to be able to download their quote with the total once the total is set on the batch order. We added the action `download_quote` into the available actions.

## Proposal

- [x] add `download_quote` in available actions for client API
