### PR TITLE
♻️(backend) refactor LMSHandler when backends share selector regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
 
 ### Fixed
 
+- LMS Handler finds appropriate configuration when many lms share same regex
+  selector
 - Allow student to enroll to course from a batch order with purchase order
   payment method and the contract is not signed yet
 - Add missing migration file for deeplink max length

--- a/src/backend/joanie/lms_handler/__init__.py
+++ b/src/backend/joanie/lms_handler/__init__.py
@@ -1,6 +1,7 @@
 """LMS Handler"""
 
 import re
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -28,9 +29,19 @@ class LMSHandler:
         ]
 
     @staticmethod
+    def _get_base_url(url):
+        """Extract scheme + netloc (e.g. 'https://host.com') from a full URL."""
+        parsed = urlparse(url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    @staticmethod
     def select_lms(resource_link):
         """
         Select and return the first LMS backend matching the url passed in argument.
+
+        Several backends may share the same SELECTOR_REGEX. In that case,
+        disambiguate by checking which backend's BASE_URL is contained in the
+        resource_link.
 
         Return an LMS Backend instance according to its course run url.
         Default to None if no LMS has been found.
@@ -38,8 +49,18 @@ class LMSHandler:
         if resource_link is None:
             return None
 
+        matches = []
+
         for lms_configuration in settings.JOANIE_LMS_BACKENDS:
             if re.match(lms_configuration.get("SELECTOR_REGEX", r".*"), resource_link):
+                matches.append(lms_configuration)
+
+        if len(matches) == 1:
+            lms_configuration = matches[0]
+            return import_string(lms_configuration["BACKEND"])(lms_configuration)
+
+        for lms_configuration in matches:
+            if LMSHandler._get_base_url(lms_configuration["BASE_URL"]) in resource_link:
                 return import_string(lms_configuration["BACKEND"])(lms_configuration)
 
         return None

--- a/src/backend/joanie/tests/lms_handler/test_handler.py
+++ b/src/backend/joanie/tests/lms_handler/test_handler.py
@@ -46,6 +46,66 @@ class LMSHandlerTestCase(TestCase):
     @override_settings(
         JOANIE_LMS_BACKENDS=[
             {
+                "API_TOKEN": "token_1",
+                "BASE_URL": "https://openedx.apps.test.acme",
+                "BACKEND": "joanie.lms_handler.backends.openedx.OpenEdXLMSBackend",
+                "COURSE_REGEX": "^.*/courses/(?P<course_id>.*)/info/?$",
+                "SELECTOR_REGEX": "^.*/courses/(?P<course_id>.*)/info/?$",
+                "COURSE_RUN_SYNC_NO_UPDATE_FIELDS": ["languages"],
+            },
+            {
+                "API_TOKEN": "token_2",
+                "BASE_URL": "https://moodle.1-fun.apps.test.acme/webservice/rest/server.php",
+                "BACKEND": "joanie.lms_handler.backends.moodle.MoodleLMSBackend",
+                "COURSE_REGEX": "^.*/course/view.php\\?id=.*$",
+                "SELECTOR_REGEX": "^.*/course/view.php\\?id=.*$",
+            },
+            {
+                "API_TOKEN": "token_3",
+                "BASE_URL": "https://moodle.2.test.acme/webservice/rest/server.php",
+                "BACKEND": "joanie.lms_handler.backends.moodle.MoodleLMSBackend",
+                "COURSE_REGEX": "^.*/course/view.php\\?id=.*$",
+                "SELECTOR_REGEX": "^.*/course/view.php\\?id=.*$",
+            },
+        ]
+    )
+    def test_lms_handler_select_lms_with_shared_selector_regex(self):
+        """
+        When there are lms backends that share the same selector regex, the lms handler
+        should compare with the base_url to find the appropriate class to instantiate.
+        """
+        backend = LMSHandler.select_lms(
+            "https://openedx.apps.test.acme/courses/course-v1:some+course+id/info"
+        )
+        self.assertIsInstance(backend, OpenEdXLMSBackend)
+        self.assertEqual(
+            backend.configuration["BASE_URL"], "https://openedx.apps.test.acme"
+        )
+
+        backend = LMSHandler.select_lms(
+            "https://moodle.1-fun.apps.test.acme/course/view.php?id=472"
+        )
+        self.assertIsInstance(backend, MoodleLMSBackend)
+        self.assertEqual(
+            backend.configuration["BASE_URL"],
+            "https://moodle.1-fun.apps.test.acme/webservice/rest/server.php",
+        )
+
+        backend = LMSHandler.select_lms(
+            "https://moodle.2.test.acme/course/view.php?id=4"
+        )
+        self.assertIsInstance(backend, MoodleLMSBackend)
+        self.assertEqual(
+            backend.configuration["BASE_URL"],
+            "https://moodle.2.test.acme/webservice/rest/server.php",
+        )
+
+        backend = LMSHandler.select_lms("http://unknown-lms.test/courses/42")
+        self.assertIsNone(backend)
+
+    @override_settings(
+        JOANIE_LMS_BACKENDS=[
+            {
                 "BACKEND": "joanie.lms_handler.backends.base.BaseLMSBackend",
                 "BASE_URL": "http://lms-1.test",
                 "SELECTOR_REGEX": r"^disabled$",


### PR DESCRIPTION

## Purpose

When several LMS backends in the configuration share the same selector regex, we now compare the scheme and host of each backend's base url against the resource link to determine which backend to instantiate.

## Proposal

- [x] update logic in `select_lms` when two LMS backend share the same `SELECTOR_REGEX` value
