### PR TITLE
♻️ (backend) refactor `_withdrawal_limit` for Order model

### DIFF
--- a/src/backend/joanie/core/models/products.py
+++ b/src/backend/joanie/core/models/products.py
@@ -1863,34 +1863,31 @@ class Order(BaseModel):
         contract, or None if not applicable (wrong product type, no contract,
         or contract not yet signed).
         """
-        should_have_withdrawal_date = (
-            self.product.type == enums.PRODUCT_TYPE_CREDENTIAL
-            and self.has_contract
-            and not self.has_unsigned_contract
-        ) or (
-            self.product.type == enums.PRODUCT_TYPE_CERTIFICATE
-            and not self.is_free
-            and self.state == enums.ORDER_STATE_COMPLETED
-        )
+        if self.product.type == enums.PRODUCT_TYPE_CREDENTIAL:
+            if not self.has_contract:
+                return None
 
-        if not should_have_withdrawal_date:
-            return None
+            course_start_date = self.get_equivalent_course_run_dates(
+                ignore_archived=True
+            )["start"]
+            # Ignore if all target course runs are archived and not in ending in future
+            if not course_start_date:
+                return None
 
-        return (
-            withdrawal_limit_date(
+            return withdrawal_limit_date(
                 signed_contract_date=self.contract.student_signed_on,  # pylint:disable=no-member
-                course_start_date=self.get_equivalent_course_run_dates(
-                    ignore_archived=True
-                )["start"],
+                course_start_date=course_start_date,
             )
-            if self.product.type == enums.PRODUCT_TYPE_CREDENTIAL
-            else withdrawal_limit_date_after_purchase(
-                purchase_date=self.invoices.get(  # pylint:disable=no-member
-                    parent__isnull=False
-                )
-                .transactions.last()
-                .created_on
-            )
+
+        if self.product.type == enums.PRODUCT_TYPE_CERTIFICATE:
+            if self.is_free or self.state != enums.ORDER_STATE_COMPLETED:
+                return None
+
+        last_transaction = self.invoices.get(  # pylint:disable=no-member
+            parent__isnull=False
+        ).transactions.last()
+        return withdrawal_limit_date_after_purchase(
+            purchase_date=last_transaction.created_on
         )
 
     @property

--- a/src/backend/joanie/tests/core/test_models_order.py
+++ b/src/backend/joanie/tests/core/test_models_order.py
@@ -21,6 +21,7 @@ from joanie.core.enums import PAYMENT_STATE_PENDING
 from joanie.core.factories import CourseRunFactory
 from joanie.core.models import Contract, CourseState, Order
 from joanie.core.utils import contract_definition
+from joanie.core.utils.course_run import aggregate_course_runs_dates
 from joanie.payment.factories import (
     BillingAddressDictFactory,
     CreditCardFactory,
@@ -1777,3 +1778,99 @@ class OrderModelsTestCase(LoggingTestCase):
                         )
 
                     order.flow.cancel()
+
+    @override_settings(
+        JOANIE_PAYMENT_SCHEDULE_LIMITS={
+            10: (100,),
+        },
+        DEFAULT_CURRENCY="EUR",
+    )
+    def test_models_order_withdrawal_limit_date_product_credential_course_run_archived(
+        self,
+    ):
+        """
+        This occurs in preproduction where course runs were deleted after creating orders.
+        To avoid this problem, here's a representation of the identified bug. The order was
+        created and the method `aggregate_course_runs_dates` should return None to each keys.
+        When an credential product order has archived course run because the end
+        (ignore_archived=True) is in the past, the method `_withdrawal_limit` should return None,
+        because there's nothing to compute.
+        """
+        course_run = factories.CourseRunFactory(
+            enrollment_start=django_timezone.now() - timedelta(days=60),
+            enrollment_end=django_timezone.now() - timedelta(days=41),
+            start=django_timezone.now() - timedelta(days=40),
+            end=django_timezone.now() - timedelta(days=1),
+            course=factories.CourseFactory(),
+        )
+        course = course_run.course
+        organization = factories.OrganizationFactory()
+        offering = factories.OfferingFactory(
+            course=course,
+            product=factories.ProductFactory(
+                price=10,
+                type=enums.PRODUCT_TYPE_CREDENTIAL,
+                target_courses=[course],
+                contract_definition_order=factories.ContractDefinitionFactory(),
+            ),
+            organizations=[organization],
+        )
+        # Simulate that `aggregate_course_runs_dates` return None to each keys
+        dates = aggregate_course_runs_dates(course.course_runs, ignore_archived=True)
+        # This would be the result when the end is not greater than today's date
+        self.assertEqual(
+            dates,
+            {
+                "start": None,
+                "end": None,
+                "enrollment_start": None,
+                "enrollment_end": None,
+            },
+        )
+
+        order = factories.OrderFactory(
+            course=offering.course,
+            product=offering.product,
+            organization=organization,
+            payment_schedule=[
+                {
+                    "id": "1932fbc5-d971-48aa-8fee-6d637c3154a5",
+                    "amount": "100.00",
+                    "due_date": "2026-07-08",
+                    "state": PAYMENT_STATE_PENDING,
+                },
+            ],
+        )
+        order.init_flow(billing_address=BillingAddressDictFactory())
+        order.contract.student_signed_on = django_timezone.now()
+
+        self.assertIsNone(order._withdrawal_limit())  # pylint:disable=protected-access
+
+    def test_models_order_withdrawal_limit_date_product_credential_course_run_ongoing(
+        self,
+    ):
+        """
+        When the course run's end date is greater than todays, it should return
+        a date limit. It means that the course run is ongoing, so the method `_withdrawal_limit`
+        should return the limit date.
+        """
+        course_run_ongoing_open = factories.CourseRunFactory(
+            state=CourseState.ONGOING_OPEN,
+        )
+        course = factories.CourseFactory(course_runs=[course_run_ongoing_open])
+        product = factories.ProductFactory(
+            target_courses=[course],
+            type=enums.PRODUCT_TYPE_CREDENTIAL,
+        )
+        offering = factories.OfferingFactory(
+            product=product, course=course_run_ongoing_open.course
+        )
+
+        order = factories.OrderGeneratorFactory(
+            product=offering.product,
+            state=enums.ORDER_STATE_SIGNING,
+        )
+        order.contract.student_signed_on = django_timezone.now()
+        order.contract.save()
+
+        self.assertIsNotNone(order._withdrawal_limit())  # pylint:disable=protected-access


### PR DESCRIPTION

## Purpose

We refactored the method `_withdrawal_limit` to simplify it. When the course run related to the order's course is already archived, and in the past, we return None immediately.