### PR TITLE
♻️(backend) allow configure role id student for moodle LMS backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Changed
 
+- Allow configure role id student for Moodle as environment variable
 - Allow deeplink max length to 400 characters
 - Gate admin order custom discount behind the `admin_order_custom_discount`
   waffle switch (off by default)

--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -16,6 +16,7 @@ JOANIE_LMS_BACKENDS = '[{
     "COURSE_REGEX": "^.*/courses/(?P<course_id>.*)/course/?$",
     "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages"]
 }]'
+JOANIE_LMS_MOODLE_STUDENT_ROLE_ID="IntegerRoleIdStudent"
 
 #JWT
 DJANGO_JWT_PRIVATE_SIGNING_KEY=ThisIsAnExampleKeyForDevPurposeOnly

--- a/src/backend/joanie/lms_handler/backends/moodle.py
+++ b/src/backend/joanie/lms_handler/backends/moodle.py
@@ -21,10 +21,6 @@ from .base import BaseLMSBackend
 logger = logging.getLogger(__name__)
 
 
-class MoodleStudentRoleException(Exception):
-    """Raised when the student role is not found in Moodle."""
-
-
 class MoodleUserException(Exception):
     """Raised when a user is not found in Moodle."""
 
@@ -42,6 +38,7 @@ class MoodleLMSBackend(BaseLMSBackend):
         self.base_url = self.configuration["BASE_URL"]
         self.token = self.configuration["API_TOKEN"]
         self.moodle = Moodle(self.base_url, self.token)
+        self.role_id = settings.JOANIE_LMS_MOODLE_STUDENT_ROLE_ID
 
     def build_url(self, function):
         """Build a Moodle API url."""
@@ -85,22 +82,6 @@ class MoodleLMSBackend(BaseLMSBackend):
             logger.error("Moodle error while retrieving enrollments: %s", e)
             return None
 
-    def get_roles(self):
-        """Retrieve roles."""
-        try:
-            return self.moodle("local_wsgetroles_get_roles")
-        except (MoodleException, NetworkMoodleException, EmptyResponseException) as e:
-            logger.error(e)
-            return []
-
-    def student_role_id(self):
-        """Retrieve student role id."""
-        roles = self.get_roles()
-        for role in roles:
-            if role.get("shortname") == "student":
-                return role.get("id")
-        raise MoodleStudentRoleException("Student role not found in Moodle")
-
     # pylint: disable=invalid-name
     def get_user_id(self, username):
         """Retrieve user id."""
@@ -138,12 +119,6 @@ class MoodleLMSBackend(BaseLMSBackend):
     # pylint: disable=too-many-branches
     def set_enrollment(self, enrollment):
         """Activate/deactivate an enrollment."""
-        try:
-            role_id = self.student_role_id()
-        except MoodleStudentRoleException as e:
-            logger.error("Moodle error while retrieving student role: %s", e)
-            raise EnrollmentError() from e
-
         user_id = None
         try:
             user_id = self.get_user_id(enrollment.user.username)
@@ -162,7 +137,7 @@ class MoodleLMSBackend(BaseLMSBackend):
         moodle_enrollment = {
             "courseid": course_id,
             "userid": user_id,
-            "roleid": role_id,
+            "roleid": self.role_id,
         }
         try:
             if enrollment.is_active:
@@ -175,7 +150,7 @@ class MoodleLMSBackend(BaseLMSBackend):
                 "enrolling" if enrollment.is_active else "unenrolling",
                 enrollment.user.username,
                 user_id,
-                role_id,
+                self.role_id,
                 course_id,
                 e,
                 e.exception if hasattr(e, "exception") else "",

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -238,6 +238,11 @@ class Base(Configuration):
     MOODLE_AUTH_METHOD = values.Value(
         "oauth2", environ_name="MOODLE_AUTH_METHOD", environ_prefix=None
     )
+    # Override this variable depending on the student role id of your moodle instance
+    # if you use moodle as one of your LMS backends
+    JOANIE_LMS_MOODLE_STUDENT_ROLE_ID = values.Value(
+        "", environ_name="JOANIE_LMS_MOODLE_STUDENT_ROLE_ID", environ_prefix=None
+    )
     JOANIE_BADGE_PROVIDERS = {
         "obf": {
             "client_id": values.Value(
@@ -831,6 +836,8 @@ class Test(Base):
             "COURSE_REGEX": r"^(?P<course_id>.*)$",
         }
     ]
+    # This environment variable is only used for moodle student role id
+    JOANIE_LMS_MOODLE_STUDENT_ROLE_ID = "5"
 
     COURSE_WEB_HOOKS = []
 

--- a/src/backend/joanie/tests/core/test_flows_order.py
+++ b/src/backend/joanie/tests/core/test_flows_order.py
@@ -611,22 +611,6 @@ class OrderFlowsTestCase(LoggingTestCase):
 
         responses.add(
             responses.POST,
-            backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=[
-                {
-                    "id": 5,
-                    "name": "",
-                    "shortname": "student",
-                    "description": "",
-                    "sortorder": 5,
-                    "archetype": "student",
-                },
-            ],
-        )
-
-        responses.add(
-            responses.POST,
             backend.build_url("enrol_manual_enrol_users"),
             match=[
                 responses.matchers.urlencoded_params_matcher(
@@ -650,7 +634,7 @@ class OrderFlowsTestCase(LoggingTestCase):
 
         self.assertEqual(order.state, enums.ORDER_STATE_COMPLETED)
 
-        self.assertEqual(len(responses.calls), 3)
+        self.assertEqual(len(responses.calls), 2)
 
     @responses.activate
     @override_settings(
@@ -681,22 +665,6 @@ class OrderFlowsTestCase(LoggingTestCase):
         )
         product = factories.ProductFactory(target_courses=[course], price="0.00")
         backend = LMSHandler.select_lms(resource_link)
-
-        responses.add(
-            responses.POST,
-            backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=[
-                {
-                    "id": 5,
-                    "name": "",
-                    "shortname": "student",
-                    "description": "",
-                    "sortorder": 5,
-                    "archetype": "student",
-                },
-            ],
-        )
 
         responses.add(
             responses.POST,
@@ -740,7 +708,7 @@ class OrderFlowsTestCase(LoggingTestCase):
         order.refresh_from_db()
         self.assertEqual(order.state, enums.ORDER_STATE_COMPLETED)
 
-        self.assertEqual(len(responses.calls), 3)
+        self.assertEqual(len(responses.calls), 2)
 
     def test_flows_order_cancel_success(self):
         """Test that the cancel transition is successful from any state"""

--- a/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
+++ b/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
@@ -1,6 +1,5 @@
 """Test suite for the Moodle LMS Backend."""
 
-import random
 from http import HTTPStatus
 from logging import ERROR, INFO
 
@@ -627,13 +626,6 @@ class MoodleLMSBackendTestCase(TestCase):
 
         responses.add(
             responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
-        )
-
-        responses.add(
-            responses.POST,
             self.backend.build_url("enrol_manual_enrol_users"),
             match=[
                 responses.matchers.urlencoded_params_matcher(
@@ -686,13 +678,6 @@ class MoodleLMSBackendTestCase(TestCase):
 
         responses.add(
             responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
-        )
-
-        responses.add(
-            responses.POST,
             self.backend.build_url("enrol_manual_unenrol_users"),
             match=[
                 responses.matchers.urlencoded_params_matcher(
@@ -724,13 +709,6 @@ class MoodleLMSBackendTestCase(TestCase):
         )
         enrollment = models.Enrollment(
             course_run=course_run, user=user, is_active=False
-        )
-
-        responses.add(
-            responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
         )
 
         responses.add(
@@ -817,13 +795,6 @@ class MoodleLMSBackendTestCase(TestCase):
 
         responses.add(
             responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
-        )
-
-        responses.add(
-            responses.POST,
             self.backend.build_url("enrol_manual_enrol_users"),
             match=[
                 responses.matchers.urlencoded_params_matcher(
@@ -855,13 +826,6 @@ class MoodleLMSBackendTestCase(TestCase):
         )
         enrollment = models.Enrollment(
             course_run=course_run, user=user, is_active=False
-        )
-
-        responses.add(
-            responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
         )
 
         responses.add(
@@ -898,97 +862,6 @@ class MoodleLMSBackendTestCase(TestCase):
         )
 
     @responses.activate(assert_all_requests_are_fired=True)
-    def test_backend_moodle_set_enrollment_student_role_error(self):
-        """
-        When enrolling, if getting roles fails, it should raise an EnrollmentError.
-        """
-        course_run = factories.CourseRunMoodleFactory(
-            is_listed=True,
-            state=models.CourseState.ONGOING_OPEN,
-        )
-        user = factories.UserFactory(
-            username="student",
-        )
-        is_active = random.choice([True, False])
-        enrollment = models.Enrollment(
-            course_run=course_run, user=user, is_active=is_active
-        )
-
-        responses.add(
-            responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.INTERNAL_SERVER_ERROR,
-        )
-
-        with (
-            self.assertLogs(
-                "joanie.lms_handler.backends.moodle", level=ERROR
-            ) as error_logs,
-            self.assertRaises(EnrollmentError),
-        ):
-            self.backend.set_enrollment(enrollment)
-
-        self.assertEqual(
-            error_logs.output,
-            [
-                "ERROR:joanie.lms_handler.backends.moodle:Empty response from server!",
-                "ERROR:joanie.lms_handler.backends.moodle:"
-                "Moodle error while retrieving student role: "
-                "Student role not found in Moodle",
-            ],
-        )
-
-    @responses.activate(assert_all_requests_are_fired=True)
-    def test_backend_moodle_set_enrollment_student_role_not_found(self):
-        """
-        When enrolling, if student role is not found, it should raise an EnrollmentError.
-        """
-        course_run = factories.CourseRunMoodleFactory(
-            is_listed=True,
-            state=models.CourseState.ONGOING_OPEN,
-        )
-        user = factories.UserFactory(
-            username="student",
-        )
-        is_active = random.choice([True, False])
-        enrollment = models.Enrollment(
-            course_run=course_run, user=user, is_active=is_active
-        )
-
-        responses.add(
-            responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=[
-                {
-                    "id": 1,
-                    "name": "",
-                    "shortname": "manager",
-                    "description": "",
-                    "sortorder": 1,
-                    "archetype": "manager",
-                },
-            ],
-        )
-
-        with (
-            self.assertLogs(
-                "joanie.lms_handler.backends.moodle", level=ERROR
-            ) as error_logs,
-            self.assertRaises(EnrollmentError),
-        ):
-            self.backend.set_enrollment(enrollment)
-
-        self.assertEqual(
-            error_logs.output,
-            [
-                "ERROR:joanie.lms_handler.backends.moodle:"
-                "Moodle error while retrieving student role: "
-                "Student role not found in Moodle"
-            ],
-        )
-
-    @responses.activate(assert_all_requests_are_fired=True)
     def test_backend_moodle_set_enrollment_enroll_fail(self):
         """
         When enrolling, if Moodle returns an error, it should raise an EnrollmentError.
@@ -1016,13 +889,6 @@ class MoodleLMSBackendTestCase(TestCase):
             ],
             status=HTTPStatus.OK,
             json=MOODLE_RESPONSE_USERS,
-        )
-
-        responses.add(
-            responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
         )
 
         responses.add(
@@ -1093,13 +959,6 @@ class MoodleLMSBackendTestCase(TestCase):
 
         responses.add(
             responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
-        )
-
-        responses.add(
-            responses.POST,
             self.backend.build_url("enrol_manual_unenrol_users"),
             match=[
                 responses.matchers.urlencoded_params_matcher(
@@ -1164,13 +1023,6 @@ class MoodleLMSBackendTestCase(TestCase):
 
         responses.add(
             responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
-        )
-
-        responses.add(
-            responses.POST,
             self.backend.build_url("enrol_manual_enrol_users"),
             body=RequestException(),
         )
@@ -1227,13 +1079,6 @@ class MoodleLMSBackendTestCase(TestCase):
 
         responses.add(
             responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
-        )
-
-        responses.add(
-            responses.POST,
             self.backend.build_url("enrol_manual_unenrol_users"),
             body=RequestException(),
         )
@@ -1284,13 +1129,6 @@ class MoodleLMSBackendTestCase(TestCase):
             ],
             status=HTTPStatus.OK,
             json=MOODLE_RESPONSE_USERS,
-        )
-
-        responses.add(
-            responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
         )
 
         responses.add(
@@ -1352,13 +1190,6 @@ class MoodleLMSBackendTestCase(TestCase):
             ],
             status=HTTPStatus.OK,
             json=MOODLE_RESPONSE_USERS,
-        )
-
-        responses.add(
-            responses.POST,
-            self.backend.build_url("local_wsgetroles_get_roles"),
-            status=HTTPStatus.OK,
-            json=MOODLE_RESPONSE_ROLES,
         )
 
         responses.add(


### PR DESCRIPTION
## Purpose

The plugin we were using for our moodle instance to get the role of a student is deprecated for version 4.5 of Moodle. It was still available until version 4.2. 

Meanwhile, before we develop our own plugin to support latest versions, we will set the role id of the student for Moodle as an environment variable. This will ease in the future to update this value if needed.
Make sure to always declare `JOANIE_LMS_MOODLE_STUDENT_ROLE_ID`.

Beware, if the role id changes in your Moodle instance, you can just update the environment variable to the newest value to keep enrolling students to courses. This will avoid you to do a full release. For your information, Moodle would always set the role id 5 for the student per default, but if you have customized it, make sure to change it in Joanie.

## Proposal

- [x] Add `JOANIE_LMS_MOODLE_STUDENT_ROLE_ID`
- [x] Update Moodle LMS Backend