### PR TITLE
:recycle:(backend) rework emails withdrawal 

### DIFF
--- a/env.d/development/common.dist
+++ b/env.d/development/common.dist
@@ -91,6 +91,9 @@ JOANIE_AUTHORIZED_API_TOKENS = "secretTokenForRemoteAPIConsumer"
 # Add here the dashboard link of orders for email sent when an installment is paid
 JOANIE_DASHBOARD_ORDER_LINK = "http://localhost:8070/dashboard/courses/orders/:orderId/"
 
+# Add here the backoffice link of an order for email sent when a withdrawal action is done
+JOANIE_BACKOFFICE_ORDER_LINK = "http://localhost:8072/admin/orders/:orderId/view"
+
 # Add generic email for withdrawal emails
 JOANIE_EMAIL_SUPPORT_CERTIFICATE = "certificate@support.acme"
 JOANIE_EMAIL_SUPPORT_CREDENTIAL = "credential@support.acme"

--- a/src/backend/joanie/core/admin.py
+++ b/src/backend/joanie/core/admin.py
@@ -592,6 +592,8 @@ class OrderAdmin(DjangoObjectActions, admin.ModelAdmin):
         "invoice",
         "certificate",
         "batch_order_link",
+        "withdrawn_requested_at",
+        "withdrawn_confirmation_at",
     )
     search_fields = ["course__translations__title", "organization__translations__title"]
 

--- a/src/backend/joanie/core/utils/emails.py
+++ b/src/backend/joanie/core/utils/emails.py
@@ -106,33 +106,46 @@ def send(subject, template_vars, template_name, to_user_email):
         logger.error("%s purchase order mail %s not send", to_user_email, exception)
 
 
-def _prepare_withdrawal_context(order, title):
+def _prepare_withdrawal_context(
+    order,
+    is_support_email=False,
+    is_organization_admin=False,
+):
     """Prepare the common context variables for withdrawal-related emails."""
     product_title = order.product.safe_translation_getter(
         "title", language_code=order.owner.language
     )
     return {
-        "title": title,
         "email": order.owner.email,
-        "fullname": order.owner.name,
+        "buyer_fullname": order.owner.name,
         "product_title": product_title,
+        "order_id": str(order.id),
+        "course_code": (
+            order.course.code if order.product.type == PRODUCT_TYPE_CREDENTIAL else None
+        ),
+        "withdrawal_requested_at": order.withdrawn_requested_at,
         "dashboard_order_link": (
             settings.JOANIE_DASHBOARD_ORDER_LINK.replace(":orderId", str(order.id))
+        ),
+        "backoffice_dashboard_order_link": (
+            settings.JOANIE_BACKOFFICE_ORDER_LINK.replace(":orderId", str(order.id))
         ),
         "site": {
             "name": settings.JOANIE_CATALOG_NAME,
             "url": settings.JOANIE_CATALOG_BASE_URL,
         },
+        "is_support_email": is_support_email,
+        "is_organization_admin": is_organization_admin,
     }
 
 
 def _prepare_withdrawal_recipients(order):
     """
-    The withdrawal email should be sent to 3 recipients.
+    The withdrawal email should be sent to 3 recipients at least.
     Those recipients are : the buyer, the organization administrators, and the generic
     staff member mail.
     """
-    recipients = [order.owner.email]
+    recipients = {order.owner.name: order.owner.email}
 
     support_email = None
     if order.product.type == PRODUCT_TYPE_CERTIFICATE:
@@ -140,25 +153,38 @@ def _prepare_withdrawal_recipients(order):
     elif order.product.type == PRODUCT_TYPE_CREDENTIAL:
         support_email = settings.JOANIE_EMAIL_SUPPORT_CREDENTIAL
     if support_email:
-        recipients.append(support_email)
+        recipients["Support"] = support_email
 
     organization_emails = order.organization.accesses.filter(role=ADMIN).values_list(
-        "user__email", flat=True
+        "user__first_name", "user__email"
     )
-    recipients.extend(list(organization_emails))
+
+    recipients.update(dict(organization_emails))
 
     return recipients
 
 
-def _send_withdrawal_email(order, title, template_name):
-    """Send a withdrawal-related mail to the order owner."""
+def _send_withdrawal_email(order, subject, template_name):
+    """
+    Send a withdrawal-related mail to the order owner.
+    The first recipient is the buyer, the second is the support, and finally the
+    organization administrators.
+    """
     email_recipients = _prepare_withdrawal_recipients(order)
-    for to_user_email in email_recipients:
+    for index, recipient in enumerate(email_recipients.items()):
+        is_support_email = index == 1
+        is_organization_admin = index >= 2  # noqa : PLR2004
+        context = _prepare_withdrawal_context(
+            order,
+            is_support_email=is_support_email,
+            is_organization_admin=is_organization_admin,
+        )
+        context["fullname"] = recipient[0]
         send(
-            subject=title,
-            template_vars=_prepare_withdrawal_context(order, title),
+            subject=subject,
+            template_vars=context,
             template_name=template_name,
-            to_user_email=to_user_email,
+            to_user_email=recipient[1],
         )
 
 

--- a/src/backend/joanie/debug/views.py
+++ b/src/backend/joanie/debug/views.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals, too-many-lines
 """All debug views of the `debug`app."""
 
 import base64
@@ -110,6 +110,23 @@ class DebugMailSuccessPaymentViewTxt(DebugMailSuccessPayment):
 class DebugWithdrawal(TemplateView):
     """Debug View to check the layout of withdrawal-related emails"""
 
+    def update_context(self, context):
+        """
+        Retrieve the query parameter passed in the url to see different views of the email
+        depending on the recipient role.
+        """
+        is_support_email = self.request.GET.get("is_support_email")
+        is_organization_admin = self.request.GET.get("is_organization_admin")
+        context["is_support_email"] = bool(is_support_email)
+        context["is_organization_admin"] = bool(is_organization_admin)
+        # Override fullname because the receiver is not the buyer
+        if is_support_email:
+            context["fullname"] = "Support"
+        if is_organization_admin:
+            context["fullname"] = "Organization Admin"
+
+        return context
+
     def get_context_data(self, **kwargs):
         """Generates sample datas to have a valid debug email"""
         enrollment = EnrollmentFactory()
@@ -140,18 +157,25 @@ class DebugWithdrawal(TemplateView):
             )
             context = super().get_context_data(**kwargs)
             context["title"] = "👨‍💻Development email preview"
+            context["withdrawal_requested_at"] = timezone.now()
+            context["course_code"] = "0001"  # Use None to see difference in template
             context["email"] = order.owner.email
             context["fullname"] = order.owner.name
+            context["buyer_fullname"] = order.owner.name
             context["product_title"] = product_title
+            context["order_id"] = str(order.id)
             context["dashboard_order_link"] = (
                 settings.JOANIE_DASHBOARD_ORDER_LINK.replace(":orderId", str(order.id))
+            )
+            context["backoffice_dashboard_order_link"] = (
+                settings.JOANIE_BACKOFFICE_ORDER_LINK.replace("orderId", str(order.id))
             )
             context["site"] = {
                 "name": settings.JOANIE_CATALOG_NAME,
                 "url": settings.JOANIE_CATALOG_BASE_URL,
             }
 
-            return context
+            return self.update_context(context)
 
 
 class DebugWithdrawalRequestViewHtml(DebugWithdrawal):

--- a/src/backend/joanie/settings.py
+++ b/src/backend/joanie/settings.py
@@ -473,6 +473,13 @@ class Base(Configuration):
         environ_name="JOANIE_INSTALLMENT_REMINDER_DAYS_BEFORE",
         environ_prefix=None,
     )
+    # Email for withdrawal
+    # Add here the backoffice order detail view link
+    JOANIE_BACKOFFICE_ORDER_LINK = values.Value(
+        None,
+        environ_name="JOANIE_BACKOFFICE_ORDER_LINK",
+        environ_prefix=None,
+    )
     # Link to the microcertification terms of service which is used
     # at a first place in the Unicamp certificate template
     JOANIE_DEGREE_MICROCERTIFICATION_TERMS_URL = values.Value(
@@ -867,6 +874,7 @@ class Test(Base):
     JOANIE_DASHBOARD_ORDER_LINK = (
         "http://localhost:8070/dashboard/courses/orders/:orderId/"
     )
+    JOANIE_BACKOFFICE_ORDER_LINK = "http://localhost:8072/admin/orders/:orderId/view"
 
     JOANIE_DEGREE_MICROCERTIFICATION_TERMS_URL = "https://example.com/terms"
 

--- a/src/backend/joanie/tests/core/api/admin/orders/test_confirm_withdrawal.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_confirm_withdrawal.py
@@ -218,16 +218,16 @@ class OrdersAdminApiConfirmWithdrawalTestCase(BaseAPITestCase):
         self.assertEqual("Withdrawal confirmed", mail.outbox[0].subject)
         self.assertEqual(mail.outbox[0].to[0], order.owner.email)
         email_content = " ".join(mail.outbox[0].body.split())
-        self.assertIn("The order has been cancelled accordingly", email_content)
+        self.assertIn("has been cancelled accordingly", email_content)
 
         self.assertEqual("Withdrawal confirmed", mail.outbox[1].subject)
         self.assertEqual(
             mail.outbox[1].to[0], settings.JOANIE_EMAIL_SUPPORT_CERTIFICATE
         )
         email_content = " ".join(mail.outbox[1].body.split())
-        self.assertIn("The order has been cancelled accordingly", email_content)
+        self.assertIn("has been confirmed", email_content)
 
         self.assertEqual("Withdrawal confirmed", mail.outbox[2].subject)
         self.assertEqual(mail.outbox[2].to[0], access.user.email)
         email_content = " ".join(mail.outbox[2].body.split())
-        self.assertIn("The order has been cancelled accordingly", email_content)
+        self.assertIn("has been cancelled accordingly", email_content)

--- a/src/backend/joanie/tests/core/api/admin/orders/test_reject_withdrawal.py
+++ b/src/backend/joanie/tests/core/api/admin/orders/test_reject_withdrawal.py
@@ -218,22 +218,16 @@ class OrdersAdminApiRejectWithdrawalTestCase(BaseAPITestCase):
         self.assertEqual("Withdrawal request rejected", mail.outbox[0].subject)
         self.assertEqual(mail.outbox[0].to[0], order.owner.email)
         email_content = " ".join(mail.outbox[0].body.split())
-        self.assertIn(
-            "The order remains active and resumes its normal course", email_content
-        )
+        self.assertIn("remains active and resumes its normal course", email_content)
 
         self.assertEqual("Withdrawal request rejected", mail.outbox[1].subject)
         self.assertEqual(
             mail.outbox[1].to[0], settings.JOANIE_EMAIL_SUPPORT_CERTIFICATE
         )
         email_content = " ".join(mail.outbox[1].body.split())
-        self.assertIn(
-            "The order remains active and resumes its normal course", email_content
-        )
+        self.assertIn("remains active and resumes its normal course", email_content)
 
         self.assertEqual("Withdrawal request rejected", mail.outbox[2].subject)
         self.assertEqual(mail.outbox[2].to[0], access.user.email)
         email_content = " ".join(mail.outbox[2].body.split())
-        self.assertIn(
-            "The order remains active and resumes its normal course", email_content
-        )
+        self.assertIn("remains active and resumes its normal course", email_content)

--- a/src/backend/joanie/tests/core/api/order/test_withdraw.py
+++ b/src/backend/joanie/tests/core/api/order/test_withdraw.py
@@ -227,7 +227,7 @@ class OrderWithdrawApiTest(BaseAPITestCase):
                                 )
                                 email_content = " ".join(mail.outbox[0].body.split())
                                 self.assertIn(
-                                    "We have received a withdrawal request",
+                                    "will review your request",
                                     email_content,
                                 )
 
@@ -241,7 +241,7 @@ class OrderWithdrawApiTest(BaseAPITestCase):
                                 )
                                 email_content = " ".join(mail.outbox[1].body.split())
                                 self.assertIn(
-                                    "We have received a withdrawal request",
+                                    "needs your review to validate",
                                     email_content,
                                 )
                                 mail.outbox.clear()
@@ -270,7 +270,7 @@ class OrderWithdrawApiTest(BaseAPITestCase):
                                 )
                                 email_content = " ".join(mail.outbox[0].body.split())
                                 self.assertIn(
-                                    "The order has been cancelled accordingly",
+                                    "has been cancelled accordingly",
                                     email_content,
                                 )
 
@@ -283,7 +283,7 @@ class OrderWithdrawApiTest(BaseAPITestCase):
                                 )
                                 email_content = " ".join(mail.outbox[1].body.split())
                                 self.assertIn(
-                                    "The order has been cancelled accordingly",
+                                    "has been confirmed",
                                     email_content,
                                 )
                                 mail.outbox.clear()
@@ -368,7 +368,6 @@ class OrderWithdrawApiTest(BaseAPITestCase):
                             )
 
                             order.refresh_from_db()
-                            # breakpoint()
                             if (
                                 day <= settings.JOANIE_WITHDRAWAL_PERIOD_DAYS
                                 and not value

--- a/src/mail/mjml/withdrawal_confirmation.mjml
+++ b/src/mail/mjml/withdrawal_confirmation.mjml
@@ -6,11 +6,47 @@
       <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
         <mj-column>
           <mj-text padding="0">
-            {% blocktranslate with title=product_title %}
-            The withdrawal request for <strong>{{ title }}</strong> has been confirmed.
+          {% if not is_organization_admin or is_support_email  %}
+          {% blocktranslate with title=product_title withdrawal_request_date=withdrawal_requested_at|date:"DATETIME_FORMAT" %}
+            The withdrawal request on the {{ withdrawal_request_date }} for <strong>{{ title }}</strong> has been confirmed.
             <br />
-            The order has been cancelled accordingly.
+          {% endblocktranslate %}
+          {% elif is_organization_admin or is_support_email %}
+            {% blocktranslate with title=product_title %}
+              The order '{{ order_id }}' on course <strong>{{ title }}</strong> for <strong>{{ buyer_fullname }}</strong> has been
+              cancelled accordingly.
             {% endblocktranslate %}
+          {% endif %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+            {% if not course_code and not is_support_email and not is_organization_admin %}
+              {% blocktranslate %}
+                Your order '{{ order_id }}' has been cancelled accordingly.
+              {% endblocktranslate %}
+            {% elif course_code and not is_support_email and not is_organization_admin %}
+              {% blocktranslate %}
+                The order '{{ order_id }}' for course code {{ course_code }} has been cancelled accordingly.
+              {% endblocktranslate %}
+            {% endif %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+          {% if is_support_email %}
+            {% blocktranslate %}
+              Please find the order in the <a href="{{ backoffice_dashboard_order_link }}">backoffice</a>
+            {% endblocktranslate %}
+          {% elif not is_organization_admin and not is_support_email %}
+            {% blocktranslate %}
+              You may check your order on your <a href="{{ dashboard_order_link }}">dashboard</a>
+            {% endblocktranslate %}
+          {% endif %}
           </mj-text>
         </mj-column>
       </mj-section>

--- a/src/mail/mjml/withdrawal_rejection.mjml
+++ b/src/mail/mjml/withdrawal_rejection.mjml
@@ -6,11 +6,26 @@
       <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
         <mj-column>
           <mj-text padding="0">
-            {% blocktranslate with title=product_title %}
-            After review, the withdrawal request for <strong>{{ title }}</strong> has been rejected.
-            <br />
-            The order remains active and resumes its normal course.
+            {% blocktranslate with title=product_title withdrawal_requested_at=withdrawal_requested_at|date:"DATETIME_FORMAT" %}
+              After review by our support team, the withdrawal request on {{ withdrawal_requested_at }} for <strong>{{ title }}</strong> has been <strong>rejected</strong>.
+              The order '{{ order_id }}' remains active and resumes its normal course.
             {% endblocktranslate %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+          {% if is_support_email %}
+            {% blocktranslate %}
+              Please find the order in the <a href="{{ backoffice_dashboard_order_link }}">backoffice</a>
+            {% endblocktranslate %}
+          {% elif not is_organization_admin and not is_support_email %}
+            {% blocktranslate %}
+              You may check your order on your <a href="{{ dashboard_order_link }}">dashboard</a>.
+              If you have any questions, please feel free to reach our support team.
+            {% endblocktranslate %}
+          {% endif %}
           </mj-text>
         </mj-column>
       </mj-section>

--- a/src/mail/mjml/withdrawal_request.mjml
+++ b/src/mail/mjml/withdrawal_request.mjml
@@ -6,11 +6,46 @@
       <mj-section mj-class="bg--blue-100" border-radius="6px 6px 0 0" padding="0 50px 20px 50px">
         <mj-column>
           <mj-text padding="0">
+          {% if is_support_email %}
             {% blocktranslate with title=product_title %}
-            We have received a withdrawal request for <strong>{{ title }}</strong>.
-            <br />
-            Our team will review the request and receive a confirmation email once it has been processed.
+              A withdrawal request is made for the <strong>{{ title }}</strong>.
+              The order '{{ order_id }}' for {{ buyer_fullname }} needs your review to validate
+              the withdrawal.
             {% endblocktranslate %}
+          {% elif is_organization_admin %}
+            {% blocktranslate with title=product_title %}
+              A withdrawal request has been made on an order on the course <strong>{{ title }}</strong>.
+              The order for {{ buyer_fullname }} will go under investigation by the support team to see if it is eligible
+              to be withdrawn.
+            {% endblocktranslate %}
+          {% elif not is_support_email or not is_organization_admin %}
+            {% with withdrawal_request_date=withdrawal_requested_at|date:"DATETIME_FORMAT" %}
+            {% blocktranslate with title=product_title %}
+              We have received a withdrawal request for <strong>{{ title }}</strong> for your order '{{ order_id }}'.
+              </br>
+              We registered your withdrawal request on <strong>{{ withdrawal_request_date }}</strong>, and it is now being processed.
+            {% endblocktranslate %}
+            {% endwith %}
+          {% endif %}
+          </mj-text>
+        </mj-column>
+      </mj-section>
+      <mj-section mj-class="bg--blue-100" padding="0 50px 20px 50px">
+        <mj-column>
+          <mj-text padding="0">
+          {% if is_support_email %}
+            {% blocktranslate %}
+              Please find the order in the <a href="{{ backoffice_dashboard_order_link }}">backoffice</a>
+            {% endblocktranslate %}
+          {% elif is_organization_admin %}
+            {% blocktranslate %}
+              A confirmation or rejection email will soon follow up about the state of this order.
+            {% endblocktranslate %}
+          {% else %}
+            {% blocktranslate %}
+              Our team will review your request.
+            {% endblocktranslate %}
+          {% endif %}
           </mj-text>
         </mj-column>
       </mj-section>


### PR DESCRIPTION
## Purpose

Last small adjustments on the template of the email related to withdrawal.
New environment variable for withdrawal template redirect to backoffice : `JOANIE_BACKOFFICE_ORDER_LINK`

To improve developer's experience, for the __debug__ template, you may use those parameter to switch email view : 
`is_support_email=True` or `is_organization_admin=True`. When none of those parameters are set, it will be the view of the buyer.

Here are some snapshots of the email templates for each case : 

## Request 📥
**Withdrawal request buyer** 
<img width="1016" height="900" alt="image" src="https://github.com/user-attachments/assets/82d5b501-5a76-4893-876d-4f6eac91efb7" />

**Withdrawal request support**
<img width="1016" height="900" alt="image" src="https://github.com/user-attachments/assets/dcdc3a28-00b6-4992-bd96-f870a1acb745" />

**Withdrawal request organization admin**
<img width="1016" height="900" alt="image" src="https://github.com/user-attachments/assets/b9cf46d3-0526-4978-b372-746798fb5c2d" />

## Rejection :x: 
**Withdrawal rejection buyer**
<img width="990" height="950" alt="image" src="https://github.com/user-attachments/assets/bdf3ca06-2930-4ef6-a43e-a0cd016b9d7e" />

**Withdrawal rejection support**
<img width="990" height="950" alt="image" src="https://github.com/user-attachments/assets/0c62e3fe-8135-4e26-879b-c1d8a69d983d" />

**Withdrawal rejection organization**
<img width="990" height="870" alt="image" src="https://github.com/user-attachments/assets/43d757e5-14b4-4398-b1dd-cddd422ddc85" />

## Confirmation :heavy_check_mark: 
**Withdrawal confirmation buyer**
<img width="990" height="804" alt="image" src="https://github.com/user-attachments/assets/4f027a81-9cc4-4366-aef9-0487ee53e92a" />

**Withdrawal confirmation support**
<img width="990" height="804" alt="image" src="https://github.com/user-attachments/assets/5ee88272-1bbb-481c-88fc-3231f43aae58" />

**Withdrawal confirmation organization**
<img width="1050" height="792" alt="image" src="https://github.com/user-attachments/assets/e2fbcbd7-cd96-4ea9-96c1-3d6d97194ebe" />

## Proposal

- [x] Add conditional template depending on the receiver for withdrawal emails
- [x] Add new environment variable to redirect to backoffice for support 