### PR TITLE
✨(frontend) withdrawal management of order 

### DIFF
--- a/src/frontend/admin/src/components/templates/orders/buttons/OrderActions.spec.tsx
+++ b/src/frontend/admin/src/components/templates/orders/buttons/OrderActions.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import * as React from "react";
+import { server } from "mocks/server";
+import OrderActionsButton from "@/components/templates/orders/buttons/OrderActions";
+import { OrderFactory } from "@/services/factories/orders";
+import { buildApiUrl } from "@/services/http/HttpService";
+import { orderRoutes } from "@/services/repositories/orders/OrderRepository";
+import { OrderStatesEnum } from "@/services/api/models/Order";
+import { TestingWrapper } from "@/components/testing/TestingWrapper";
+
+const openActionsMenu = async () => {
+  const button = screen.getByRole("button", { name: /actions/i });
+  await userEvent.click(button);
+};
+
+describe("<OrderActionsButton /> withdrawal actions", () => {
+  it("disables confirm and reject withdrawal actions when the order has no pending withdrawal request", async () => {
+    const order = OrderFactory();
+    order.state = OrderStatesEnum.ORDER_STATE_COMPLETED;
+    server.use(
+      http.get(buildApiUrl(orderRoutes.get(order.id)), () =>
+        HttpResponse.json(order),
+      ),
+    );
+
+    render(<OrderActionsButton order={order} />, { wrapper: TestingWrapper });
+    await openActionsMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: "Confirm withdrawal" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByRole("menuitem", { name: "Reject withdrawal" }),
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("enables confirm and reject withdrawal actions when the order has a pending withdrawal request", async () => {
+    const order = OrderFactory();
+    order.state = OrderStatesEnum.ORDER_STATE_PENDING_WITHDRAW;
+    server.use(
+      http.get(buildApiUrl(orderRoutes.get(order.id)), () =>
+        HttpResponse.json(order),
+      ),
+    );
+
+    render(<OrderActionsButton order={order} />, { wrapper: TestingWrapper });
+    await openActionsMenu();
+
+    expect(
+      screen.getByRole("menuitem", { name: "Confirm withdrawal" }),
+    ).not.toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getByRole("menuitem", { name: "Reject withdrawal" }),
+    ).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("sends a confirm-withdrawal request when clicking Confirm withdrawal", async () => {
+    const order = OrderFactory();
+    order.state = OrderStatesEnum.ORDER_STATE_PENDING_WITHDRAW;
+    const onConfirmWithdrawal = jest.fn();
+    server.use(
+      http.get(buildApiUrl(orderRoutes.get(order.id)), () =>
+        HttpResponse.json(order),
+      ),
+      http.post(buildApiUrl(orderRoutes.confirmWithdrawal(order.id)), () => {
+        onConfirmWithdrawal();
+        return HttpResponse.json(null);
+      }),
+    );
+
+    render(<OrderActionsButton order={order} />, { wrapper: TestingWrapper });
+    await openActionsMenu();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Confirm withdrawal" }),
+    );
+
+    expect(onConfirmWithdrawal).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends a reject-withdrawal request when clicking Reject withdrawal", async () => {
+    const order = OrderFactory();
+    order.state = OrderStatesEnum.ORDER_STATE_PENDING_WITHDRAW;
+    const onRejectWithdrawal = jest.fn();
+    server.use(
+      http.get(buildApiUrl(orderRoutes.get(order.id)), () =>
+        HttpResponse.json(order),
+      ),
+      http.post(buildApiUrl(orderRoutes.rejectWithdrawal(order.id)), () => {
+        onRejectWithdrawal();
+        return HttpResponse.json(null);
+      }),
+    );
+
+    render(<OrderActionsButton order={order} />, { wrapper: TestingWrapper });
+    await openActionsMenu();
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Reject withdrawal" }),
+    );
+
+    expect(onRejectWithdrawal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/frontend/admin/src/components/templates/orders/buttons/OrderActions.tsx
+++ b/src/frontend/admin/src/components/templates/orders/buttons/OrderActions.tsx
@@ -4,6 +4,8 @@ import { defineMessages, useIntl } from "react-intl";
 import CancelIcon from "@mui/icons-material/Cancel";
 import ArticleIcon from "@mui/icons-material/Article";
 import CurrencyExchangeIcon from "@mui/icons-material/CurrencyExchange";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import DoNotDisturbIcon from "@mui/icons-material/DoNotDisturb";
 import { Order, OrderStatesEnum } from "@/services/api/models/Order";
 import ButtonMenu, {
   MenuOption,
@@ -60,6 +62,22 @@ const messages = defineMessages({
     id: "components.templates.orders.buttons.orderActionsButton.generateCertificate",
     description: "Label for the generate certificate order action",
     defaultMessage: "Generate certificate",
+  },
+  notPendingWithdrawalTooltip: {
+    id: "components.templates.orders.buttons.orderActionsButton.notPendingWithdrawalTooltip",
+    description:
+      "Text when the order has no withdrawal request awaiting review",
+    defaultMessage: "This order has no withdrawal request awaiting review",
+  },
+  confirmWithdrawal: {
+    id: "components.templates.orders.buttons.orderActionsButton.confirmWithdrawal",
+    description: "Label for the confirm withdrawal order action",
+    defaultMessage: "Confirm withdrawal",
+  },
+  rejectWithdrawal: {
+    id: "components.templates.orders.buttons.orderActionsButton.rejectWithdrawal",
+    description: "Label for the reject withdrawal order action",
+    defaultMessage: "Reject withdrawal",
   },
 });
 
@@ -132,6 +150,38 @@ export default function OrderActionsButton({ order }: Props) {
         disableMessage: generateCertificateDisableMessage(),
         onClick: async () => {
           ordersQuery.methods.generateCertificate(
+            { orderId: order.id },
+            {
+              onSuccess: orderQuery.methods.invalidate,
+            },
+          );
+        },
+      },
+      {
+        icon: <CheckCircleIcon />,
+        mainLabel: intl.formatMessage(messages.confirmWithdrawal),
+        isDisable: order.state !== OrderStatesEnum.ORDER_STATE_PENDING_WITHDRAW,
+        disableMessage: intl.formatMessage(
+          messages.notPendingWithdrawalTooltip,
+        ),
+        onClick: async () => {
+          ordersQuery.methods.confirmWithdrawal(
+            { orderId: order.id },
+            {
+              onSuccess: orderQuery.methods.invalidate,
+            },
+          );
+        },
+      },
+      {
+        icon: <DoNotDisturbIcon />,
+        mainLabel: intl.formatMessage(messages.rejectWithdrawal),
+        isDisable: order.state !== OrderStatesEnum.ORDER_STATE_PENDING_WITHDRAW,
+        disableMessage: intl.formatMessage(
+          messages.notPendingWithdrawalTooltip,
+        ),
+        onClick: async () => {
+          ordersQuery.methods.rejectWithdrawal(
             { orderId: order.id },
             {
               onSuccess: orderQuery.methods.invalidate,

--- a/src/frontend/admin/src/components/templates/orders/list/OrdersList.tsx
+++ b/src/frontend/admin/src/components/templates/orders/list/OrdersList.tsx
@@ -20,8 +20,8 @@ import { commonTranslations } from "@/translations/common/commonTranslations";
 import { OrderFilters } from "@/components/templates/orders/filters/OrderFilters";
 import { formatShortDate } from "@/utils/dates";
 import {
+  getOrderStateMessage,
   orderNatureMessages,
-  orderStatesMessages,
 } from "@/components/templates/orders/view/translations";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
@@ -127,7 +127,8 @@ export function OrdersList(props: Props) {
       field: "state",
       headerName: intl.formatMessage(messages.state),
       flex: 1,
-      valueGetter: (value) => intl.formatMessage(orderStatesMessages[value]),
+      valueGetter: (_value, row) =>
+        intl.formatMessage(getOrderStateMessage(row)),
     },
     {
       field: "nature",

--- a/src/frontend/admin/src/components/templates/orders/view/OrderView.spec.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/OrderView.spec.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { OrderView } from "@/components/templates/orders/view/OrderView";
 import { OrderFactory } from "@/services/factories/orders";
 import { TestingWrapper } from "@/components/testing/TestingWrapper";
+import { formatShortDate } from "@/utils/dates";
 
 jest.mock("@/hooks/useCopyToClipboard", () => ({
   useCopyToClipboard: () => jest.fn(),
@@ -42,5 +43,46 @@ describe("<OrderView /> voucher section", () => {
     expect(
       screen.queryByRole("button", { name: "Click to copy" }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("<OrderView /> withdrawal dates", () => {
+  it("does not render the withdrawal fields when the order has no withdrawal request", () => {
+    const order = OrderFactory();
+    order.withdrawn_requested_at = null;
+    order.withdrawn_confirmation_at = null;
+
+    render(<OrderView order={order} />, { wrapper: TestingWrapper });
+
+    expect(
+      screen.queryByLabelText("Withdrawal requested on"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Withdrawal confirmed on"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the withdrawal requested date when present", () => {
+    const order = OrderFactory();
+    order.withdrawn_requested_at = "2024-06-27T10:00:00Z";
+    order.withdrawn_confirmation_at = null;
+
+    render(<OrderView order={order} />, { wrapper: TestingWrapper });
+
+    expect(screen.getByLabelText("Withdrawal requested on")).toHaveValue(
+      formatShortDate(order.withdrawn_requested_at),
+    );
+  });
+
+  it("renders the withdrawal confirmation date when present", () => {
+    const order = OrderFactory();
+    order.withdrawn_requested_at = "2024-06-27T10:00:00Z";
+    order.withdrawn_confirmation_at = "2024-06-28T10:00:00Z";
+
+    render(<OrderView order={order} />, { wrapper: TestingWrapper });
+
+    expect(screen.getByLabelText("Withdrawal confirmed on")).toHaveValue(
+      formatShortDate(order.withdrawn_confirmation_at),
+    );
   });
 });

--- a/src/frontend/admin/src/components/templates/orders/view/OrderView.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/OrderView.tsx
@@ -23,8 +23,8 @@ import FormControlLabel from "@mui/material/FormControlLabel";
 import { useTheme } from "@mui/material/styles";
 import { Order, PaymentStatesEnum } from "@/services/api/models/Order";
 import {
+  getOrderStateMessage,
   orderNatureMessages,
-  orderStatesMessages,
   orderViewMessages,
 } from "@/components/templates/orders/view/translations";
 import { SimpleCard } from "@/components/presentational/card/SimpleCard";
@@ -215,7 +215,7 @@ export function OrderView({ order }: Props) {
                 fullWidth={true}
                 disabled={true}
                 label={intl.formatMessage(orderViewMessages.state)}
-                value={intl.formatMessage(orderStatesMessages[order.state])}
+                value={intl.formatMessage(getOrderStateMessage(order))}
               />
             </Grid>
             <Grid size={{ xs: 12, sm: 6 }}>
@@ -237,6 +237,31 @@ export function OrderView({ order }: Props) {
                 )}
               />
             </Grid>
+
+            {order.withdrawn_requested_at && (
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <TextField
+                  fullWidth={true}
+                  disabled={true}
+                  label={intl.formatMessage(
+                    orderViewMessages.withdrawnRequestedAt,
+                  )}
+                  value={formatShortDate(order.withdrawn_requested_at)}
+                />
+              </Grid>
+            )}
+            {order.withdrawn_confirmation_at && (
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <TextField
+                  fullWidth={true}
+                  disabled={true}
+                  label={intl.formatMessage(
+                    orderViewMessages.withdrawnConfirmationAt,
+                  )}
+                  value={formatShortDate(order.withdrawn_confirmation_at)}
+                />
+              </Grid>
+            )}
 
             {order.voucher && (
               <Grid size={{ xs: 12, sm: 6 }}>

--- a/src/frontend/admin/src/components/templates/orders/view/translations.spec.ts
+++ b/src/frontend/admin/src/components/templates/orders/view/translations.spec.ts
@@ -1,0 +1,35 @@
+import {
+  getOrderStateMessage,
+  orderStatesMessages,
+  orderStateWithdrawnMessage,
+} from "@/components/templates/orders/view/translations";
+import { OrderStatesEnum } from "@/services/api/models/Order";
+
+describe("getOrderStateMessage", () => {
+  it("returns the withdrawn message for a canceled order with a withdrawal confirmation date", () => {
+    const message = getOrderStateMessage({
+      state: OrderStatesEnum.ORDER_STATE_CANCELED,
+      withdrawn_confirmation_at: "2024-06-27T10:00:00Z",
+    });
+
+    expect(message).toBe(orderStateWithdrawnMessage);
+  });
+
+  it("returns the canceled message for a canceled order without a withdrawal confirmation date", () => {
+    const message = getOrderStateMessage({
+      state: OrderStatesEnum.ORDER_STATE_CANCELED,
+      withdrawn_confirmation_at: null,
+    });
+
+    expect(message).toBe(orderStatesMessages.canceled);
+  });
+
+  it("returns the regular state message for a non-canceled state", () => {
+    const message = getOrderStateMessage({
+      state: OrderStatesEnum.ORDER_STATE_PENDING_WITHDRAW,
+      withdrawn_confirmation_at: null,
+    });
+
+    expect(message).toBe(orderStatesMessages.pending_withdraw);
+  });
+});

--- a/src/frontend/admin/src/components/templates/orders/view/translations.tsx
+++ b/src/frontend/admin/src/components/templates/orders/view/translations.tsx
@@ -1,10 +1,11 @@
-import { defineMessages } from "react-intl";
+import { defineMessage, defineMessages } from "react-intl";
 import {
   OrderInvoiceStatusEnum,
   OrderInvoiceTypesEnum,
   OrderNatureEnum,
   OrderStatesEnum,
 } from "@/services/api/models/Order";
+import { Nullable } from "@/types/utils";
 
 export const orderViewMessages = defineMessages({
   contract: {
@@ -200,6 +201,16 @@ export const orderViewMessages = defineMessages({
     defaultMessage: "The user has not waived its withdrawal right.",
     description: "Text for the has waived withdrawal right label",
   },
+  withdrawnRequestedAt: {
+    id: "components.templates.orders.view.withdrawnRequestedAt",
+    defaultMessage: "Withdrawal requested on",
+    description: "Label for the withdrawal request date field",
+  },
+  withdrawnConfirmationAt: {
+    id: "components.templates.orders.view.withdrawnConfirmationAt",
+    defaultMessage: "Withdrawal confirmed on",
+    description: "Label for the withdrawal confirmation date field",
+  },
   voucher: {
     id: "components.templates.orders.view.voucher",
     defaultMessage: "Voucher code",
@@ -287,6 +298,11 @@ export const orderStatesMessages = defineMessages<OrderStatesEnum>({
     defaultMessage: "Pending",
     description: "Text for pending order state",
   },
+  pending_withdraw: {
+    id: "components.templates.orders.view.orderStatesMessages.pending_withdraw",
+    defaultMessage: "Withdrawal to review",
+    description: "Text for pending withdraw order state",
+  },
   canceled: {
     id: "components.templates.orders.view.orderStatesMessages.canceled",
     defaultMessage: "Canceled",
@@ -328,3 +344,29 @@ export const orderStatesMessages = defineMessages<OrderStatesEnum>({
     description: "Text for refunded order state",
   },
 });
+
+export const orderStateWithdrawnMessage = defineMessage({
+  id: "components.templates.orders.view.orderStatesMessages.withdrawn",
+  defaultMessage: "Withdrawn",
+  description:
+    "Text for a canceled order state that was actually canceled by the owner exercising their withdrawal right",
+});
+
+/**
+ * A withdrawn order shares the same `canceled` state as any other cancellation, the only
+ * distinguishing signal being `withdrawn_confirmation_at`. Use this instead of
+ * `orderStatesMessages[order.state]` directly wherever the order state is displayed, so
+ * withdrawn orders read as "Withdrawn" rather than a plain, ambiguous "Canceled".
+ */
+export const getOrderStateMessage = (order: {
+  state: OrderStatesEnum;
+  withdrawn_confirmation_at?: Nullable<string>;
+}) => {
+  if (
+    order.state === OrderStatesEnum.ORDER_STATE_CANCELED &&
+    order.withdrawn_confirmation_at
+  ) {
+    return orderStateWithdrawnMessage;
+  }
+  return orderStatesMessages[order.state];
+};

--- a/src/frontend/admin/src/hooks/useOrders/useOrders.tsx
+++ b/src/frontend/admin/src/hooks/useOrders/useOrders.tsx
@@ -31,6 +31,18 @@ export const useOrdersMessages = defineMessages({
       "Success message shown to the user when the order is being refunded.",
     defaultMessage: "Refunding order.",
   },
+  successConfirmWithdrawal: {
+    id: "hooks.useOrders.successConfirmWithdrawal",
+    description:
+      "Success message shown to the user when the withdrawal request has been confirmed.",
+    defaultMessage: "Withdrawal request confirmed.",
+  },
+  successRejectWithdrawal: {
+    id: "hooks.useOrders.successRejectWithdrawal",
+    description:
+      "Success message shown to the user when the withdrawal request has been rejected.",
+    defaultMessage: "Withdrawal request rejected.",
+  },
   errorGet: {
     id: "hooks.useOrders.errorGet",
     description:
@@ -152,6 +164,40 @@ export const useOrders = (
           custom.methods.invalidate();
           custom.methods.showSuccessMessage(
             intl.formatMessage(useOrdersMessages.successRefund),
+          );
+        },
+        onError: (error: HttpError) => {
+          custom.methods.setError(
+            error.data?.details ??
+              intl.formatMessage(useOrdersMessages.errorUpdate),
+          );
+        },
+      }).mutate,
+      confirmWithdrawal: mutation({
+        mutationFn: async (data: { orderId: string }) => {
+          return OrderRepository.confirmWithdrawal(data.orderId);
+        },
+        onSuccess: () => {
+          custom.methods.invalidate();
+          custom.methods.showSuccessMessage(
+            intl.formatMessage(useOrdersMessages.successConfirmWithdrawal),
+          );
+        },
+        onError: (error: HttpError) => {
+          custom.methods.setError(
+            error.data?.details ??
+              intl.formatMessage(useOrdersMessages.errorUpdate),
+          );
+        },
+      }).mutate,
+      rejectWithdrawal: mutation({
+        mutationFn: async (data: { orderId: string }) => {
+          return OrderRepository.rejectWithdrawal(data.orderId);
+        },
+        onSuccess: () => {
+          custom.methods.invalidate();
+          custom.methods.showSuccessMessage(
+            intl.formatMessage(useOrdersMessages.successRejectWithdrawal),
           );
         },
         onError: (error: HttpError) => {

--- a/src/frontend/admin/src/services/api/models/Order.ts
+++ b/src/frontend/admin/src/services/api/models/Order.ts
@@ -31,6 +31,7 @@ export type OrderListItem = AbstractOrder & {
   owner_name: string;
   product_title: string;
   voucher: Nullable<string>;
+  withdrawn_confirmation_at: Nullable<string>;
 };
 
 export enum PaymentStatesEnum {
@@ -73,6 +74,8 @@ export type Order = AbstractOrder & {
   payment_schedule: Nullable<OrderPaymentSchedule[]>;
   credit_card: Nullable<OrderCreditCard>;
   has_waived_withdrawal_right: boolean;
+  withdrawn_requested_at: Nullable<string>;
+  withdrawn_confirmation_at: Nullable<string>;
   voucher: Nullable<OrderVoucher>;
 };
 
@@ -141,6 +144,7 @@ export enum OrderStatesEnum {
   ORDER_STATE_TO_SIGN = "to_sign", // order needs a contract signature
   ORDER_STATE_SIGNING = "signing", // order is pending for contract signature validation
   ORDER_STATE_PENDING = "pending", // payment has failed but can be retried
+  ORDER_STATE_PENDING_WITHDRAW = "pending_withdraw", // withdrawal request awaiting manual review
   ORDER_STATE_CANCELED = "canceled", // has been canceled
   ORDER_STATE_PENDING_PAYMENT = "pending_payment", // payment is pending
   ORDER_STATE_TO_OWN = "to_own", // order is paid but is awaiting owner to claim it
@@ -166,6 +170,7 @@ export const transformOrderToOrderListItem = (order: Order): OrderListItem => {
     total: order.total,
     total_currency: order.total_currency,
     voucher: order.voucher?.code ?? null,
+    withdrawn_confirmation_at: order.withdrawn_confirmation_at,
   };
 };
 

--- a/src/frontend/admin/src/services/factories/orders/index.ts
+++ b/src/frontend/admin/src/services/factories/orders/index.ts
@@ -82,6 +82,8 @@ const build = (state?: OrderStatesEnum): Order => {
     ],
     credit_card: CreditCardFactory(),
     has_waived_withdrawal_right: faker.datatype.boolean(),
+    withdrawn_requested_at: null,
+    withdrawn_confirmation_at: null,
     voucher: null,
   };
   if (
@@ -136,6 +138,7 @@ const buildOrderListItem = (): OrderListItem => {
     total: faker.number.float({ min: 1, max: 9999 }),
     total_currency: "EUR",
     voucher: null,
+    withdrawn_confirmation_at: null,
   };
 };
 

--- a/src/frontend/admin/src/services/repositories/orders/OrderRepository.ts
+++ b/src/frontend/admin/src/services/repositories/orders/OrderRepository.ts
@@ -16,6 +16,8 @@ export const orderRoutes = {
   delete: (id: string) => `/orders/${id}/`,
   generateCertificate: (id: string) => `/orders/${id}/generate_certificate/`,
   refund: (id: string) => `/orders/${id}/refund/`,
+  confirmWithdrawal: (id: string) => `/orders/${id}/confirm-withdrawal/`,
+  rejectWithdrawal: (id: string) => `/orders/${id}/reject-withdrawal/`,
   export: (params: string = "") => `/orders/export/${params}`,
 };
 
@@ -57,6 +59,16 @@ export class OrderRepository {
 
   static refund(id: string): Promise<void> {
     const url = orderRoutes.refund(id);
+    return fetchApi(url, { method: "POST" }).then(checkStatus);
+  }
+
+  static confirmWithdrawal(id: string): Promise<void> {
+    const url = orderRoutes.confirmWithdrawal(id);
+    return fetchApi(url, { method: "POST" }).then(checkStatus);
+  }
+
+  static rejectWithdrawal(id: string): Promise<void> {
+    const url = orderRoutes.rejectWithdrawal(id);
     return fetchApi(url, { method: "POST" }).then(checkStatus);
   }
 


### PR DESCRIPTION
## Purpose

Add confirm / reject withdrawal action in the back-office, display the withdrawal dates and display a new withdrawn
state.
