### PR TITLE
🐛(backend) download quote issued on date and total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add issued on information in quote's context when total is set
 - Add payment method, session code and course code to order export csv
 - Update Volta configuration with yarn fixed version
 - Update certificate degree

--- a/src/backend/joanie/core/api/admin/__init__.py
+++ b/src/backend/joanie/core/api/admin/__init__.py
@@ -1080,10 +1080,14 @@ class BatchOrderViewSet(
         """
         When the batch order has a total, the related quote can be downloaded.
         """
-        quote = self.get_object().quote
+        batch_order = self.get_object()
+        quote = batch_order.quote
 
         if not quote.has_total:
             raise ValidationError("Quote does not have total, cannot download.")
+
+        # Load the total into the context
+        quote.context["batch_order"]["total"] = str(str(batch_order.total))
 
         context_with_images = contract_definition.embed_images_in_context(quote.context)
         quote_pdf_bytes = issuers.generate_document(

--- a/src/backend/joanie/core/models/quotes.py
+++ b/src/backend/joanie/core/models/quotes.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models, transaction
-from django.utils import timezone
+from django.utils import formats, timezone
 from django.utils.functional import lazy
 from django.utils.translation import gettext_lazy as _
 
@@ -246,7 +246,7 @@ class Quote(BaseModel):
         """
         return self.is_signed_by_organization and self.has_purchase_order
 
-    def update_context(self):
+    def update_context(self, batch_order_created_on_date=False):
         """
         Update the context of the quote once the total of the related batch order
         is set. Otherwise, if the total is not yet set, it raises an error.
@@ -256,6 +256,11 @@ class Quote(BaseModel):
         self.context = quote_utility.generate_document_context(
             self.batch_order.relation.product.quote_definition, self.batch_order
         )
+        if batch_order_created_on_date:
+            self.context["quote"]["issued_on"] = formats.date_format(
+                self.batch_order.created_on, "SHORT_DATE_FORMAT"
+            )
+
         self.save()
 
     def get_abilities(self, user):

--- a/src/backend/joanie/core/templates/issuers/quote_default.html
+++ b/src/backend/joanie/core/templates/issuers/quote_default.html
@@ -177,14 +177,12 @@ for your training, feel free to use this template as a base.
           {{ quote.body|safe }}
         {% endif %}
         <section class="content-created-on">
-          <div class="signature_zone">
-            {% if quote %}
-            <p>
-              {% translate "Quote issued on: " %}
-              {{ quote.issued_on }}
-            </p>
-            {% endif %}
-          </div>
+          {% if quote %}
+          <p>
+            {% translate "Quote issued on: " %}
+            {{ quote.issued_on }}
+          </p>
+          {% endif %}
         </section>
       </article>
     </main>

--- a/src/backend/joanie/core/templates/issuers/quote_default.html
+++ b/src/backend/joanie/core/templates/issuers/quote_default.html
@@ -178,10 +178,12 @@ for your training, feel free to use this template as a base.
         {% endif %}
         <section class="content-created-on">
           <div class="signature_zone">
+            {% if quote %}
             <p>
               {% translate "Quote issued on: " %}
-              {% now "SHORT_DATE_FORMAT" %}
+              {{ quote.issued_on }}
             </p>
+            {% endif %}
           </div>
         </section>
       </article>

--- a/src/backend/joanie/core/utils/quotes.py
+++ b/src/backend/joanie/core/utils/quotes.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 
 from django.conf import settings
+from django.utils import formats, timezone
 from django.utils.duration import duration_iso_string
 from django.utils.translation import gettext as _
 
@@ -212,6 +213,9 @@ def generate_document_context(quote_definition=None, batch_order=None):
                     "description": quote_definition.description,
                     "body": quote_definition.get_body_in_html(),
                     "reference": batch_order.quote.reference,
+                    "issued_on": formats.date_format(
+                        timezone.now(), "SHORT_DATE_FORMAT"
+                    ),
                 },
                 "batch_order": {
                     "nb_seats": batch_order.nb_seats,

--- a/src/backend/joanie/tests/core/models/test_quote.py
+++ b/src/backend/joanie/tests/core/models/test_quote.py
@@ -191,6 +191,32 @@ class QuoteModelsTestCase(LoggingTestCase):
             batch_order.quote.context.get("batch_order").get("total"), "100.00"
         )
 
+    def test_models_quote_update_context_with_batch_order_created_on_date(self):
+        """
+        When the quote already exists and has a total (e.g., in production), the key
+        `issued_on` may not be present in the context yet. To compensate, we add
+        the batch order's creation date as `issued_on` instead of using today's date
+        when generating the quote context. This ensures that older quotes reflect
+        a date closer to their actual generation, rather than the current date.
+        """
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2026, 1, 13, 0, tzinfo=ZoneInfo("UTC")),
+        ):
+            batch_order = BatchOrderFactory(state=enums.BATCH_ORDER_STATE_COMPLETED)
+
+        with mock.patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2026, 1, 14, 0, tzinfo=ZoneInfo("UTC")),
+        ):
+            batch_order.quote.update_context(batch_order_created_on_date=True)
+
+        batch_order.refresh_from_db()
+
+        self.assertEqual(
+            batch_order.quote.context.get("quote").get("issued_on"), "01/13/2026"
+        )
+
 
 # pylint:disable=unused-argument
 @override_settings(JOANIE_PREFIX_QUOTE_REFERENCE="JOANIE")

--- a/src/backend/joanie/tests/core/utils/test_quote_generate_document_context.py
+++ b/src/backend/joanie/tests/core/utils/test_quote_generate_document_context.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.test import TestCase
+from django.utils import formats
 
 from PIL import Image
 
@@ -195,6 +196,9 @@ class UtilsQuoteGenerateContextDocument(TestCase):
                 "description": batch_order.quote.definition.description,
                 "body": batch_order.quote.definition.get_body_in_html(),
                 "reference": batch_order.quote.reference,
+                "issued_on": formats.date_format(
+                    batch_order.created_on, "SHORT_DATE_FORMAT"
+                ),
             },
             "batch_order": {
                 "nb_seats": batch_order.nb_seats,


### PR DESCRIPTION
## Purpose

On the very first objects of batch orders in production, their quote contexts did not have the issued on date and the total date. We added a small fix into the endpoint to download the quote, because existing objects context are not aligned with the following new batch orders.


## Proposal

- [x] Ensure the issued on date of quote and total are displayed into the quote on download when the batch order has a total
