### PR TITLE
♻️(backend) add `alternatename` in moodle backend create user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add `alternatename` to create user for moodle lms backend
+
 ## [3.4.0] - 2026-08-13
 
 ### Added

--- a/src/backend/joanie/lms_handler/backends/moodle.py
+++ b/src/backend/joanie/lms_handler/backends/moodle.py
@@ -110,6 +110,7 @@ class MoodleLMSBackend(BaseLMSBackend):
             "email": user.email,
             "auth": settings.MOODLE_AUTH_METHOD,
             "idnumber": user.username,
+            "alternatename": user.username,
         }
         try:
             return self.moodle("core_user_create_users", users=[user_data])[0]

--- a/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
+++ b/src/backend/joanie/tests/lms_handler/test_backend_moodle.py
@@ -371,6 +371,7 @@ class MoodleLMSBackendTestCase(TestCase):
                         "users[0][email]": user.email,
                         "users[0][auth]": "moodle_auth_method",
                         "users[0][idnumber]": user.username,
+                        "users[0][alternatename]": user.username,
                     }
                 )
             ],
@@ -403,6 +404,7 @@ class MoodleLMSBackendTestCase(TestCase):
                         "users[0][email]": user.email,
                         "users[0][auth]": "moodle_auth_method",
                         "users[0][idnumber]": "johndoe",
+                        "users[0][alternatename]": "johndoe",
                     }
                 )
             ],
@@ -436,6 +438,7 @@ class MoodleLMSBackendTestCase(TestCase):
                         "users[0][email]": user.email,
                         "users[0][auth]": "moodle_auth_method",
                         "users[0][idnumber]": user.username,
+                        "users[0][alternatename]": user.username,
                     }
                 )
             ],
@@ -724,6 +727,7 @@ class MoodleLMSBackendTestCase(TestCase):
                         "users[0][email]": user.email,
                         "users[0][auth]": "oauth2",
                         "users[0][idnumber]": user.username,
+                        "users[0][alternatename]": user.username,
                     }
                 )
             ],


### PR DESCRIPTION
## Purpose

We want to use the alternatename as the username of the student in Moodle. This will allow moodle to not display the fullname of the users accross the platform, and instead use the username.

## Proposal

- [x] add `alternatename` in creation user payload in Moodle LMS Backend