### PR TITLE
🐛(backend) fix missing vouchers in batch order email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to
 - Prevent seat exports of batch orders when no seats claimed
 - Normalize session code of course run in export orders csv
 - Update tray job in circle ci for ubuntu image version
+- Display voucher list in mail for purchase order batch order
 
 ## [3.3.0] - 2026-04-09
 

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -2510,8 +2510,11 @@ class BatchOrder(BaseModel):
 
     @property
     def vouchers(self):
-        """Return the exhaustive list of voucher codes generated from the orders"""
-        if self.state != enums.BATCH_ORDER_STATE_COMPLETED:
+        """
+        Return the exhaustive list of voucher codes generated from the orders.
+        When the batch order is cancelled, it returns an empty list.
+        """
+        if not self.has_orders_generated or self.is_canceled:
             return []
         return list(self.orders.values_list("voucher__code", flat=True))
 

--- a/src/backend/joanie/tests/core/api/admin/batch_order/test_retrieve.perf.yml
+++ b/src/backend/joanie/tests/core/api/admin/batch_order/test_retrieve.perf.yml
@@ -5,6 +5,7 @@ BatchOrdersAdminApiDetailTestCase.test_api_admin_batch_order_read_with_orders:
 - cache|get: parler.core.OrganizationTranslation.#.en-us
 - db: 'SELECT ... FROM "joanie_invoice" WHERE ("joanie_invoice"."batch_order_id" = #::uuid AND "joanie_invoice"."parent_id" IS #) LIMIT #'
 - db: 'SELECT ... FROM "joanie_contract_definition" WHERE "joanie_contract_definition"."id" = #::uuid LIMIT #'
+- db: 'SELECT # AS "a" FROM "joanie_order" WHERE "joanie_order"."batch_order_id" = #::uuid LIMIT #'
 - db: 'SELECT "joanie_voucher"."code" FROM "joanie_order" LEFT OUTER JOIN "joanie_voucher" ON ("joanie_order"."voucher_id" = "joanie_voucher"."id") WHERE "joanie_order"."batch_order_id" = #::uuid ORDER BY "joanie_order"."created_on" DESC'
 - db: 'SELECT ... FROM "joanie_offeringrule" INNER JOIN "joanie_batch_order_offering_rules" ON ("joanie_offeringrule"."id" = "joanie_batch_order_offering_rules"."offeringrule_id") INNER JOIN "joanie_course_product_relation" ON ("joanie_offeringrule"."course_product_relation_id" = "joanie_course_product_relation"."id") WHERE "joanie_batch_order_offering_rules"."batchorder_id" = #::uuid ORDER BY "joanie_course_product_relation"."created_on" DESC, "joanie_offeringrule"."position" ASC'
 - db: 'SELECT ... FROM "joanie_quote_definition" WHERE "joanie_quote_definition"."id" = #::uuid LIMIT #'

--- a/src/backend/joanie/tests/core/models/test_batch_order.py
+++ b/src/backend/joanie/tests/core/models/test_batch_order.py
@@ -593,27 +593,20 @@ class BatchOrderModelsTestCase(LoggingTestCase):
 
                     self.assertListEqual([], batch_order.vouchers)
 
-    def test_models_batch_order_property_vouchers_when_state_not_completed_for_purchase_order(
+    def test_models_batch_order_property_vouchers_with_purchase_order_payment_method(
         self,
     ):
         """
-        The property vouchers should return an empty list if the state of the batch order
-        is not completed with payment method `purchase_order`.
+        The property `vouchers` should return an empty list when the orders are not generated,
+        or if the batch order is cancelled when it uses purchase order payment method.
         """
-        excluded_states = [
-            enums.BATCH_ORDER_STATE_SIGNING,
-            enums.BATCH_ORDER_STATE_PENDING,
-            enums.BATCH_ORDER_STATE_PROCESS_PAYMENT,
-            enums.BATCH_ORDER_STATE_COMPLETED,
-        ]
         for state, _ in enums.BATCH_ORDER_STATE_CHOICES:
-            if state in excluded_states:
-                continue
             with self.subTest(state=state):
                 batch_order = factories.BatchOrderFactory(
                     state=state, payment_method=enums.BATCH_ORDER_WITH_PURCHASE_ORDER
                 )
-
+                if batch_order.has_orders_generated:
+                    continue
                 self.assertListEqual([], batch_order.vouchers)
 
     def test_models_batch_order_property_vouchers_when_batch_order_was_completed_to_canceled(
@@ -690,6 +683,8 @@ class BatchOrderModelsTestCase(LoggingTestCase):
             batch_order.orders.exclude(state=enums.ORDER_STATE_CANCELED).exists()
         )
         self.assertFalse(models.Voucher.objects.filter(code__in=voucher_codes).exists())
+        # Calling the property vouchers now should return an empty list
+        self.assertEqual(batch_order.vouchers, [])
 
     def test_models_batch_order_is_paid_quote_has_not_received_purchase_order(self):
         """


### PR DESCRIPTION
A previous change generating vouchers earlier for purchase orders was never reflected in the code sending the confirmation email, so it kept sending an empty voucher list.

Now it's fixed because we have updated the property `vouchers` of the `BatchOrder` model.

<img width="2025" height="1285" alt="Capture d’écran du 2026-08-06 14-00-10" src="https://github.com/user-attachments/assets/2f5aa63a-ccc3-4b65-acd1-c6360d8ee6c7" />
