### PR TITLE
Add scan cve job to pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,37 @@ jobs:
           name: Check built image availability
           command: docker images "joanie-admin:${CIRCLE_SHA1}*"
 
+  # Scan front & back dependencies, and the base OS environment, for known
+  # CVEs (report only, never fails)
+  scan-cve:
+    docker:
+      - image: cimg/base:current
+    working_directory: ~/joanie
+    steps:
+      - checkout:
+          path: ~/joanie
+      - setup_remote_docker:
+          version: default
+      - run:
+          name: Build production image
+          command: docker build -t joanie:${CIRCLE_SHA1} --target production .
+      - run:
+          name: Install trivy
+          command: curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+      - run:
+          name: Scan runtime environment (OS packages) for known CVEs
+          command: |
+            mkdir -p reports/trivy
+            trivy image --vuln-type os --exit-code 0 --format template --template "@.circleci/templates/trivy-cve-report.tpl" -o reports/trivy/env-report.html joanie:${CIRCLE_SHA1}
+      - run:
+          name: Scan back-end application dependencies for known CVEs
+          command: trivy image --vuln-type library --exit-code 0 --format template --template "@.circleci/templates/trivy-cve-report.tpl" -o reports/trivy/back-report.html joanie:${CIRCLE_SHA1}
+      - run:
+          name: Scan front-end application dependencies for known CVEs
+          command: trivy fs --vuln-type library --exit-code 0 --format template --template "@.circleci/templates/trivy-cve-report.tpl" -o reports/trivy/front-report.html src/frontend/admin
+      - store_artifacts:
+          path: reports/trivy
+
   # ---- Backend jobs ----
   # Build backend development environment
   build-back:
@@ -820,6 +851,14 @@ workflows:
               only: /.*/
 
       - build-docker-admin:
+          filters:
+            tags:
+              only: /.*/
+
+      # Security jobs
+      #
+      # Scan front & back dependencies for known CVEs (report only)
+      - scan-cve:
           filters:
             tags:
               only: /.*/

--- a/.circleci/templates/trivy-cve-report.tpl
+++ b/.circleci/templates/trivy-cve-report.tpl
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Trivy CVE Report - {{ now }}</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-dt@2/css/dataTables.dataTables.min.css">
+    <style>
+      body { font-family: Arial, Helvetica, sans-serif; margin: 2em; }
+      h1 { text-align: center; }
+      .severity { text-align: center; font-weight: bold; color: #fafafa; padding: .2em .6em; border-radius: 4px; }
+      .severity-LOW { background-color: #5fbb31; }
+      .severity-MEDIUM { background-color: #e9c600; }
+      .severity-HIGH { background-color: #ff8800; }
+      .severity-CRITICAL { background-color: #e40000; }
+      .severity-UNKNOWN { background-color: #747474; }
+      table.dataTable { width: 100% !important; }
+    </style>
+  </head>
+  <body>
+    <h1>Trivy CVE Report - {{ now }}</h1>
+    <table id="cve-table" class="display" style="width:100%">
+      <thead>
+        <tr>
+          <th>Target</th>
+          <th>Package</th>
+          <th>Vulnerability ID</th>
+          <th>Severity</th>
+          <th>Installed Version</th>
+          <th>Fixed Version</th>
+          <th>Title</th>
+        </tr>
+      </thead>
+      <tbody>
+      {{- range . }}
+        {{- $target := .Target }}
+        {{- range .Vulnerabilities }}
+        {{- $sev := .Vulnerability.Severity }}
+        {{- $rank := 0 }}
+        {{- if eq $sev "CRITICAL" }}{{ $rank = 4 }}
+        {{- else if eq $sev "HIGH" }}{{ $rank = 3 }}
+        {{- else if eq $sev "MEDIUM" }}{{ $rank = 2 }}
+        {{- else if eq $sev "LOW" }}{{ $rank = 1 }}
+        {{- end }}
+        <tr>
+          <td>{{ escapeXML $target }}</td>
+          <td>{{ escapeXML .PkgName }}</td>
+          <td><a href="{{ escapeXML .PrimaryURL }}" target="_blank" rel="noopener">{{ escapeXML .VulnerabilityID }}</a></td>
+          <td data-order="{{ $rank }}"><span class="severity severity-{{ escapeXML $sev }}">{{ escapeXML $sev }}</span></td>
+          <td>{{ escapeXML .InstalledVersion }}</td>
+          <td>{{ escapeXML .FixedVersion }}</td>
+          <td>{{ escapeXML .Title }}</td>
+        </tr>
+        {{- end }}
+      {{- end }}
+      </tbody>
+    </table>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/datatables.net@2/js/dataTables.min.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', function () {
+        new DataTable('#cve-table', {
+          paging: false,
+          order: [[3, 'desc']]
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- Add Trivy CVE scan job in CI (report only, non-blocking)
 - Add `idnumber` in create user for Moodle LMS
 - Add issued on information in quote's context when total is set
 - Add payment method, session code and course code to order export csv


### PR DESCRIPTION
## Summary
- Add a `scan-cve` CircleCI job that scans the production image and frontend dependencies with Trivy
- Produces 3 separate, unambiguous HTML reports (via `--vuln-type os|library`) instead of one mixed report:
  - `env-report.html`: OS/Debian CVEs from the `python:3.11-bookworm` base image
  - `back-report.html`: back-end (Python/pip) application CVEs only
  - `front-report.html`: front-end (yarn/npm) application CVEs only
- Reports are published as CircleCI artifacts, downloadable from the job's "Artifacts" tab
- Informational only for now: `--exit-code 0`, the job never fails the pipeline

## Test plan
- [ ] Push branch and check the `scan-cve` job runs on CircleCI
- [ ] Download the 3 artifacts from the job's "Artifacts" tab
- [ ] Confirm each report only lists CVEs matching its scope (no Debian packages in `back-report.html`)
- [ ] Confirm the job passes regardless of findings