### PR TITLE
🐛(backend) property withdrawal limit returns None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Add withdrawal action for orders in client and admin API
 
+### Fixed
+
+- Withdrawal date limit for credential product orders
+
 ## [3.5.0] - 2026-08-13
 
 ### Added

--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -1863,27 +1863,35 @@ class Order(BaseModel):
         contract, or None if not applicable (wrong product type, no contract,
         or contract not yet signed).
         """
-        if self.product.type == enums.PRODUCT_TYPE_CREDENTIAL:
-            if not self.has_contract or self.has_unsigned_contract:
-                return None
-            return withdrawal_limit_date(
+        should_have_withdrawal_date = (
+            self.product.type == enums.PRODUCT_TYPE_CREDENTIAL
+            and self.has_contract
+            and not self.has_unsigned_contract
+        ) or (
+            self.product.type == enums.PRODUCT_TYPE_CERTIFICATE
+            and not self.is_free
+            and self.state == enums.ORDER_STATE_COMPLETED
+        )
+
+        if not should_have_withdrawal_date:
+            return None
+
+        return (
+            withdrawal_limit_date(
                 signed_contract_date=self.contract.student_signed_on,  # pylint:disable=no-member
                 course_start_date=self.get_equivalent_course_run_dates(
                     ignore_archived=True
                 )["start"],
             )
-
-        if self.product.type == enums.PRODUCT_TYPE_CERTIFICATE and not self.is_free:
-            if self.state != enums.ORDER_STATE_COMPLETED:
-                return None
-            last_transaction = self.invoices.get(  # pylint:disable=no-member
-                parent__isnull=False
-            ).transactions.last()
-            return withdrawal_limit_date_after_purchase(
-                purchase_date=last_transaction.created_on
+            if self.product.type == enums.PRODUCT_TYPE_CREDENTIAL
+            else withdrawal_limit_date_after_purchase(
+                purchase_date=self.invoices.get(  # pylint:disable=no-member
+                    parent__isnull=False
+                )
+                .transactions.last()
+                .created_on
             )
-
-        return None
+        )
 
     @property
     def eligible_to_withdraw(self) -> bool:
@@ -1919,10 +1927,10 @@ class Order(BaseModel):
     @property
     def withdrawal_date_limit(self):
         """
-        Returns the the withdrawal limit date when the order is eligible to be withdrawn.
+        Returns the withdrawal limit date when the order is eligible to be withdrawn.
         Otherwise, this returns None.
         """
-        return self._withdrawal_limit()
+        return self._withdrawal_limit() if self.eligible_to_withdraw else None
 
     def withdraw(self):
         """

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -1730,6 +1730,7 @@ class OrderModelsTestCase(LoggingTestCase):
 
                     order.flow.cancel()
 
+    @override_settings(JOANIE_WITHDRAWAL_PERIOD_DAYS=14)
     def test_models_order_withdrawal_limit_product_type_credential(self):
         """
         The method `withdrawal_limit_date` should return the withdrawal date limit
@@ -1766,14 +1767,13 @@ class OrderModelsTestCase(LoggingTestCase):
                         days=settings.JOANIE_WITHDRAWAL_PERIOD_DAYS
                     )
                     if value:
-                        order.submit_for_signature(user=order.owner)
+                        self.assertIsNone(order.withdrawal_date_limit)
+                    else:
+                        # Sign for the student
                         order.contract.student_signed_on = mocked_now
-                        order.flow.update()
-                        order.save()
+                        order.contract.save()
                         self.assertEqual(
                             order.withdrawal_date_limit, withdrawal_date_limit
                         )
-                    else:
-                        self.assertIsNone(order.withdrawal_date_limit)
 
                     order.flow.cancel()


### PR DESCRIPTION

## Purpose

We encountered an error where the order list view
would not find any course start date and thus generate an error (TypeError) in the method `withdrawal_limit_date` when it was comparing NoneType with datetime.

In fact, the property `withdrawal_limit` concerning credential product, we wouldn't check for withdrawal dates when the user has not waived his withdrawal right.

Also, those errors occured in preproduction, which might not reflect what could be in production.
But nonetheless, we ensure that now our code works in both environments.

## Proposal

- [x] fix logic for withdrawal date limit for credential product orders
